### PR TITLE
Adding ACR, MSI, and AcrPull role

### DIFF
--- a/infra/core/main.tf
+++ b/infra/core/main.tf
@@ -48,5 +48,30 @@ module "aca_env" {
   dapr_application_insights_connection_string = module.ai.connection_string
   infrastructure_subnet_id                    = module.aca_subnet.subnet_id
   tags                                        = var.tags
+}
 
+module "usi" {
+  source   = "../modules/user-assigned-identity"
+  name     = var.user_assigned_identity_name
+  location = var.location
+  rg_name  = module.resource_group.name
+  tags     = var.tags
+}
+
+module "acr" {
+  source                    = "../modules/container-registry"
+  name                      = var.acr_name
+  location                  = var.location
+  rg_name                   = module.resource_group.name
+  sku                       = var.acr_sku
+  admin_enabled             = var.acr_admin_enabled
+  user_assigned_identity_id = module.usi.id
+  tags                      = var.tags
+}
+
+module "acr_pull_role" {
+  source       = "../modules/role-assignment"
+  role_name    = var.acr_pull_role_name
+  principal_id = module.usi.principal_id
+  scope_id     = module.acr.acr_id
 }

--- a/infra/core/main.tf
+++ b/infra/core/main.tf
@@ -65,13 +65,13 @@ module "acr" {
   rg_name                   = module.resource_group.name
   sku                       = var.acr_sku
   admin_enabled             = var.acr_admin_enabled
-  user_assigned_identity_id = module.usi.id
+  user_assigned_identity_id = module.usi.user_assinged_identity_id
   tags                      = var.tags
 }
 
 module "acr_pull_role" {
   source       = "../modules/role-assignment"
   role_name    = var.acr_pull_role_name
-  principal_id = module.usi.principal_id
+  principal_id = module.usi.user_assinged_identity_principal_id
   scope_id     = module.acr.acr_id
 }

--- a/infra/core/tfvars/terraform.tfvars
+++ b/infra/core/tfvars/terraform.tfvars
@@ -17,3 +17,5 @@ aca_subnet_address_prefixes = [
 ]
 app_insights_name = "ai-biotrackr-prod-ae"
 aca_env_name = "env-biotrackr-prod-ae"
+acr_name = "acrbiotrackrprodae"
+user_assigned_identity_name = "uai-biotrackr-prod-ae"

--- a/infra/core/variables.tf
+++ b/infra/core/variables.tf
@@ -48,3 +48,31 @@ variable "aca_env_name" {
   type        = string
 
 }
+
+variable "acr_name" {
+  description = "The name of the Azure Container Registry"
+  type        = string
+}
+
+variable "acr_admin_enabled" {
+  description = "Enable admin user for the Azure Container Registry"
+  type        = bool
+  default     = true
+}
+
+variable "acr_sku" {
+  description = "The SKU of the Azure Container Registry"
+  type        = string
+  default     = "Basic"
+}
+
+variable "user_assigned_identity_name" {
+  description = "The name of the user-assigned managed identity that's used by the AKS cluster"
+  type        = string
+}
+
+variable "acr_pull_role_name" {
+  type        = string
+  description = "The name of the AcrPull role given to the user-assigned identity"
+  default     = "AcrPull"
+}

--- a/infra/modules/container-registry/main.tf
+++ b/infra/modules/container-registry/main.tf
@@ -1,0 +1,12 @@
+resource "azurerm_container_registry" "acr" {
+  name = var.name
+  location = var.location
+  tags = var.tags
+  resource_group_name = var.rg_name
+  sku = var.sku
+  admin_enabled = var.admin_enabled
+  identity {
+    type = "UserAssigned"
+    identity_ids = [ var.user_assigned_identity_id ]
+  }
+}

--- a/infra/modules/container-registry/outputs.tf
+++ b/infra/modules/container-registry/outputs.tf
@@ -1,0 +1,4 @@
+output "acr_id" {
+  value = azurerm_container_registry.acr.id
+  description = "The ID of the Azure Container Registry."
+}

--- a/infra/modules/container-registry/variables.tf
+++ b/infra/modules/container-registry/variables.tf
@@ -1,0 +1,34 @@
+variable "name" {
+  description = "The name of the Container Registry"
+  type = string
+}
+
+variable "location" {
+  description = "The location where the resources will be created."
+  type = string
+}
+
+variable "rg_name" {
+  description = "The name of the resource group in which the resources will be created."
+  type = string
+}
+
+variable "sku" {
+  description = "The SKU of the Container Registry"
+  type = string
+}
+
+variable "admin_enabled" {
+  description = "Enable admin user for the Container Registry"
+  type = bool
+}
+
+variable "user_assigned_identity_id" {
+  description = "The ID of the user-assigned managed identity"
+  type = string
+}
+
+variable "tags" {
+    description = "A mapping of tags to assign to the resources."
+    type = map(string)
+}


### PR DESCRIPTION
This pull request introduces new modules for user-assigned identity and Azure Container Registry (ACR) in the Terraform infrastructure code. The changes include defining new variables, adding new modules, and creating resources for ACR. Below are the most important changes:

### New Modules and Resources:

* Added a module for user-assigned identity (`usi`) in `infra/core/main.tf`. This module will manage the creation and configuration of user-assigned managed identities.
* Added a module for Azure Container Registry (`acr`) in `infra/core/main.tf`, which includes the creation of the ACR resource with user-assigned identity.
* Created the resource definition for `azurerm_container_registry` in `infra/modules/container-registry/main.tf`. This resource will manage the ACR instance.

### New Variables:

* Defined new variables in `infra/core/variables.tf` for ACR configuration, including `acr_name`, `acr_admin_enabled`, `acr_sku`, `user_assigned_identity_name`, and `acr_pull_role_name`. These variables will help in configuring the ACR module.
* Added new variables in `infra/modules/container-registry/variables.tf` to support the ACR module, such as `name`, `location`, `rg_name`, `sku`, `admin_enabled`, `user_assigned_identity_id`, and `tags`. These variables will be used to parameterize the ACR resource creation.

### Outputs:

* Added an output for `acr_id` in `infra/modules/container-registry/outputs.tf` to expose the ID of the created ACR instance. This will be useful for referencing the ACR in other parts of the infrastructure.