### PR TITLE
Adding budgets and monitor action group to repo

### DIFF
--- a/infra/core/main.tf
+++ b/infra/core/main.tf
@@ -75,3 +75,21 @@ module "acr_pull_role" {
   principal_id = module.usi.user_assinged_identity_principal_id
   scope_id     = module.acr.acr_id
 }
+
+module "mag" {
+  source              = "../modules/monitor-action-group"
+  amg_name            = var.monitor_action_group_name
+  amg_short_name      = var.monitor_action_group_short_name
+  rg_name             = module.resource_group.name
+  tags                = var.tags
+  email_address       = var.email_address
+  email_receiver_name = var.email_receiver_name
+}
+
+module "budget" {
+  source                  = "../modules/budgets"
+  budget_name             = var.budget_name
+  resource_group_name     = module.resource_group.name
+  resource_group_id       = module.resource_group.id
+  monitor_action_group_id = module.mag.amg_id
+}

--- a/infra/core/variables.tf
+++ b/infra/core/variables.tf
@@ -76,3 +76,33 @@ variable "acr_pull_role_name" {
   description = "The name of the AcrPull role given to the user-assigned identity"
   default     = "AcrPull"
 }
+
+variable "email_address" {
+  description = "The email address of the user that will be assigned the AcrPull role"
+  type        = string
+  default     = "willvelida@hotmail.co.uk"
+}
+
+variable "email_receiver_name" {
+  description = "The name of the user that will be assigned the AcrPull role"
+  type        = string
+  default     = "Will Velida (Biotrackr)"
+}
+
+variable "monitor_action_group_name" {
+  description = "The name of the Monitor Action Group"
+  type        = string
+  default     = "Biotrackr-Action-Group"
+}
+
+variable "monitor_action_group_short_name" {
+  description = "The short name of the Monitor Action Group"
+  type        = string
+  default     = "BAG"
+}
+
+variable "budget_name" {
+  description = "The name of the budget"
+  type        = string
+  default     = "Biotrackr-Budget"
+}

--- a/infra/modules/budgets/main.tf
+++ b/infra/modules/budgets/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_consumption_budget_resource_group" "budget" {
         enabled = true
         threshold = var.threshold_one
         operator = "EqualTo"
-        threshold_type = "ActualCost"
+        threshold_type = "Actual"
       contact_groups = [ 
         var.monitor_action_group_id
        ]
@@ -30,7 +30,7 @@ resource "azurerm_consumption_budget_resource_group" "budget" {
         enabled = true
         threshold = var.threshold_two
         operator = "GreaterThan"
-        threshold_type = "ActualCost"
+        threshold_type = "Actual"
       contact_groups = [ 
         var.monitor_action_group_id
        ]

--- a/infra/modules/budgets/main.tf
+++ b/infra/modules/budgets/main.tf
@@ -1,0 +1,38 @@
+resource "azurerm_consumption_budget_resource_group" "budget" {
+  name = var.budget_name
+  resource_group_id = var.resource_group_id
+    amount = var.amount
+    time_grain = "Monthly"
+    time_period {
+        start_date = var.start_date
+        end_date = var.end_date
+    }
+
+    filter {
+      dimension {
+        name = "ResourceGroupName"
+        operator = "In"
+        values = [ var.resource_group_name ]
+      }
+    }
+
+    notification {
+        enabled = true
+        threshold = var.threshold_one
+        operator = "EqualTo"
+        threshold_type = "ActualCost"
+      contact_groups = [ 
+        var.monitor_action_group_id
+       ]
+    }
+
+    notification {
+        enabled = true
+        threshold = var.threshold_two
+        operator = "GreaterThan"
+        threshold_type = "ActualCost"
+      contact_groups = [ 
+        var.monitor_action_group_id
+       ]
+    }
+}

--- a/infra/modules/budgets/variables.tf
+++ b/infra/modules/budgets/variables.tf
@@ -17,13 +17,13 @@ variable "amount" {
 variable "start_date" {
   description = "The start date of the budget"
   type = string
-  default = "01/09/2024"
+  default = "2024-09-01T00:00:00Z"
 }
 
 variable "end_date" {
   description = "The end date of the budget"
   type = string
-  default = "01/09/2094"
+  default = "2094-09-01T00:00:00Z"
 }
 
 variable "resource_group_name" {

--- a/infra/modules/budgets/variables.tf
+++ b/infra/modules/budgets/variables.tf
@@ -1,0 +1,49 @@
+variable "budget_name" {
+  description = "The name of the budget"
+  type = string
+}
+
+variable "resource_group_id" {
+  description = "The ID of the resource group"
+  type = string
+}
+
+variable "amount" {
+  description = "The amount of the budget"
+  type = number
+  default = 200
+}
+
+variable "start_date" {
+  description = "The start date of the budget"
+  type = string
+  default = "01/09/2024"
+}
+
+variable "end_date" {
+  description = "The end date of the budget"
+  type = string
+  default = "01/09/2094"
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group"
+  type = string
+}
+
+variable "threshold_one" {
+  description = "The first threshold of the budget"
+  type = number
+  default = 150
+}
+
+variable "threshold_two" {
+  description = "The second threshold of the budget"
+  type = number
+  default = 190
+}
+
+variable "monitor_action_group_id" {
+  description = "The ID of the Monitor Action Group"
+  type = string
+}

--- a/infra/modules/monitor-action-group/main.tf
+++ b/infra/modules/monitor-action-group/main.tf
@@ -1,0 +1,12 @@
+resource "azurerm_monitor_action_group" "amg" {
+  name = var.amg_name
+  resource_group_name = var.rg_name
+  short_name = var.amg_short_name
+  tags = var.tags
+
+  email_receiver {
+    name = var.email_receiver_name
+    email_address = var.email_address
+    use_common_alert_schema = true
+  }
+}

--- a/infra/modules/monitor-action-group/outputs.tf
+++ b/infra/modules/monitor-action-group/outputs.tf
@@ -1,0 +1,4 @@
+output "amg_id" {
+  value = azurerm_monitor_action_group.amg.id
+  description = "The ID of the Monitor Action Group."
+}

--- a/infra/modules/monitor-action-group/variables.tf
+++ b/infra/modules/monitor-action-group/variables.tf
@@ -1,0 +1,29 @@
+variable "amg_name" {
+  description = "The name of the Monitor Action Group"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group in which the resources should be created"
+  type        = string
+}
+
+variable "amg_short_name" {
+  description = "The short name of the Monitor Action Group"
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of tags to add to the resources"
+  type        = map(string)
+}
+
+variable "email_receiver_name" {
+  description = "The name of the email receiver"
+  type        = string
+}
+
+variable "email_address" {
+  description = "The email address of the email receiver"
+  type        = string
+}

--- a/infra/modules/monitor-action-group/variables.tf
+++ b/infra/modules/monitor-action-group/variables.tf
@@ -3,7 +3,7 @@ variable "amg_name" {
   type        = string
 }
 
-variable "resource_group_name" {
+variable "rg_name" {
   description = "The name of the resource group in which the resources should be created"
   type        = string
 }


### PR DESCRIPTION
This pull request introduces modules for managing budgets and monitor action groups in the infrastructure code. The most important changes include adding new modules for budget and monitor action groups, defining necessary variables, and setting up resource configurations for these modules.

### New Modules:

* [`infra/core/main.tf`](diffhunk://#diff-8020017f12d94e9c8c6437fe0cae3fb9e92d65ce3b1e4e5479a52f0df3f6d666R78-R95): Added `mag` and `budget` modules to manage monitor action groups and budgets respectively.

### Variable Definitions:

* [`infra/core/variables.tf`](diffhunk://#diff-5eba3ca25becb716152a6c5d89da5c26b37fb403aadfd26b60da41e6da67de19R79-R108): Introduced variables for email address, email receiver name, monitor action group name, and budget name.
* [`infra/modules/budgets/variables.tf`](diffhunk://#diff-d535b92563a5f5a94842ccff86a60f799473524fea7eeb8e2010b3beaebacbb0R1-R49): Defined variables required for budget configuration, including `budget_name`, `resource_group_id`, `amount`, `start_date`, `end_date`, `threshold_one`, `threshold_two`, and `monitor_action_group_id`.
* [`infra/modules/monitor-action-group/variables.tf`](diffhunk://#diff-ca0d74d210bc403bbcb4dfc2bd81ffb7d3058d747c48d043e0ae665f10382c83R1-R29): Added variables for monitor action group configuration, such as `amg_name`, `resource_group_name`, `amg_short_name`, `tags`, `email_receiver_name`, and `email_address`.

### Resource Configurations:

* [`infra/modules/budgets/main.tf`](diffhunk://#diff-29dcb1dbae7a5f8f3194c0a3b9a5a1f98398a9fb23729693a499929f3214e2a3R1-R38): Configured `azurerm_consumption_budget_resource_group` resource for managing budget constraints and notifications.
* [`infra/modules/monitor-action-group/main.tf`](diffhunk://#diff-39e51ad5e554ffcd378d24e72dc01c1a717bb05693cb6114ae0003a4100cf556R1-R12): Configured `azurerm_monitor_action_group` resource for setting up monitor action groups with email receivers.

### Outputs:

* [`infra/modules/monitor-action-group/outputs.tf`](diffhunk://#diff-2dbcceb742414bd467fb36bbb3e494b38bb785e59d794b87986fd2e5e963db77R1-R4): Added output for `amg_id` to retrieve the ID of the Monitor Action Group.