### PR TITLE
Updating core infra workflow to target templates on main. Updating RE…

### DIFF
--- a/.github/workflows/deploy-core-infra.yml
+++ b/.github/workflows/deploy-core-infra.yml
@@ -15,14 +15,14 @@ permissions:
 jobs:
     lint:
         name: Run Bicep Linter
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-linter.yml@feature/init-infra
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-linter.yml@main
         with:
           template-file: './infra/core/main.bicep'
 
     validate:
         needs: lint
         name: Validate Template
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@feature/init-infra
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@main
         with:
           template-file: './infra/core/main.bicep'
           parameters-file: './infra/core/main.dev.bicepparam'
@@ -36,7 +36,7 @@ jobs:
     preview:
         needs: validate
         name: Preview Changes
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@feature/init-infra
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@main
         with:
           template-file: './infra/core/main.bicep'
           parameters-file: './infra/core/main.dev.bicepparam'
@@ -49,7 +49,7 @@ jobs:
     deploy-dev:
         needs: preview
         name: Deploy Template to Dev
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@feature/init-infra
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@main
         with:
           template-file: './infra/core/main.bicep'
           parameters-file: './infra/core/main.dev.bicepparam'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Welcome to my personal health platform! I use a Fitbit to log my workouts, so this application uses the API that Fitbit provides to run some analysis on that data, and provide me insights.
 
+## Documentation
+
+Check out the following markdown files that explains decisions made in this project:
+
+- [GitHub Actions Workflow Templates](./docs/github-workflow-templates.md)
+
 ## Tech Stack Used
 
 - Bicep


### PR DESCRIPTION
This pull request includes changes to update GitHub Actions workflow references and adds documentation to the `README.md` file. The most important changes are listed below.

Updates to GitHub Actions workflow references:

* [`.github/workflows/deploy-core-infra.yml`](diffhunk://#diff-a15cf94f612a257ead43164c501c073b89ca9c8b5a601c910710a882cfd1e4adL18-R25): Updated the workflow references from `feature/init-infra` to `main` for the `lint`, `validate`, `preview`, and `deploy-dev` jobs. [[1]](diffhunk://#diff-a15cf94f612a257ead43164c501c073b89ca9c8b5a601c910710a882cfd1e4adL18-R25) [[2]](diffhunk://#diff-a15cf94f612a257ead43164c501c073b89ca9c8b5a601c910710a882cfd1e4adL39-R39) [[3]](diffhunk://#diff-a15cf94f612a257ead43164c501c073b89ca9c8b5a601c910710a882cfd1e4adL52-R52)

Documentation addition:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5-R10): Added a new "Documentation" section with a link to the markdown file that explains the GitHub Actions workflow templates.…ADME.md to include docs