### PR TITLE
Feature/add cosmos

### DIFF
--- a/infra/core/main.bicep
+++ b/infra/core/main.bicep
@@ -138,5 +138,6 @@ module cosmos '../modules/database/serverless-cosmos-db.bicep' = {
     appConfigName: appConfig.outputs.appConfigName
     databaseName: cosmosDatabaseName
     uaiName: uai.outputs.uaiName
+    logAnalyticsName: logAnalytics.outputs.logAnalyticsName
   }
 }

--- a/infra/core/main.bicep
+++ b/infra/core/main.bicep
@@ -43,6 +43,12 @@ param firstBudgetThreshold int
 @description('The second budget threshold')
 param secondBudgetThreshold int
 
+@description('The name of the Cosmos DB account')
+param cosmosAccountName string
+
+@description('The name of the Cosmos DB database')
+param cosmosDatabaseName string
+
 module logAnalytics '../modules/monitoring/log-analytics.bicep' = {
   name: 'log-analytics'
   params: {
@@ -120,5 +126,17 @@ module budget '../modules/monitoring/budget.bicep' = {
     ownerEmail: emailAddress
     secondThreshold: secondBudgetThreshold
     startDate: budgetStartDate
+  }
+}
+
+module cosmos '../modules/database/serverless-cosmos-db.bicep' = {
+  name: 'cosmos'
+  params: {
+    location: location
+    tags: tags
+    accountName: cosmosAccountName 
+    appConfigName: appConfig.outputs.appConfigName
+    databaseName: cosmosDatabaseName
+    uaiName: uai.outputs.uaiName
   }
 }

--- a/infra/core/main.dev.bicepparam
+++ b/infra/core/main.dev.bicepparam
@@ -18,3 +18,5 @@ param budgetLimit = 200
 param firstBudgetThreshold = 100
 param secondBudgetThreshold = 175
 param budgetStartDate = '2024-12-01'
+param cosmosAccountName = 'cosmos-biotrackr-dev'
+param cosmosDatabaseName = 'BiotrackrDB'

--- a/infra/modules/database/serverless-cosmos-db.bicep
+++ b/infra/modules/database/serverless-cosmos-db.bicep
@@ -100,42 +100,22 @@ resource diagnosticLogs 'Microsoft.Insights/diagnosticSettings@2021-05-01-previe
       {
         category: 'DataPlaneRequests'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true 
-        }
       }
       {
         category: 'QueryRuntimeStatistics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true 
-        }
       }
       {
         category: 'PartitionKeyStatistics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true 
-        }
       }
       {
         category: 'PartitionKeyRUConsumption'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true 
-        }
       }
       {
         category: 'ControlPlaneRequests'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true 
-        }
       }
     ]
   }

--- a/infra/modules/database/serverless-cosmos-db.bicep
+++ b/infra/modules/database/serverless-cosmos-db.bicep
@@ -65,9 +65,6 @@ resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15
     resource: {
       id: databaseName
     }
-    options: {
-      throughput: 1000
-    }
   }
 }
 

--- a/infra/modules/database/serverless-cosmos-db.bicep
+++ b/infra/modules/database/serverless-cosmos-db.bicep
@@ -98,7 +98,39 @@ resource diagnosticLogs 'Microsoft.Insights/diagnosticSettings@2021-05-01-previe
     workspaceId: logAnalytics.id
     logs: [
       {
-        category: 'AllMetrics'
+        category: 'DataPlaneRequests'
+        enabled: true
+        retentionPolicy: {
+          days: 7
+          enabled: true 
+        }
+      }
+      {
+        category: 'QueryRuntimeStatistics'
+        enabled: true
+        retentionPolicy: {
+          days: 7
+          enabled: true 
+        }
+      }
+      {
+        category: 'PartitionKeyStatistics'
+        enabled: true
+        retentionPolicy: {
+          days: 7
+          enabled: true 
+        }
+      }
+      {
+        category: 'PartitionKeyRUConsumption'
+        enabled: true
+        retentionPolicy: {
+          days: 7
+          enabled: true 
+        }
+      }
+      {
+        category: 'ControlPlaneRequests'
         enabled: true
         retentionPolicy: {
           days: 7

--- a/infra/modules/database/serverless-cosmos-db.bicep
+++ b/infra/modules/database/serverless-cosmos-db.bicep
@@ -1,0 +1,94 @@
+@description('The name of the Cosmos DB account')
+param accountName string
+
+@description('The name of the Database that will provisioned in the account')
+param databaseName string
+
+@description('The region that the Cosmos DB account will be deployed to')
+param location string
+
+@description('The tags that will be applied to the Cosmos DB account')
+param tags object
+
+@description('The user-assigned identity that this will be granted RBAC roles over the Cosmos DB account')
+param uaiName string
+
+@description('The name of the App Configuration store that will store values related to this Cosmos DB account')
+param appConfigName string
+
+var cosmosDbEndpointSettingName = 'Biotrackr:CosmosDbEndpoint'
+var cosmosDatabaseSettingName = 'Biotrackr:DatabaseName'
+
+resource uai 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: uaiName
+}
+
+resource appConfig 'Microsoft.AppConfiguration/configurationStores@2024-05-01' existing = {
+  name: appConfigName
+}
+
+resource account 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
+  name: accountName
+  location: location
+  tags: tags
+  kind: 'GlobalDocumentDB'
+  properties: {
+    databaseAccountOfferType: 'Standard'
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    locations: [
+      { 
+        failoverPriority: 0
+        locationName: location
+        isZoneRedundant: false
+      }
+    ]
+    capabilities: [
+      { 
+        name: 'EnableServerless'
+      }
+    ]
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${uai.id}': {}
+    }
+  }
+}
+
+resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
+  name: databaseName
+  parent: account
+  properties: {
+    resource: {
+      id: databaseName
+    }
+    options: {
+      throughput: 1000
+    }
+  }
+}
+
+resource endpointConfigSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2024-05-01' = {
+  name: cosmosDbEndpointSettingName
+  parent: appConfig
+  properties: {
+    value: account.properties.documentEndpoint
+  }
+}
+
+resource databaseConfigSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2024-05-01' = {
+  name: cosmosDatabaseSettingName
+  parent: appConfig
+  properties: {
+    value: database.name
+  }
+}
+
+@description('The name of the deployed Cosmos DB account')
+output accountName string = account.name
+
+@description('The name of the deployed Database')
+output databaseName string = database.name


### PR DESCRIPTION
This pull request introduces the integration of a Cosmos DB account and database into the existing infrastructure. The changes involve adding new parameters and modules to support this integration.

Key changes include:

### Parameter Additions:
* Added `cosmosAccountName` and `cosmosDatabaseName` parameters to `infra/core/main.bicep` to define the Cosmos DB account and database names.
* Added default values for `cosmosAccountName` and `cosmosDatabaseName` in `infra/core/main.dev.bicepparam`.

### Module Integration:
* Introduced a new module `cosmos` in `infra/core/main.bicep` to deploy the Cosmos DB account and database using the specified parameters.
* Created a new module file `infra/modules/database/serverless-cosmos-db.bicep` to define the resources for the Cosmos DB account, database, and related configuration settings.