### PR TITLE
Adding untagged flag to purge task

### DIFF
--- a/infra/scripts/purge-old-images.sh
+++ b/infra/scripts/purge-old-images.sh
@@ -10,5 +10,5 @@ repositories=$(az acr repository list --name $ACR_NAME --resource-group $RESOURC
 # Loop through each repository and purge old images
 for repository in $repositories; do
     echo "Purging old images in repository: $repository"
-    az acr run --registry $ACR_NAME --cmd "acr purge --filter '$repository:.*' --ago 0d --keep 3" /dev/null
+    az acr run --registry $ACR_NAME --cmd "acr purge --filter '$repository:.*' --ago 0d --keep 3 --untagged" /dev/null
 done


### PR DESCRIPTION
This pull request includes a small but important change to the `infra/scripts/purge-old-images.sh` script. The change ensures that untagged images are also purged from the repositories.

* [`infra/scripts/purge-old-images.sh`](diffhunk://#diff-9863c961c80ec825bbb7629f65b98ff967a6c87d7e4e9dbe8271c2fc48925808L13-R13): Modified the `acr purge` command to include the `--untagged` flag, ensuring that untagged images are purged along with tagged ones.