### PR TITLE
Adding Status badge for Auth Service in main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ Check out the following markdown files that explains decisions made in this proj
 | Component | Status |
 | --------- | ------ |
 | Biotrackr.Infra | [![Deploy Core Biotrackr Infrastructure](https://github.com/willvelida/biotrackr/actions/workflows/deploy-core-infra.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-core-infra.yml) |
+| Biotrackr.Auth.Svc| [![Deploy Auth Service](https://github.com/willvelida/biotrackr/actions/workflows/deploy-auth-service.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-auth-service.yml) |


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a status badge for the `Biotrackr.Auth.Svc` component, linking to its deployment workflow.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22): Added status badge for `Biotrackr.Auth.Svc` component, linking to the deployment workflow.