### PR TITLE
Updating RBAC for Cosmos DB

### DIFF
--- a/infra/core/main.bicep
+++ b/infra/core/main.bicep
@@ -132,6 +132,7 @@ module budget '../modules/monitoring/budget.bicep' = {
   }
 }
 
+// Updating RBAC flag
 module cosmos '../modules/database/serverless-cosmos-db.bicep' = {
   name: 'cosmos'
   params: {

--- a/infra/modules/database/serverless-cosmos-db.bicep
+++ b/infra/modules/database/serverless-cosmos-db.bicep
@@ -144,7 +144,7 @@ resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignm
   parent: account
   properties: {
     principalId: uai.properties.principalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', cosmosDbDataContributorRole)
+    roleDefinitionId: '/${subscription().id}/resourceGroups/${resourceGroup().name}/providers/Microsoft.DocumentDB/databaseAccounts/${account.name}/sqlRoleDefinitions/${cosmosDbDataContributorRole}'
     scope: account.id
   }
 }

--- a/infra/modules/database/serverless-cosmos-db.bicep
+++ b/infra/modules/database/serverless-cosmos-db.bicep
@@ -138,6 +138,7 @@ resource diagnosticLogs 'Microsoft.Insights/diagnosticSettings@2021-05-01-previe
   }
 }
 
+// Adding role assignment
 resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-11-15' = {
   name: cosmosDbDataContributorRole
   parent: account


### PR DESCRIPTION
This pull request includes a small change to the `infra/modules/database/serverless-cosmos-db.bicep` file. The change adds a role assignment resource for `Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-11-15`.

* [`infra/modules/database/serverless-cosmos-db.bicep`](diffhunk://#diff-89aed333217caaa0155e853ee141da06a9c5a0991726aee2caaa59137a024ef0R141): Added a new resource for SQL role assignment with the name `cosmosDbDataContributorRole` under the parent `account`.