### PR TITLE
Changing Activity SVC to 1am UTC time, 12pm Melbourne time

### DIFF
--- a/infra/apps/activity-service/main.bicep
+++ b/infra/apps/activity-service/main.bicep
@@ -59,7 +59,7 @@ module activityService '../../modules/host/container-app-jobs.bicep' = {
     tags: tags
     containerAppEnvironmentName: containerAppEnvironmentName
     containerRegistryName: containerRegistryName
-    cronExpression: '15 5 * * *'
+    cronExpression: '0 1 * * *'
     envVariables: [
             {
               name: 'keyvaulturl'


### PR DESCRIPTION
This pull request includes a change to the `infra/apps/activity-service/main.bicep` file, specifically modifying the cron expression for a scheduled job.

* [`infra/apps/activity-service/main.bicep`](diffhunk://#diff-5f272acb5cd4c9db4db517d7c2f4fdaf085c0c5a1041662031d8c9d79987ae07L62-R62): Updated the `cronExpression` for the `activityService` module from '15 5 * * *' to '0 1 * * *'.