### PR TITLE
Fixing summary model to remove unneeded properties

### DIFF
--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Models/FitbitEntities/Summary.cs
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Models/FitbitEntities/Summary.cs
@@ -4,14 +4,6 @@ namespace Biotrackr.Sleep.Svc.Models.FitbitEntities
 {
     public class Summary
     {
-        [JsonPropertyName("deep")]
-        public SleepDetails Deep { get; set; }
-        [JsonPropertyName("light")]
-        public SleepDetails Light { get; set; }
-        [JsonPropertyName("rem")]
-        public SleepDetails Rem { get; set; }
-        [JsonPropertyName("wake")]
-        public SleepDetails Wake { get; set; }
         [JsonPropertyName("stages")]
         public Stages Stages { get; set; }
         [JsonPropertyName("totalMinutesAsleep")]


### PR DESCRIPTION
This pull request includes changes to the `Summary` class in the `Biotrackr.Sleep.Svc.Models.FitbitEntities` namespace to simplify the data model by consolidating sleep details into a single `Stages` property.

Model simplification:

* [`src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Models/FitbitEntities/Summary.cs`](diffhunk://#diff-f02329a9d3a0d9168a1fc8d14a4b3aea04a7ea3b6af4a2e166401b16d8f9d24fL7-L14): Removed individual properties for `Deep`, `Light`, `Rem`, and `Wake` sleep stages and replaced them with a consolidated `Stages` property.