### PR TITLE
Adding Worker and Program Tests. Excluding some files from code coverage

### DIFF
--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/GlobalUsings.cs
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/GlobalUsings.cs
@@ -3,6 +3,7 @@ global using Biotrackr.Activity.Svc.Configuration;
 global using Biotrackr.Activity.Svc.Models;
 global using Biotrackr.Activity.Svc.Models.FitbitEntities;
 global using Biotrackr.Activity.Svc.Repositories;
+global using Biotrackr.Activity.Svc.Repositories.Interfaces;
 global using Biotrackr.Activity.Svc.Services;
 global using FluentAssertions;
 global using Microsoft.Azure.Cosmos;

--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/ProgramTests/ProgramShould.cs
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/ProgramTests/ProgramShould.cs
@@ -1,0 +1,108 @@
+﻿using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using Azure.Security.KeyVault.Secrets;
+using Biotrackr.Activity.Svc.Services.Interfaces;
+using Biotrackr.Activity.Svc.Workers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Resources;
+
+namespace Biotrackr.Activity.Svc.UnitTests.ProgramTests
+{
+    public class ProgramShould
+    {
+        [Fact]
+        public void ConfigurationIsLoadedCorrectly()
+        {
+            var host = CreateHostBuilder().Build();
+            var configuration = host.Services.GetRequiredService<IConfiguration>();
+
+            Assert.NotNull(configuration["keyvaulturl"]);
+            Assert.NotNull(configuration["managedidentityclientid"]);
+            Assert.NotNull(configuration["cosmosdbendpoint"]);
+            Assert.NotNull(configuration["applicationinsightsconnectionstring"]);
+        }
+
+        [Fact]
+        public void ServicesAreRegisteredCorrectly()
+        {
+            var host = CreateHostBuilder().Build();
+            var services = host.Services;
+
+            Assert.NotNull(services.GetService<SecretClient>());
+            Assert.NotNull(services.GetService<CosmosClient>());
+            Assert.NotNull(services.GetService<ICosmosRepository>());
+            Assert.NotNull(services.GetService<IFitbitService>());
+            Assert.NotNull(services.GetService<IActivityService>());
+            Assert.NotNull(services.GetService<IHostedService>());
+        }
+
+        [Fact]
+        public void LoggingIsConfiguredCorrectly()
+        {
+            var host = CreateHostBuilder().Build();
+            var logger = host.Services.GetService<ILogger<ProgramShould>>();
+
+            Assert.NotNull(logger);
+        }
+
+        private IHostBuilder CreateHostBuilder()
+        {
+            return Host.CreateDefaultBuilder()
+                .ConfigureAppConfiguration((context, config) =>
+                {
+                    var inMemorySettings = new Dictionary<string, string>
+                    {
+                        {"keyvaulturl", "https://example-vault.vault.azure.net/"},
+                        {"managedidentityclientid", "example-client-id"},
+                        {"cosmosdbendpoint", "https://example-cosmos.documents.azure.com:443/"},
+                        {"applicationinsightsconnectionstring", "InstrumentationKey=example-key"}
+                    };
+
+                    config.AddInMemoryCollection(inMemorySettings);
+                })
+                .ConfigureServices((context, services) =>
+                {
+                    var keyVaultUrl = context.Configuration["keyvaulturl"];
+                    var managedIdentityClient = context.Configuration["managedidentityclientid"];
+                    var defaultCredentialOptions = new DefaultAzureCredentialOptions()
+                    {
+                        ManagedIdentityClientId = managedIdentityClient
+                    };
+
+                    services.AddSingleton(new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential(defaultCredentialOptions)));
+                    services.AddSingleton(new CosmosClient(context.Configuration["cosmosdbendpoint"], new DefaultAzureCredential(defaultCredentialOptions), new CosmosClientOptions()));
+
+                    var mockCosmosRepository = new Mock<ICosmosRepository>();
+                    var mockActivityService = new Mock<IActivityService>();
+                    var mockFitbitService = new Mock<IFitbitService>();
+                    services.AddScoped<ICosmosRepository>(_ => mockCosmosRepository.Object);
+                    services.AddScoped<IActivityService>(_ => mockActivityService.Object);
+                    services.AddScoped<IFitbitService>(_ => mockFitbitService.Object);
+
+                    services.AddHostedService<ActivityWorker>();
+                })
+                .ConfigureLogging((context, logging) =>
+                {
+                    logging.AddConsole();
+                    logging.AddDebug();
+                    logging.AddOpenTelemetry(log =>
+                    {
+                        var resourceAttributes = new Dictionary<string, object>
+                        {
+                            { "service.name", "Biotrackr.Activity.Svc" },
+                            { "service.version", "1.0.0" }
+                        };
+                        var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+
+                        log.SetResourceBuilder(resourceBuilder);
+                        log.AddAzureMonitorLogExporter(options =>
+                        {
+                            options.ConnectionString = context.Configuration["applicationinsightsconnectionstring"];
+                        });
+                    });
+                }); ;
+        }
+    }
+}

--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/ServiceTests/ActivityServiceShould.cs
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/ServiceTests/ActivityServiceShould.cs
@@ -1,6 +1,4 @@
-﻿using Biotrackr.Activity.Svc.Repositories.Interfaces;
-
-namespace Biotrackr.Activity.Svc.UnitTests.ServiceTests
+﻿namespace Biotrackr.Activity.Svc.UnitTests.ServiceTests
 {
     public class ActivityServiceShould
     {

--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/WorkerTests/ActivityWorkerShould.cs
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/WorkerTests/ActivityWorkerShould.cs
@@ -1,0 +1,77 @@
+﻿using Biotrackr.Activity.Svc.Services.Interfaces;
+using Biotrackr.Activity.Svc.Workers;
+using Microsoft.Extensions.Hosting;
+using System.Reflection;
+
+namespace Biotrackr.Activity.Svc.UnitTests.WorkerTests
+{
+    public class ActivityWorkerShould
+    {
+        private readonly Mock<IFitbitService> _fitbitServiceMock;
+        private readonly Mock<IActivityService> _activityServiceMock;
+        private readonly Mock<ILogger<ActivityWorker>> _loggerMock;
+        private readonly Mock<IHostApplicationLifetime> _appLifetimeMock;
+
+        private ActivityWorker _sut;
+
+        public ActivityWorkerShould()
+        {
+            _fitbitServiceMock = new Mock<IFitbitService>();
+            _activityServiceMock = new Mock<IActivityService>();
+            _loggerMock = new Mock<ILogger<ActivityWorker>>();
+            _appLifetimeMock = new Mock<IHostApplicationLifetime>();
+
+            _sut = new ActivityWorker(_fitbitServiceMock.Object, _activityServiceMock.Object, _loggerMock.Object, _appLifetimeMock.Object);
+        }
+
+        [Fact]
+        public void ExecuteAsync_ShouldLogError_WhenFitbitServiceThrowsException()
+        {
+            // Arrange
+            var date = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd");
+            _fitbitServiceMock.Setup(x => x.GetActivityResponse(date)).ThrowsAsync(new Exception("Test exception"));
+            var executeMethod = typeof(ActivityWorker).GetMethod("ExecuteAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var result = executeMethod.Invoke(_sut, new object[] { CancellationToken.None });
+
+            // Assert
+            _loggerMock.VerifyLog(logger => logger.LogError($"Exception thrown in {nameof(ActivityWorker)}: Test exception"));
+            _appLifetimeMock.Verify(x => x.StopApplication(), Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteAsync_ShouldLogError_WhenActivityServiceThrowsException()
+        {
+            // Arrange
+            var date = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd");
+            _fitbitServiceMock.Setup(x => x.GetActivityResponse(date)).ReturnsAsync(new ActivityResponse());
+            _activityServiceMock.Setup(x => x.MapAndSaveDocument(date, It.IsAny<ActivityResponse>())).ThrowsAsync(new Exception("Test exception"));
+            var executeMethod = typeof(ActivityWorker).GetMethod("ExecuteAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var result = executeMethod.Invoke(_sut, new object[] { CancellationToken.None });
+
+            // Assert
+            _loggerMock.VerifyLog(logger => logger.LogError($"Exception thrown in {nameof(ActivityWorker)}: Test exception"));
+            _appLifetimeMock.Verify(x => x.StopApplication(), Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ShouldReturn1_WhenSuccessful()
+        {
+            // Arrange
+            var date = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd");
+            _fitbitServiceMock.Setup(x => x.GetActivityResponse(date)).ReturnsAsync(new ActivityResponse());
+            _activityServiceMock.Setup(x => x.MapAndSaveDocument(date, It.IsAny<ActivityResponse>()));
+            var executeMethod = typeof(ActivityWorker).GetMethod("ExecuteAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            Func<Task> activityWorkerAction = async () => executeMethod.Invoke(_sut, new object[] { CancellationToken.None });
+
+            // Assert
+            await activityWorkerAction.Should().NotThrowAsync();
+            _appLifetimeMock.Verify(x => x.StopApplication(), Times.Once);
+        }
+    }
+}

--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Configuration/Settings.cs
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Configuration/Settings.cs
@@ -1,8 +1,11 @@
-﻿namespace Biotrackr.Activity.Svc.Configuration
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Biotrackr.Activity.Svc.Configuration
 {
+    [ExcludeFromCodeCoverage]
     public class Settings
     {
-        public string DatabaseName { get; set; }
-        public string ContainerName { get; set; }
+        public string? DatabaseName { get; set; }
+        public string? ContainerName { get; set; }
     }
 }

--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Models/ActivityDocument.cs
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Models/ActivityDocument.cs
@@ -1,12 +1,14 @@
 ﻿using Biotrackr.Activity.Svc.Models.FitbitEntities;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Biotrackr.Activity.Svc.Models
 {
+    [ExcludeFromCodeCoverage]
     public class ActivityDocument
     {
-        public string Id { get; set; }
-        public ActivityResponse Activity { get; set; }
-        public string Date { get; set; }
-        public string DocumentType { get; set; }
+        public string? Id { get; set; }
+        public ActivityResponse? Activity { get; set; }
+        public string? Date { get; set; }
+        public string? DocumentType { get; set; }
     }
 }

--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Models/FitbitEntities/Activity.cs
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Models/FitbitEntities/Activity.cs
@@ -7,18 +7,18 @@ namespace Biotrackr.Activity.Svc.Models.FitbitEntities
     {
         public int activityId { get; set; }
         public int activityParentId { get; set; }
-        public string activityParentName { get; set; }
+        public string? activityParentName { get; set; }
         public int calories { get; set; }
-        public string description { get; set; }
+        public string? description { get; set; }
         public int duration { get; set; }
         public bool hasActiveZoneMinutes { get; set; }
         public bool hasStartTime { get; set; }
         public bool isFavorite { get; set; }
         public DateTime lastModified { get; set; }
         public long logId { get; set; }
-        public string name { get; set; }
-        public string startDate { get; set; }
-        public string startTime { get; set; }
+        public string? name { get; set; }
+        public string? startDate { get; set; }
+        public string? startTime { get; set; }
         public int steps { get; set; }
         public double? distance { get; set; }
     }

--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Models/FitbitEntities/ActivityResponse.cs
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Models/FitbitEntities/ActivityResponse.cs
@@ -5,8 +5,8 @@ namespace Biotrackr.Activity.Svc.Models.FitbitEntities
     [ExcludeFromCodeCoverage]
     public class ActivityResponse
     {
-        public List<Activity> activities { get; set; }
-        public Goals goals { get; set; }
-        public Summary summary { get; set; }
+        public List<Activity>? activities { get; set; }
+        public Goals? goals { get; set; }
+        public Summary? summary { get; set; }
     }
 }


### PR DESCRIPTION
This pull request includes several changes to improve the codebase, primarily focusing on enhancing unit tests, improving nullability annotations, and adding code coverage exclusions.

### Enhancements to Unit Tests:
* Added new unit tests for `ProgramShould` to verify configuration loading, service registration, and logging configuration (`src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/ProgramTests/ProgramShould.cs`).
* Introduced unit tests for `ActivityWorkerShould` to ensure proper error logging and application stopping on exceptions, and to verify successful execution (`src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/WorkerTests/ActivityWorkerShould.cs`).

### Nullability Annotations:
* Updated `Settings` class to use nullable reference types for properties (`src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Configuration/Settings.cs`).
* Modified `ActivityDocument` class to use nullable reference types for properties (`src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Models/ActivityDocument.cs`).
* Updated `Activity` class to use nullable reference types for string properties (`src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Models/FitbitEntities/Activity.cs`).
* Applied nullable reference types to properties in `ActivityResponse` class (`src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Models/FitbitEntities/ActivityResponse.cs`).

### Code Coverage Exclusions:
* Added `[ExcludeFromCodeCoverage]` attribute to `Settings` and `ActivityDocument` classes to exclude them from code coverage analysis (`src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Configuration/Settings.cs`) [[1]](diffhunk://#diff-4395ce209beeaa175f4da66f2bbf208045d6feae164ea60d4d70c7861295c9d5L1-R9) (`src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Models/ActivityDocument.cs`) [[2]](diffhunk://#diff-8af8fd6c2c682e20119f936f45621df94eb1dee0ae4e69c30a6eb9405b0f0642R2-R12).