### PR TITLE
Adding Liveness Check Health Probe to Activity Api

### DIFF
--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -130,7 +130,7 @@ jobs:
         dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
         working-directory: ./src/Biotrackr.Activity.Api
         api-name: biotrackr-activity-api-dev
-        test-project: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests
+        test-project: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
       secrets:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -121,18 +121,3 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}
-          
-    run-integration-tests:
-      name: Run Api Integration Tests
-      needs: [env-setup, deploy-dev]
-      uses: willvelida/biotrackr/.github/workflows/template-aca-api-integration-tests.yml@feature/activity-api-healthchecks
-      with:
-        dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
-        working-directory: ./src/Biotrackr.Activity.Api
-        api-name: biotrackr-activity-api-dev
-        test-project: ./Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
-      secrets:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}

--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -131,6 +131,7 @@ jobs:
         working-directory: ./src/Biotrackr.Activity.Api
         api-name: biotrackr-activity-api-dev
         test-project: ./Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
+        settings-file: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/appsettings.json
       secrets:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -130,7 +130,7 @@ jobs:
         dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
         working-directory: ./src/Biotrackr.Activity.Api
         api-name: biotrackr-activity-api-dev
-        test-project: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
+        test-project: ./Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
       secrets:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -131,7 +131,6 @@ jobs:
         working-directory: ./src/Biotrackr.Activity.Api
         api-name: biotrackr-activity-api-dev
         test-project: ./Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
-        settings-file: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/appsettings.json
       secrets:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -128,8 +128,9 @@ jobs:
       uses: willvelida/biotrackr/.github/workflows/template-aca-api-integration-tests.yml@feature/activity-api-healthchecks
       with:
         dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
-        working-directory: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests
+        working-directory: ./src/Biotrackr.Activity.Api
         api-name: biotrackr-activity-api-dev
+        test-project: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests
       secrets:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -34,10 +34,10 @@ jobs:
     run-unit-tests:
           name: Run Unit Tests
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@main
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@feature/activity-api-healthchecks
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
-            working-directory: ./src/Biotrackr.Activity.Api
+            working-directory: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests
             coverage-path: ${{ needs.env-setup.outputs.coverage-path }}
 
     build-container-image-dev:
@@ -121,4 +121,17 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}
-        
+          
+    run-integration-tests:
+      name: Run Api Integration Tests
+      needs: [env-setup, deploy-dev]
+      uses: willvelida/biotrackr/.github/workflows/template-aca-api-integration-tests.yml@feature/activity-api-healthchecks
+      with:
+        dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
+        working-directory: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests
+        api-name: biotrackr-activity-api-dev
+      secrets:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -19,6 +19,10 @@ on:
                 description: 'The name of the Api that will be tested'
                 required: true
                 type: string
+            settings-file:
+                description: 'The file containing app settings that are used by Integration Tests'
+                required: false
+                type: string
         secrets:
             client-id:
                 required: true
@@ -77,7 +81,7 @@ jobs:
             - name: Variable Substitution appsettings file for tests
               uses: microsoft/variable-substitution@v1
               with:
-                files: ./Biotrackr.Activity.Api.IntegrationTests/appsettings.json
+                files: ${{ inputs.settings-file }}
               env:
                 azureappconfigendpoint: ${{ steps.getappconfigendpoint.outputs.appconfigurl }}
                 managedidentityclientid: ${{ steps.getuamiClientId.outputs.clientId }}

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -56,19 +56,23 @@ jobs:
                 apiURL=$(az containerapp revision list -g ${{ secrets.resource-group-name }} -n ${{ inputs.api-name }} --query 'reverse(sort_by([].{Revision:name,Replicas:properties.replicas,Active:properties.active,Created:properties.createdTime,FQDN:properties.fqdn}[?Active!=`false`], &Created))| [0].FQDN' -o tsv)
                 echo "::set-output name=apiURL::$apiURL"
 
-            - name: Get Cosmos DB Connection String
-              id: getcosmosconnection
+            - name: Get Cosmos DB endpoint
+              id: getcosmosendpoint
               run: |
-                cosmosaccount=$(az cosmosdb list --resource-group ${{ secrets.resource-group-name }} --query "[0].name" --output tsv)
-                cosmosconnectionstring=$(az cosmosdb keys list --name $cosmosaccount --resource-group ${{ secrets.resource-group-name }} --type connection-strings --query "connectionStrings[0].connectionString" --output tsv)
-                echo "::Set-output name=cosmosconnectionstring::$cosmosconnectionstring"
+                cosmosurl=$(az cosmosdb list --resource-group ${{ secrets.resource-group-name }} --query "[0].documentEndpoint" --output tsv)
+                echo "::Set-output name=cosmosurl::$cosmosurl"
 
-            - name: Get App Config connection string
-              id: getappconfigconnection
+            - name: Get App Config endpoint
+              id: getappconfigendpoint
               run: |
-                  appconfigname=$(az appconfig list --resource-group ${{ secrets.resource-group-name }} --query "[0].name" --output tsv)
-                  appconfigconnectionstring=$(az appconfig credential list --name $appconfigname --resource-group ${{ secrets.resource-group-name }} --query "[0].connectionString" --output tsv)
-                  echo "::set-output name=appconfigconnectionstring::$appconfigconnectionstring"
+                appconfigurl=$(az appconfig list --resource-group ${{ secrets.resource-group-name }} --query "[0].endpoint" --output tsv)
+                echo "::set-output name=appconfigurl::$appconfigurl"
+
+            - name: Get User-Assigned Managed Identity Client ID
+              id: getuamiClientId
+              run: |
+                clientId=$(az identity list --resource-group ${{ secrets.resource-group-name }} --query "[0].clientId" --output tsv)
+                echo "::set-output name=clientId::$clientId"
             
             - name: Setup .NET ${{ inputs.dotnet-version }}
               uses: actions/setup-dotnet@v4
@@ -85,5 +89,6 @@ jobs:
               run: dotnet test ${{ inputs.test-project }} --no-build --verbosity normal  --logger trx
               env:
                 apiurl: "https://${{ steps.getapiurl.outputs.apiURL }}"
-                appconfigconnectionstring: ${{ steps.getappconfigconnection.outputs.appconfigconnectionstring }}
-                cosmosconnectionstring: ${{ steps.getcosmosconnection.outputs.cosmosconnectionstring }}
+                azureappconfigendpoint: ${{ steps.getappconfigendpoint.outputs.appconfigurl }}
+                managedidentityclientid: ${{ steps.getuamiClientId.outputs.clientId }}
+                cosmosdbendpoint: ${{ steps.getcosmosendpoint.outputs.cosmosurl }}

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -1,0 +1,67 @@
+name: Run ACA Api Integration Tests
+
+on:
+    workflow_call:
+        inputs:
+            dotnet-version:
+                description: 'The version of .NET to use'
+                required: true
+                type: string
+            working-directory:
+                description: 'The working directory to run the tests'
+                required: true
+                type: string
+            api-name:
+                description: 'The name of the Api that will be tested'
+                required: true
+                type: string
+        secrets:
+            client-id:
+                required: true
+            tenant-id:
+                required: true
+            subscription-id:
+                required: true
+            resource-group-name:
+                required: true
+
+jobs:
+    run-integration-tests:
+        name: Run Integration Tests
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: ${{ inputs.working-directory }}
+
+        steps:
+            - name: Checkout Repository code
+              uses: actions/checkout@v4
+
+            - uses: azure/login@v2
+              name: Login to Azure
+              with:
+                client-id: ${{ secrets.client-id }}
+                tenant-id: ${{ secrets.tenant-id }}
+                subscription-id: ${{ secrets.subscription-id }}
+
+            - name: Get API URL
+              id: getapiurl
+              run: |
+                echo "Installing containerapp extension"
+                az extension add -n containerapp --yes
+                apiURL=$(az containerapp revision list -g ${{ secrets.resource-group-name }} -n ${{ inputs.api-name }} --query 'reverse(sort_by([].{Revision:name,Replicas:properties.replicas,Active:properties.active,Created:properties.createdTime,FQDN:properties.fqdn}[?Active!=`false`], &Created))| [0].FQDN' -o tsv)
+                echo "::set-output name apiURL::$apiURL"
+            
+            - name: Setup .NET ${{ inputs.dotnet-version }}
+              uses: actions/setup-dotnet@v4
+              with:
+                dotnet-version: ${{ inputs.dotnet-version }}
+            
+            - name: Install dependencies
+              run: dotnet restore
+
+            - name: Build
+              run: dotnet build --no-restore --verbosity normal
+
+            - name: Test
+              run: dotnet test --no-build --verbosity normal  --logger trx --environment API_URL="https://${{ steps.getapiurl.outputs.apiURL }}"

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -11,6 +11,10 @@ on:
                 description: 'The working directory to run the tests'
                 required: true
                 type: string
+            test-project:
+                description: 'The Integration Test Project to run'
+                required: true
+                type: string
             api-name:
                 description: 'The name of the Api that will be tested'
                 required: true
@@ -64,4 +68,4 @@ jobs:
               run: dotnet build --no-restore --verbosity normal
 
             - name: Test
-              run: dotnet test --no-build --verbosity normal  --logger trx --environment API_URL="https://${{ steps.getapiurl.outputs.apiURL }}"
+              run: dotnet test --project ${{ inputs.test-project }} --no-build --verbosity normal  --logger trx --environment API_URL="https://${{ steps.getapiurl.outputs.apiURL }}"

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
                 echo "Installing containerapp extension"
                 az extension add -n containerapp --yes
                 apiURL=$(az containerapp revision list -g ${{ secrets.resource-group-name }} -n ${{ inputs.api-name }} --query 'reverse(sort_by([].{Revision:name,Replicas:properties.replicas,Active:properties.active,Created:properties.createdTime,FQDN:properties.fqdn}[?Active!=`false`], &Created))| [0].FQDN' -o tsv)
-                echo "::set-output name apiURL::$apiURL"
+                echo "::set-output name=apiURL::$apiURL"
             
             - name: Setup .NET ${{ inputs.dotnet-version }}
               uses: actions/setup-dotnet@v4

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -55,6 +55,24 @@ jobs:
                 az extension add -n containerapp --yes
                 apiURL=$(az containerapp revision list -g ${{ secrets.resource-group-name }} -n ${{ inputs.api-name }} --query 'reverse(sort_by([].{Revision:name,Replicas:properties.replicas,Active:properties.active,Created:properties.createdTime,FQDN:properties.fqdn}[?Active!=`false`], &Created))| [0].FQDN' -o tsv)
                 echo "::set-output name=apiURL::$apiURL"
+
+            - name: Get Cosmos DB endpoint
+              id: getcosmosendpoint
+              run: |
+                cosmosurl=$(az cosmosdb list --resource-group ${{ secrets.resource-group-name }} --query "[0].documentEndpoint" --output tsv)
+                echo "::Set-output name=cosmosurl::$cosmosurl"
+
+            - name: Get App Config endpoint
+              id: getappconfigendpoint
+              run: |
+                appconfigurl=$(az appconfig list --resource-group ${{ secrets.resource-group-name }} --query "[0].endpoint" --output tsv)
+                echo "::set-output name=appconfigurl::$appconfigurl"
+
+            - name: Get User-Assigned Managed Identity Client ID
+              id: getuamiClientId
+              run: |
+                clientId=$(az identity list --resource-group ${{ secrets.resource-group-name }} --query "[0].clientId" --output tsv)
+                echo "::set-output name=clientId::$clientId"
             
             - name: Setup .NET ${{ inputs.dotnet-version }}
               uses: actions/setup-dotnet@v4
@@ -68,4 +86,9 @@ jobs:
               run: dotnet build --no-restore --verbosity normal
 
             - name: Test
-              run: dotnet test ${{ inputs.test-project }} --no-build --verbosity normal  --logger trx --environment API_URL="https://${{ steps.getapiurl.outputs.apiURL }}"
+              run: dotnet test ${{ inputs.test-project }} --no-build --verbosity normal  --logger trx
+              env:
+                apiurl: "https://${{ steps.getapiurl.outputs.apiURL }}"
+                azureappconfigendpoint: ${{ steps.getappconfigendpoint.outputs.appconfigurl }}
+                managedidentityclientid: ${{ steps.getuamiClientId.outputs.clientId }}
+                cosmosdbendpoint: ${{ steps.getcosmosendpoint.outputs.cosmosurl }}

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -73,6 +73,15 @@ jobs:
               run: |
                 clientId=$(az identity list --resource-group ${{ secrets.resource-group-name }} --query "[0].clientId" --output tsv)
                 echo "::set-output name=clientId::$clientId"
+
+            - name: Variable Substitution appsettings file for tests
+              uses: microsoft/variable-substitution@v1
+              with:
+                files: ./Biotrackr.Activity.Api.IntegrationTests/appsettings.json
+              env:
+                azureappconfigendpoint: ${{ steps.getappconfigendpoint.outputs.appconfigurl }}
+                managedidentityclientid: ${{ steps.getuamiClientId.outputs.clientId }}
+                cosmosdbendpoint: ${{ steps.getcosmosendpoint.outputs.cosmosurl }}
             
             - name: Setup .NET ${{ inputs.dotnet-version }}
               uses: actions/setup-dotnet@v4
@@ -88,7 +97,4 @@ jobs:
             - name: Test
               run: dotnet test ${{ inputs.test-project }} --no-build --verbosity normal  --logger trx
               env:
-                apiurl: "https://${{ steps.getapiurl.outputs.apiURL }}"
-                azureappconfigendpoint: ${{ steps.getappconfigendpoint.outputs.appconfigurl }}
-                managedidentityclientid: ${{ steps.getuamiClientId.outputs.clientId }}
-                cosmosdbendpoint: ${{ steps.getcosmosendpoint.outputs.cosmosurl }}
+                apiurl: "https://${{ steps.getapiurl.outputs.apiURL }}"               

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -56,23 +56,19 @@ jobs:
                 apiURL=$(az containerapp revision list -g ${{ secrets.resource-group-name }} -n ${{ inputs.api-name }} --query 'reverse(sort_by([].{Revision:name,Replicas:properties.replicas,Active:properties.active,Created:properties.createdTime,FQDN:properties.fqdn}[?Active!=`false`], &Created))| [0].FQDN' -o tsv)
                 echo "::set-output name=apiURL::$apiURL"
 
-            - name: Get Cosmos DB endpoint
-              id: getcosmosendpoint
+            - name: Get Cosmos DB Connection String
+              id: getcosmosconnection
               run: |
-                cosmosurl=$(az cosmosdb list --resource-group ${{ secrets.resource-group-name }} --query "[0].documentEndpoint" --output tsv)
-                echo "::Set-output name=cosmosurl::$cosmosurl"
+                cosmosaccount=$(az cosmosdb list --resource-group ${{ secrets.resource-group-name }} --query "[0].name" --output tsv)
+                cosmosconnectionstring=$(az cosmosdb keys list --name $cosmosaccount --resource-group ${{ secrets.resource-group-name }} --type connection-strings --query "connectionStrings[0].connectionString" --output tsv)
+                echo "::Set-output name=cosmosconnectionstring::$cosmosconnectionstring"
 
-            - name: Get App Config endpoint
-              id: getappconfigendpoint
+            - name: Get App Config connection string
+              id: getappconfigconnection
               run: |
-                appconfigurl=$(az appconfig list --resource-group ${{ secrets.resource-group-name }} --query "[0].endpoint" --output tsv)
-                echo "::set-output name=appconfigurl::$appconfigurl"
-
-            - name: Get User-Assigned Managed Identity Client ID
-              id: getuamiClientId
-              run: |
-                clientId=$(az identity list --resource-group ${{ secrets.resource-group-name }} --query "[0].clientId" --output tsv)
-                echo "::set-output name=clientId::$clientId"
+                  appconfigname=$(az appconfig list --resource-group ${{ secrets.resource-group-name }} --query "[0].name" --output tsv)
+                  appconfigconnectionstring=$(az appconfig credential list --name $appconfigname --resource-group ${{ secrets.resource-group-name }} --query "[0].connectionString" --output tsv)
+                  echo "::set-output name=appconfigconnectionstring::$appconfigconnectionstring"
             
             - name: Setup .NET ${{ inputs.dotnet-version }}
               uses: actions/setup-dotnet@v4
@@ -89,6 +85,5 @@ jobs:
               run: dotnet test ${{ inputs.test-project }} --no-build --verbosity normal  --logger trx
               env:
                 apiurl: "https://${{ steps.getapiurl.outputs.apiURL }}"
-                azureappconfigendpoint: ${{ steps.getappconfigendpoint.outputs.appconfigurl }}
-                managedidentityclientid: ${{ steps.getuamiClientId.outputs.clientId }}
-                cosmosdbendpoint: ${{ steps.getcosmosendpoint.outputs.cosmosurl }}
+                appconfigconnectionstring: ${{ steps.getappconfigconnection.outputs.appconfigconnectionstring }}
+                cosmosconnectionstring: ${{ steps.getcosmosconnection.outputs.cosmosconnectionstring }}

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -68,4 +68,4 @@ jobs:
               run: dotnet build --no-restore --verbosity normal
 
             - name: Test
-              run: dotnet test --project ${{ inputs.test-project }} --no-build --verbosity normal  --logger trx --environment API_URL="https://${{ steps.getapiurl.outputs.apiURL }}"
+              run: dotnet test ${{ inputs.test-project }} --no-build --verbosity normal  --logger trx --environment API_URL="https://${{ steps.getapiurl.outputs.apiURL }}"

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -101,4 +101,7 @@ jobs:
             - name: Test
               run: dotnet test ${{ inputs.test-project }} --no-build --verbosity normal  --logger trx
               env:
-                apiurl: "https://${{ steps.getapiurl.outputs.apiURL }}"               
+                apiurl: "https://${{ steps.getapiurl.outputs.apiURL }}"
+                azureappconfigendpoint: ${{ steps.getappconfigendpoint.outputs.appconfigurl }}
+                managedidentityclientid: ${{ steps.getuamiClientId.outputs.clientId }}
+                cosmosdbendpoint: ${{ steps.getcosmosendpoint.outputs.cosmosurl }}               

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -19,10 +19,6 @@ on:
                 description: 'The name of the Api that will be tested'
                 required: true
                 type: string
-            settings-file:
-                description: 'The file containing app settings that are used by Integration Tests'
-                required: false
-                type: string
         secrets:
             client-id:
                 required: true
@@ -71,21 +67,6 @@ jobs:
               run: |
                 appconfigurl=$(az appconfig list --resource-group ${{ secrets.resource-group-name }} --query "[0].endpoint" --output tsv)
                 echo "::set-output name=appconfigurl::$appconfigurl"
-
-            - name: Get User-Assigned Managed Identity Client ID
-              id: getuamiClientId
-              run: |
-                clientId=$(az identity list --resource-group ${{ secrets.resource-group-name }} --query "[0].clientId" --output tsv)
-                echo "::set-output name=clientId::$clientId"
-
-            - name: Variable Substitution appsettings file for tests
-              uses: microsoft/variable-substitution@v1
-              with:
-                files: ${{ inputs.settings-file }}
-              env:
-                azureappconfigendpoint: ${{ steps.getappconfigendpoint.outputs.appconfigurl }}
-                managedidentityclientid: ${{ steps.getuamiClientId.outputs.clientId }}
-                cosmosdbendpoint: ${{ steps.getcosmosendpoint.outputs.cosmosurl }}
             
             - name: Setup .NET ${{ inputs.dotnet-version }}
               uses: actions/setup-dotnet@v4
@@ -103,5 +84,5 @@ jobs:
               env:
                 apiurl: "https://${{ steps.getapiurl.outputs.apiURL }}"
                 azureappconfigendpoint: ${{ steps.getappconfigendpoint.outputs.appconfigurl }}
-                managedidentityclientid: ${{ steps.getuamiClientId.outputs.clientId }}
+                managedidentityclientid: ${{secrets.client-id }}
                 cosmosdbendpoint: ${{ steps.getcosmosendpoint.outputs.cosmosurl }}               

--- a/infra/apps/activity-api/main.bicep
+++ b/infra/apps/activity-api/main.bicep
@@ -48,6 +48,19 @@ module activityApi '../../modules/host/container-app-http.bicep' = {
     imageName: imageName
     uaiName: uai.name
     targetPort: 8080
+    healthProbes: [
+      {
+        type: 'Liveness'
+        httpGet: {
+          port: 8080
+          path: '/healthz/liveness'
+        }
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        failureThreshold: 3
+        timeoutSeconds: 1
+      }
+    ]
     envVariables: [
       { 
         name: 'azureappconfigendpoint'

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
@@ -11,9 +11,14 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Biotrackr.Activity.Api\Biotrackr.Activity.Api.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <UserSecretsId>e906c52a-35a7-4fab-9828-500505131806</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -51,6 +51,8 @@ namespace Biotrackr.Activity.Api.IntegrationTests
                 services.AddSingleton(cosmosClient);
                 services.AddTransient<ICosmosRepository, CosmosRepository>();
             });
+
+            builder.UseEnvironment("Development");
         }
     }
 }

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -20,9 +20,9 @@ namespace Biotrackr.Activity.Api.IntegrationTests
                       .AddEnvironmentVariables()
                       .AddJsonFile("appsettings.json");
                 var builtConfig = config.Build();
-                var managedIdentityClientId = builtConfig.GetValue<string>("managedidentityclientid");
-                var azureAppConfigEndpoint = builtConfig.GetValue<string>("azureappconfigendpoint");
-                var cosmosDbEndpoint = builtConfig.GetValue<string>("cosmosdbendpoint");
+                var managedIdentityClientId = Environment.GetEnvironmentVariable("managedidentityclientid");
+                var azureAppConfigEndpoint = Environment.GetEnvironmentVariable("azureappconfigendpoint");
+                var cosmosDbEndpoint = Environment.GetEnvironmentVariable("cosmosdbendpoint");
 
                 if (string.IsNullOrEmpty(managedIdentityClientId) || string.IsNullOrEmpty(azureAppConfigEndpoint) || string.IsNullOrEmpty(cosmosDbEndpoint))
                 {
@@ -54,11 +54,11 @@ namespace Biotrackr.Activity.Api.IntegrationTests
 
                 var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
                 {
-                    ManagedIdentityClientId = context.Configuration.GetValue<string>("managedidentityclientid")
+                    ManagedIdentityClientId = Environment.GetEnvironmentVariable("managedidentityclientid")
                 });
 
                 var cosmosClient = new CosmosClient(
-                    context.Configuration.GetValue<string>("cosmosdbendpoint"),
+                    Environment.GetEnvironmentVariable("cosmosdbendpoint"),
                     credential,
                     cosmosClientOptions);
 

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -16,6 +16,7 @@ namespace Biotrackr.Activity.Api.IntegrationTests
         {
             builder.ConfigureAppConfiguration((context, config) =>
             {
+                config.AddEnvironmentVariables();
                 var builtConfig = config.Build();
                 var managedIdentityClientId = builtConfig.GetValue<string>("managedidentityclientid");
                 var defaultCredentialOptions = new DefaultAzureCredentialOptions()

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -1,0 +1,55 @@
+﻿using Azure.Identity;
+using Biotrackr.Activity.Api.Repositories;
+using Biotrackr.Activity.Api.Repositories.Interfaces;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Biotrackr.Activity.Api.IntegrationTests
+{
+    public class CustomWebApplicationFactory<TStartup> : WebApplicationFactory<TStartup> where TStartup : class
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureAppConfiguration((context, config) =>
+            {
+                var builtConfig = config.Build();
+                var managedIdentityClientId = builtConfig.GetValue<string>("managedidentityclientid");
+                var defaultCredentialOptions = new DefaultAzureCredentialOptions()
+                {
+                    ManagedIdentityClientId = managedIdentityClientId
+                };
+
+                config.AddAzureAppConfiguration(config =>
+                {
+                    config.Connect(new Uri(builtConfig.GetValue<string>("azureappconfigendpoint")),
+                                   new ManagedIdentityCredential(managedIdentityClientId))
+                          .Select(KeyFilter.Any, LabelFilter.Null);
+                });
+            });
+
+            builder.ConfigureServices((context, services) =>
+            {
+                var cosmosClientOptions = new CosmosClientOptions
+                {
+                    SerializerOptions = new CosmosSerializationOptions
+                    {
+                        PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+                    }
+                };
+                var cosmosClient = new CosmosClient(
+                    context.Configuration.GetValue<string>("cosmosdbendpoint"),
+                    new DefaultAzureCredential(new DefaultAzureCredentialOptions
+                    {
+                        ManagedIdentityClientId = context.Configuration.GetValue<string>("managedidentityclientid")
+                    }),
+                    cosmosClientOptions);
+                services.AddSingleton(cosmosClient);
+                services.AddTransient<ICosmosRepository, CosmosRepository>();
+            });
+        }
+    }
+}

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -18,16 +18,9 @@ namespace Biotrackr.Activity.Api.IntegrationTests
             {
                 config.AddEnvironmentVariables();
                 var builtConfig = config.Build();
-                var managedIdentityClientId = builtConfig.GetValue<string>("managedidentityclientid");
-                var defaultCredentialOptions = new DefaultAzureCredentialOptions()
-                {
-                    ManagedIdentityClientId = managedIdentityClientId
-                };
-
                 config.AddAzureAppConfiguration(config =>
                 {
-                    config.Connect(new Uri(builtConfig.GetValue<string>("azureappconfigendpoint")),
-                                   new ManagedIdentityCredential(managedIdentityClientId))
+                    config.Connect(builtConfig.GetValue<string>("appconfigconnectionstring"))
                           .Select(KeyFilter.Any, LabelFilter.Null);
                 });
             });
@@ -42,11 +35,7 @@ namespace Biotrackr.Activity.Api.IntegrationTests
                     }
                 };
                 var cosmosClient = new CosmosClient(
-                    context.Configuration.GetValue<string>("cosmosdbendpoint"),
-                    new DefaultAzureCredential(new DefaultAzureCredentialOptions
-                    {
-                        ManagedIdentityClientId = context.Configuration.GetValue<string>("managedidentityclientid")
-                    }),
+                    context.Configuration.GetValue<string>("cosmosconnectionstring"),
                     cosmosClientOptions);
                 services.AddSingleton(cosmosClient);
                 services.AddTransient<ICosmosRepository, CosmosRepository>();

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/HealthCheckHandlerTests/HealthChecksShould.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/HealthCheckHandlerTests/HealthChecksShould.cs
@@ -19,7 +19,7 @@ namespace Biotrackr.Activity.Api.IntegrationTests.HealthCheckHandlerTests
             // Arrange
             var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
             {
-                BaseAddress = new Uri(Environment.GetEnvironmentVariable("API_URL"))
+                BaseAddress = new Uri(Environment.GetEnvironmentVariable("apiurl"))
             });
 
             // Act

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/HealthCheckHandlerTests/HealthChecksShould.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/HealthCheckHandlerTests/HealthChecksShould.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net;
+
+namespace Biotrackr.Activity.Api.IntegrationTests.HealthCheckHandlerTests
+{
+    public class HealthChecksShould : IClassFixture<WebApplicationFactory<Program>>
+    {
+        private readonly WebApplicationFactory<Program> _factory;
+
+        public HealthChecksShould(WebApplicationFactory<Program> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task MapHealthChecks_ShouldReturn200Ok_WhenHealthCheckIsHealthy()
+        {
+            // Arrange
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                BaseAddress = new Uri(Environment.GetEnvironmentVariable("API_URL"))
+            });
+
+            // Act
+            var response = await client.GetAsync("/healthz/liveness");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            Assert.Equal((HttpStatusCode)StatusCodes.Status200OK, response.StatusCode);
+        }
+    }
+}

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/HealthCheckHandlerTests/HealthChecksShould.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/HealthCheckHandlerTests/HealthChecksShould.cs
@@ -4,11 +4,11 @@ using System.Net;
 
 namespace Biotrackr.Activity.Api.IntegrationTests.HealthCheckHandlerTests
 {
-    public class HealthChecksShould : IClassFixture<WebApplicationFactory<Program>>
+    public class HealthChecksShould : IClassFixture<CustomWebApplicationFactory<Program>>
     {
-        private readonly WebApplicationFactory<Program> _factory;
+        private readonly CustomWebApplicationFactory<Program> _factory;
 
-        public HealthChecksShould(WebApplicationFactory<Program> factory)
+        public HealthChecksShould(CustomWebApplicationFactory<Program> factory)
         {
             _factory = factory;
         }

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/appsettings.json
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "azureappconfigendpoint": "",
+  "managedidentityclientid": "",
+  "cosmosdbendpoint": ""
+}

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.sln
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Biotrackr.Activity.Api", "B
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Biotrackr.Activity.Api.UnitTests", "Biotrackr.Activity.Api.UnitTests\Biotrackr.Activity.Api.UnitTests.csproj", "{BDEB59D1-F440-4066-B59F-C080459A619E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Biotrackr.Activity.Api.IntegrationTests", "Biotrackr.Activity.Api.IntegrationTests\Biotrackr.Activity.Api.IntegrationTests.csproj", "{2E886029-D44E-4176-921D-CE1746F3D5FB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{BDEB59D1-F440-4066-B59F-C080459A619E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BDEB59D1-F440-4066-B59F-C080459A619E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BDEB59D1-F440-4066-B59F-C080459A619E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E886029-D44E-4176-921D-CE1746F3D5FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E886029-D44E-4176-921D-CE1746F3D5FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E886029-D44E-4176-921D-CE1746F3D5FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E886029-D44E-4176-921D-CE1746F3D5FB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Extensions/EndpointRouteBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace Biotrackr.Activity.Api.Extensions
 
         public static void RegisterHealthCheckEndpoints(this IEndpointRouteBuilder endpointRouteBuilder)
         {
-            var healthEndpoints = endpointRouteBuilder.MapGroup("/health");
+            var healthEndpoints = endpointRouteBuilder.MapGroup("/healthz");
 
             healthEndpoints.MapHealthChecks("/liveness", new HealthCheckOptions
             {

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Extensions/EndpointRouteBuilderExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using Biotrackr.Activity.Api.EndpointHandlers;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Biotrackr.Activity.Api.Extensions
 {
@@ -13,6 +15,21 @@ namespace Biotrackr.Activity.Api.Extensions
                 .WithOpenApi()
                 .WithSummary("Get an Activity Summary by providing a date")
                 .WithDescription("You can get a specific activity summary via this endpoint by providing the date in the following format (YYYY-MM-DD)");
+        }
+
+        public static void RegisterHealthCheckEndpoints(this IEndpointRouteBuilder endpointRouteBuilder)
+        {
+            var healthEndpoints = endpointRouteBuilder.MapGroup("/health");
+
+            healthEndpoints.MapHealthChecks("/liveness", new HealthCheckOptions
+            {
+                ResultStatusCodes =
+                {
+                    [HealthStatus.Healthy] = StatusCodes.Status200OK,
+                    [HealthStatus.Degraded] = StatusCodes.Status200OK,
+                    [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+                }
+            });
         }
     }
 }

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Program.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Program.cs
@@ -55,11 +55,14 @@ builder.Services.AddSwaggerGen(options =>
     });
 });
 
+builder.Services.AddHealthChecks();
+
 var app = builder.Build();
 
 app.UseSwagger();
 app.UseSwaggerUI();
 
 app.RegisterActivityEndpoints();
+app.RegisterHealthCheckEndpoints();
 
 app.Run();

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Program.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Program.cs
@@ -66,3 +66,5 @@ app.RegisterActivityEndpoints();
 app.RegisterHealthCheckEndpoints();
 
 app.Run();
+
+public partial class Program { }


### PR DESCRIPTION
This pull request introduces health check functionality to the `Biotrackr.Activity.Api` service. The changes include adding health probes in the infrastructure configuration, registering health check endpoints, and updating the service configuration to support health checks.

### Health Check Functionality:

* [`infra/apps/activity-api/main.bicep`](diffhunk://#diff-97bd90f954a37e249e028237c0853552fbe664a6a9ed6d200109a990933128afR51-R63): Added health probes for liveness checks to the container configuration.
* [`src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Extensions/EndpointRouteBuilderExtensions.cs`](diffhunk://#diff-6c3fb6425e9ef14b4be0de9ce174ad22ec5d9317c44e65a3cc0ee912e468e1c5R2-R3): Added using statements for health check libraries and defined a new method `RegisterHealthCheckEndpoints` to map health check endpoints. [[1]](diffhunk://#diff-6c3fb6425e9ef14b4be0de9ce174ad22ec5d9317c44e65a3cc0ee912e468e1c5R2-R3) [[2]](diffhunk://#diff-6c3fb6425e9ef14b4be0de9ce174ad22ec5d9317c44e65a3cc0ee912e468e1c5R19-R33)
* [`src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Program.cs`](diffhunk://#diff-b924385448f29e2ed04285f3069354209c5fe65ed0de80ebb3a5c0d800b6efc6R58-R66): Registered health check services and endpoints in the application startup configuration.