### PR TITLE
Using WorkloadIdentityCredential in Integration Tests

### DIFF
--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -125,7 +125,7 @@ jobs:
     run-integration-tests:
       name: Run Api Integration Tests
       needs: [env-setup, deploy-dev]
-      uses: willvelida/biotrackr/.github/workflows/template-aca-api-integration-tests.yml@main
+      uses: willvelida/biotrackr/.github/workflows/template-aca-api-integration-tests.yml@feature/activity-api-integration-tests
       with:
         dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
         working-directory: ./src/Biotrackr.Activity.Api

--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -34,7 +34,7 @@ jobs:
     run-unit-tests:
           name: Run Unit Tests
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@feature/activity-api-healthchecks
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@main
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
             working-directory: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests
@@ -121,3 +121,18 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}
+
+    run-integration-tests:
+      name: Run Api Integration Tests
+      needs: [env-setup, deploy-dev]
+      uses: willvelida/biotrackr/.github/workflows/template-aca-api-integration-tests.yml@main
+      with:
+        dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
+        working-directory: ./src/Biotrackr.Activity.Api
+        api-name: biotrackr-activity-api-dev
+        test-project: ./Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
+      secrets:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}

--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -121,18 +121,3 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}
-
-    run-integration-tests:
-      name: Run Api Integration Tests
-      needs: [env-setup, deploy-dev]
-      uses: willvelida/biotrackr/.github/workflows/template-aca-api-integration-tests.yml@feature/activity-api-integration-tests
-      with:
-        dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
-        working-directory: ./src/Biotrackr.Activity.Api
-        api-name: biotrackr-activity-api-dev
-        test-project: ./Biotrackr.Activity.Api.IntegrationTests/Biotrackr.Activity.Api.IntegrationTests.csproj
-      secrets:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -84,5 +84,5 @@ jobs:
               env:
                 apiurl: "https://${{ steps.getapiurl.outputs.apiURL }}"
                 azureappconfigendpoint: ${{ steps.getappconfigendpoint.outputs.appconfigurl }}
-                managedidentityclientid: ${{secrets.client-id }}
+                managedidentityclientid: ${{ secrets.client-id }}
                 cosmosdbendpoint: ${{ steps.getcosmosendpoint.outputs.cosmosurl }}               

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -85,4 +85,5 @@ jobs:
                 apiurl: "https://${{ steps.getapiurl.outputs.apiURL }}"
                 azureappconfigendpoint: ${{ steps.getappconfigendpoint.outputs.appconfigurl }}
                 managedidentityclientid: ${{ secrets.client-id }}
-                cosmosdbendpoint: ${{ steps.getcosmosendpoint.outputs.cosmosurl }}               
+                cosmosdbendpoint: ${{ steps.getcosmosendpoint.outputs.cosmosurl }}
+                tenantid: ${{ secrets.tenant-id }}               

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -22,6 +22,7 @@ namespace Biotrackr.Activity.Api.IntegrationTests
                       .AddJsonFile("appsettings.json");
                 var builtConfig = config.Build();
                 var managedIdentityClientId = Environment.GetEnvironmentVariable("managedidentityclientid");
+                var tenantId = Environment.GetEnvironmentVariable("tenantid");
                 var azureAppConfigEndpoint = Environment.GetEnvironmentVariable("azureappconfigendpoint");
                 var cosmosDbEndpoint = Environment.GetEnvironmentVariable("cosmosdbendpoint");
 
@@ -30,15 +31,14 @@ namespace Biotrackr.Activity.Api.IntegrationTests
                     throw new InvalidOperationException("Required environment variables are not set.");
                 }
 
-                var workloadIdentityCredentialOptions = new WorkloadIdentityCredentialOptions
-                {
-                    ClientId = managedIdentityClientId
-                };
-
                 config.AddAzureAppConfiguration(config =>
                 {
                     config.Connect(new Uri(azureAppConfigEndpoint),
-                                   new WorkloadIdentityCredential(workloadIdentityCredentialOptions))
+                                   new WorkloadIdentityCredential(new WorkloadIdentityCredentialOptions
+                                   {
+                                       ClientId = managedIdentityClientId,
+                                       TenantId = tenantId
+                                   }))
                           .Select(KeyFilter.Any, LabelFilter.Null);
                 });
             });
@@ -55,14 +55,16 @@ namespace Biotrackr.Activity.Api.IntegrationTests
                     }
                 };
 
-                var workloadIdentityCredentialOptions = new WorkloadIdentityCredentialOptions
-                {
-                    ClientId = Environment.GetEnvironmentVariable("managedidentityclientid")
-                };
+                var managedIdentityClientId = Environment.GetEnvironmentVariable("managedidentityclientid");
+                var tenantId = Environment.GetEnvironmentVariable("tenantid");
 
                 var cosmosClient = new CosmosClient(
                     Environment.GetEnvironmentVariable("cosmosdbendpoint"),
-                    new WorkloadIdentityCredential(workloadIdentityCredentialOptions),
+                    new WorkloadIdentityCredential(new WorkloadIdentityCredentialOptions
+                    {
+                        ClientId = managedIdentityClientId,
+                        TenantId = tenantId
+                    }),
                     cosmosClientOptions);
 
                 services.AddSingleton(cosmosClient);

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -30,10 +30,15 @@ namespace Biotrackr.Activity.Api.IntegrationTests
                     throw new InvalidOperationException("Required environment variables are not set.");
                 }
 
+                var workloadIdentityCredentialOptions = new WorkloadIdentityCredentialOptions
+                {
+                    ClientId = managedIdentityClientId
+                };
+
                 config.AddAzureAppConfiguration(config =>
                 {
                     config.Connect(new Uri(azureAppConfigEndpoint),
-                                   new ManagedIdentityCredential(managedIdentityClientId))
+                                   new WorkloadIdentityCredential(workloadIdentityCredentialOptions))
                           .Select(KeyFilter.Any, LabelFilter.Null);
                 });
             });
@@ -50,11 +55,14 @@ namespace Biotrackr.Activity.Api.IntegrationTests
                     }
                 };
 
-                var credential = new ManagedIdentityCredential(Environment.GetEnvironmentVariable("managedidentityclientid"));
+                var workloadIdentityCredentialOptions = new WorkloadIdentityCredentialOptions
+                {
+                    ClientId = Environment.GetEnvironmentVariable("managedidentityclientid")
+                };
 
                 var cosmosClient = new CosmosClient(
                     Environment.GetEnvironmentVariable("cosmosdbendpoint"),
-                    credential,
+                    new WorkloadIdentityCredential(workloadIdentityCredentialOptions),
                     cosmosClientOptions);
 
                 services.AddSingleton(cosmosClient);


### PR DESCRIPTION
This pull request includes updates to the deployment workflow and integration test setup for the `Biotrackr.Activity.Api` project. The most important changes involve updating the workflow configuration to run integration tests and modifying the integration test setup to use `WorkloadIdentityCredential` instead of `ManagedIdentityCredential`.

**Workflow updates:**

* [`.github/workflows/deploy-activity-api.yml`](diffhunk://#diff-678d6cd7866beb45956fda554cce64ac37b5c8e5bc8c29b108095019a5f74a4aL37-R37): Updated the `run-unit-tests` job to use the main branch of the template and added a new `run-integration-tests` job to run API integration tests. [[1]](diffhunk://#diff-678d6cd7866beb45956fda554cce64ac37b5c8e5bc8c29b108095019a5f74a4aL37-R37) [[2]](diffhunk://#diff-678d6cd7866beb45956fda554cce64ac37b5c8e5bc8c29b108095019a5f74a4aR124-R138)

**Integration test setup:**

* [`src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/CustomWebApplicationFactory.cs`](diffhunk://#diff-f0bfdbeeb0e29e63bab5afbf7561f76faf0fdc98dbed48ed649ba91d29db50f6R33-R41): Replaced `ManagedIdentityCredential` with `WorkloadIdentityCredential` for Azure App Configuration and Cosmos DB client setup. [[1]](diffhunk://#diff-f0bfdbeeb0e29e63bab5afbf7561f76faf0fdc98dbed48ed649ba91d29db50f6R33-R41) [[2]](diffhunk://#diff-f0bfdbeeb0e29e63bab5afbf7561f76faf0fdc98dbed48ed649ba91d29db50f6L53-R65)