### PR TITLE
Adding endpoint to search for weight by date

### DIFF
--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/EndpointHandlerTests/WeightHandlersShould.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/EndpointHandlerTests/WeightHandlersShould.cs
@@ -30,5 +30,37 @@ namespace Biotrackr.Weight.Api.UnitTests.EndpointHandlerTests
             result.Should().BeOfType<Ok<List<WeightDocument>>>();
             result.Value.Should().BeEquivalentTo(weightDocuments);
         }
+
+        [Fact]
+        public async Task GetWeightByDate_ShouldReturnOk_WhenWeightIsFound()
+        {
+            // Arrange
+            var date = "2022-01-01";
+            var fixture = new Fixture();
+            var weightDocument = fixture.Create<WeightDocument>();
+            weightDocument.Date = date;
+
+            _cosmosRepositoryMock.Setup(c => c.GetWeightDocumentByDate(date)).ReturnsAsync(weightDocument);
+
+            // Act
+            var result = await WeightHandlers.GetWeightByDate(_cosmosRepositoryMock.Object, date);
+
+            // Assert
+            result.Result.Should().BeOfType<Ok<WeightDocument>>();
+        }
+
+        [Fact]
+        public async Task GetWeightByDate_ShouldReturnNotFound_WhenWeightIsNotFound()
+        {
+            // Arrange
+            var date = "2022-01-01";
+            _cosmosRepositoryMock.Setup(c => c.GetWeightDocumentByDate(date)).ReturnsAsync((WeightDocument)null);
+
+            // Act
+            var result = await WeightHandlers.GetWeightByDate(_cosmosRepositoryMock.Object, date);
+
+            // Assert
+            result.Result.Should().BeOfType<NotFound>();
+        }
     }
 }

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/EndpointHandlers/WeightHandlers.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/EndpointHandlers/WeightHandlers.cs
@@ -12,5 +12,17 @@ namespace Biotrackr.Weight.Api.EndpointHandlers
             var weightDocuments = await cosmosRepository.GetAllWeightDocuments();
             return TypedResults.Ok(weightDocuments);
         }
+
+        public static async Task<Results<NotFound, Ok<WeightDocument>>> GetWeightByDate(
+            ICosmosRepository cosmosRepository,
+            string date)
+        {
+            var weightDocument = await cosmosRepository.GetWeightDocumentByDate(date);
+            if (weightDocument == null)
+            {
+                return TypedResults.NotFound();
+            }
+            return TypedResults.Ok(weightDocument);
+        }
     }
 }

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Extensions/EndpointRouteBuilderExtensions.cs
@@ -15,6 +15,12 @@ namespace Biotrackr.Weight.Api.Extensions
                 .WithOpenApi()
                 .WithSummary("Gets all weight documents")
                 .WithDescription("Gets all weight documents from the database");
+
+            weightEndpoints.MapGet("/{date}", WeightHandlers.GetWeightByDate)
+                .WithName("GetWeightByDate")
+                .WithOpenApi()
+                .WithSummary("Gets a weight document by date")
+                .WithDescription("Gets a weight document from the database by date");
         }
 
         public static void RegisterHealthCheckEndpoints(this IEndpointRouteBuilder endpointRouteBuilder)

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Repositories/CosmosRepository.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Repositories/CosmosRepository.cs
@@ -48,5 +48,34 @@ namespace Biotrackr.Weight.Api.Repositories
                 throw;
             }
         }
+
+        public async Task<WeightDocument> GetWeightDocumentByDate(string date)
+        {
+            try
+            {
+                QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM c WHERE c.date = @date")
+                    .WithParameter("@date", date);
+                QueryRequestOptions queryRequestOptions = new QueryRequestOptions
+                {
+                    PartitionKey = new PartitionKey("Weight")
+                };
+
+                var iterator = _container.GetItemQueryIterator<WeightDocument>(queryDefinition, requestOptions: queryRequestOptions);
+                var results = new List<WeightDocument>();
+
+                while (iterator.HasMoreResults)
+                {
+                    var response = await iterator.ReadNextAsync();
+                    results.AddRange(response.ToList());
+                }
+
+                return results.FirstOrDefault();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Exception thrown in {nameof(GetWeightDocumentByDate)}: {ex.Message}");
+                throw;
+            }
+        }
     }
 }

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Repositories/Interfaces/ICosmosRepository.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Repositories/Interfaces/ICosmosRepository.cs
@@ -5,5 +5,6 @@ namespace Biotrackr.Weight.Api.Repositories.Interfaces
     public interface ICosmosRepository
     {
         Task<List<WeightDocument>> GetAllWeightDocuments();
+        Task<WeightDocument> GetWeightDocumentByDate(string date);
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to retrieve weight documents by date in the `Biotrackr.Weight.Api` project. The changes include adding new methods, updating interfaces, and extending endpoint routes to support this functionality.

### New Feature: Retrieve Weight Documents by Date

* **Endpoint Handlers**:
  * [`src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/EndpointHandlers/WeightHandlers.cs`](diffhunk://#diff-5abc98c58ea8850d9846a703853cc2eede0bd2972b1f259a1aca6417140a8012R15-R26): Added `GetWeightByDate` method to handle requests for weight documents by date.

* **Repository Implementation**:
  * [`src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Repositories/CosmosRepository.cs`](diffhunk://#diff-f3b4e1be766f3a509b202cf37194859a862af9db7e03ffc6b8c97bb150092837R51-R79): Added `GetWeightDocumentByDate` method to query the database for a weight document by date.

* **Interface Update**:
  * [`src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Repositories/Interfaces/ICosmosRepository.cs`](diffhunk://#diff-19ee1c7859f4f224a4c1c222051292451a6f207d82df3be4ba504f3f918a6a85R8): Added `GetWeightDocumentByDate` method to the `ICosmosRepository` interface.

* **Endpoint Route Registration**:
  * [`src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Extensions/EndpointRouteBuilderExtensions.cs`](diffhunk://#diff-e8b9ac74b9930a51e41ac8aa5f9ea8d85b76d6ba450255df7fd69b8dcb94d785R18-R23): Registered a new endpoint for `GetWeightByDate` to map requests to the handler.

* **Unit Tests**:
  * [`src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/EndpointHandlerTests/WeightHandlersShould.cs`](diffhunk://#diff-dea3629a66910a8d8eeeb57715956b8d150b6d0d1c26951bf412a43b7f4db646R33-R64): Added tests for `GetWeightByDate` to ensure it returns the correct results based on the presence of the weight document.
  * [`src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/RepositoryTests/CosmosRepositoryShould.cs`](diffhunk://#diff-2dcd4ae899902421c09b03a1cfe3c78849f95ede372d93ae9cf6933df62384bcR93-R176): Added tests for `GetWeightDocumentByDate` to validate its behavior under various conditions, including error handling.

/resolves #39 