### PR TITLE
Adding endpoint to retrieve all activity summaries

### DIFF
--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests/EndpointHandlerTests/ActivityHandlersShould.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests/EndpointHandlerTests/ActivityHandlersShould.cs
@@ -49,5 +49,35 @@ namespace Biotrackr.Activity.Api.UnitTests.EndpointHandlerTests
             // Assert
             result.Result.Should().BeOfType<NotFound>();
         }
+
+        [Fact]
+        public async Task GetAllActivities_ShouldReturnOk_WhenActivitiesAreFound()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var activityDocuments = fixture.CreateMany<ActivityDocument>().ToList();
+            _cosmosRepositoryMock.Setup(x => x.GetAllActivitySummaries()).ReturnsAsync(activityDocuments);
+
+            // Act
+            var result = await ActivityHandlers.GetAllActivities(_cosmosRepositoryMock.Object);
+
+            // Assert
+            result.Should().BeOfType<Ok<List<ActivityDocument>>>();
+            result.Value.Should().BeEquivalentTo(activityDocuments);
+        }
+
+        [Fact]
+        public async Task GetAllActivities_ShouldReturnOk_WhenActivitiesAreNotFound()
+        {
+            // Arrange
+            _cosmosRepositoryMock.Setup(x => x.GetAllActivitySummaries()).ReturnsAsync(new List<ActivityDocument>());
+
+            // Act
+            var result = await ActivityHandlers.GetAllActivities(_cosmosRepositoryMock.Object);
+
+            // Assert
+            result.Should().BeOfType<Ok<List<ActivityDocument>>>();
+            result.Value.Should().BeEmpty();
+        }
     }
 }

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/EndpointHandlers/ActivityHandlers.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/EndpointHandlers/ActivityHandlers.cs
@@ -17,5 +17,11 @@ namespace Biotrackr.Activity.Api.EndpointHandlers
             }
             return TypedResults.Ok(activity);
         }
+
+        public static async Task<Ok<List<ActivityDocument>>> GetAllActivities(ICosmosRepository cosmosRepository)
+        {
+            var activities = await cosmosRepository.GetAllActivitySummaries();
+            return TypedResults.Ok(activities);
+        }
     }
 }

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Extensions/EndpointRouteBuilderExtensions.cs
@@ -10,6 +10,12 @@ namespace Biotrackr.Activity.Api.Extensions
         {
             var activityEndpoints = endpointRouteBuilder.MapGroup("/activity");
 
+            activityEndpoints.MapGet("/", ActivityHandlers.GetAllActivities)
+                .WithName("GetAllActivities")
+                .WithOpenApi()
+                .WithSummary("Get all Activity Summaries")
+                .WithDescription("You can get all activity summaries via this endpoint");
+
             activityEndpoints.MapGet("/{date}", ActivityHandlers.GetActivityByDate)
                 .WithName("GetActivityByDate")
                 .WithOpenApi()

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Repositories/CosmosRepository.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Repositories/CosmosRepository.cs
@@ -50,5 +50,33 @@ namespace Biotrackr.Activity.Api.Repositories
                 throw;
             }
         }
+
+        public async Task<List<ActivityDocument>> GetAllActivitySummaries()
+        {
+            try
+            {
+                QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM c");
+                QueryRequestOptions queryRequestOptions = new QueryRequestOptions
+                {
+                    PartitionKey = new PartitionKey("Activity")
+                };
+
+                var iterator = _container.GetItemQueryIterator<ActivityDocument>(queryDefinition, null, queryRequestOptions);
+                var results = new List<ActivityDocument>();
+
+                while (iterator.HasMoreResults)
+                {
+                    var response = await iterator.ReadNextAsync();
+                    results.AddRange(response);
+                }
+
+                return results;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Exception thrown in {nameof(GetAllActivitySummaries)}: {ex.Message}");
+                throw;
+            }
+        }
     }
 }

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Repositories/Interfaces/ICosmosRepository.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Repositories/Interfaces/ICosmosRepository.cs
@@ -5,5 +5,6 @@ namespace Biotrackr.Activity.Api.Repositories.Interfaces
     public interface ICosmosRepository
     {
         Task<ActivityDocument> GetActivitySummaryByDate(string date);
+        Task<List<ActivityDocument>> GetAllActivitySummaries();
     }
 }


### PR DESCRIPTION
This pull request introduces functionality to retrieve all activity summaries from the database, including the necessary endpoint, handler, repository method, and unit tests. The most important changes are:

### New functionality for retrieving all activity summaries:

* [`src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Repositories/Interfaces/ICosmosRepository.cs`](diffhunk://#diff-c735af1dfdc0434107bb4c5ddf1ec5bb021bfa25c72f050467787a04a8a27cb6R8): Added `GetAllActivitySummaries` method to the `ICosmosRepository` interface.
* [`src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Repositories/CosmosRepository.cs`](diffhunk://#diff-7dfdd61d6492a3ce3eca588bafa67313baaf94179807fd9de74829e12f0135e8R53-R80): Implemented `GetAllActivitySummaries` method to retrieve all activity summaries from the database.
* [`src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/EndpointHandlers/ActivityHandlers.cs`](diffhunk://#diff-503b857548772d46879b506af97db59ce843f7be6952c97c9bc0c06e97fe7362R20-R25): Added `GetAllActivities` handler method to fetch all activity summaries using the repository.
* [`src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Extensions/EndpointRouteBuilderExtensions.cs`](diffhunk://#diff-6c3fb6425e9ef14b4be0de9ce174ad22ec5d9317c44e65a3cc0ee912e468e1c5R13-R18): Registered the new `GetAllActivities` endpoint with appropriate metadata.

### Unit tests for the new functionality:

* [`src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests/EndpointHandlerTests/ActivityHandlersShould.cs`](diffhunk://#diff-7f34fe81a3ed4022c0895e0f39f7fa862d0ec0de3812530c1af292f323b908d5R52-R81): Added tests for the `GetAllActivities` handler to ensure it returns the correct responses based on the presence of activities.
* [`src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests/RepositoryTests/CosmosRepositoryShould.cs`](diffhunk://#diff-cf73e0f872fda903ef60afd687fd55d875cb4427501892e20d4e901a16d9dc64R103-R161): Added tests for the `GetAllActivitySummaries` method to verify it returns the correct results and handles exceptions properly.

/resolves #38 