### PR TITLE
Updating all pipelines to use GITHUB_OUTPUT instead of set-output

### DIFF
--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -19,17 +19,17 @@ env:
 
 jobs:
     env-setup:
-          name: Setup Environment
-          runs-on: ubuntu-latest
-          outputs:
-            dotnet-version: ${{ steps.set-output-defaults.outputs.dotnet-version }}
-            coverage-path: ${{ steps.set-output-defaults.outputs.coverage-path }}
-          steps:
-            - name: set outputs with default values
-              id: set-output-defaults
-              run: |
-                echo "::set-output name=dotnet-version::${{ env.DOTNET_VERSION }}"
-                echo "::set-output name=coverage-path::${{ env.COVERAGE_PATH }}"
+        name: Setup Environment
+        runs-on: ubuntu-latest
+        outputs:
+          dotnet-version: ${{ steps.set-output-defaults.outputs.dotnet-version }}
+          coverage-path: ${{ steps.set-output-defaults.outputs.coverage-path }}
+        steps:
+          - name: set outputs with default values
+            id: set-output-defaults
+            run: |
+              echo "dotnet-version=${{ env.DOTNET_VERSION }}" >> "$GITHUB_OUTPUT"
+              echo "coverage-path=${{ env.COVERAGE_PATH }}" >> "$GITHUB_OUTPUT"
 
     run-unit-tests:
           name: Run Unit Tests
@@ -71,7 +71,7 @@ jobs:
             id: get-acr-server
             run: |
               loginServer=$(az acr list --resource-group ${{ secrets.AZURE_RG_NAME_DEV }} --query "[0].loginServer" -o tsv)
-              echo "::set-output name=loginServer::$loginServer"
+              echo "loginServer=$loginServer" > "$GITHUB_OUTPUT"
 
     lint:
         name: Run Bicep Linter

--- a/.github/workflows/deploy-activity-service.yml
+++ b/.github/workflows/deploy-activity-service.yml
@@ -28,8 +28,8 @@ jobs:
           - name: set outputs with default values
             id: set-output-defaults
             run: |
-              echo "::set-output name=dotnet-version::${{ env.DOTNET_VERSION }}"
-              echo "::set-output name=coverage-path::${{ env.COVERAGE_PATH }}"
+              echo "dotnet-version=${{ env.DOTNET_VERSION }}" >> "$GITHUB_OUTPUT"
+              echo "coverage-path=${{ env.COVERAGE_PATH }}" >> "$GITHUB_OUTPUT"
 
     run-unit-tests:
         name: Run Unit Tests
@@ -71,7 +71,7 @@ jobs:
           id: get-acr-server
           run: |
             loginServer=$(az acr list --resource-group ${{ secrets.AZURE_RG_NAME_DEV }} --query "[0].loginServer" -o tsv)
-            echo "::set-output name=loginServer::$loginServer"
+            echo "loginServer=$loginServer" > "$GITHUB_OUTPUT"
 
     lint:
         name: Run Bicep Linter

--- a/.github/workflows/deploy-auth-service.yml
+++ b/.github/workflows/deploy-auth-service.yml
@@ -19,17 +19,17 @@ env:
 
 jobs:
   env-setup:
-      name: Setup Environment
-      runs-on: ubuntu-latest
-      outputs:
-        dotnet-version: ${{ steps.set-output-defaults.outputs.dotnet-version }}
-        coverage-path: ${{ steps.set-output-defaults.outputs.coverage-path }}
-      steps:
-        - name: set outputs with default values
-          id: set-output-defaults
-          run: |
-            echo "::set-output name=dotnet-version::${{ env.DOTNET_VERSION }}"
-            echo "::set-output name=coverage-path::${{ env.COVERAGE_PATH }}"
+        name: Setup Environment
+        runs-on: ubuntu-latest
+        outputs:
+          dotnet-version: ${{ steps.set-output-defaults.outputs.dotnet-version }}
+          coverage-path: ${{ steps.set-output-defaults.outputs.coverage-path }}
+        steps:
+          - name: set outputs with default values
+            id: set-output-defaults
+            run: |
+              echo "dotnet-version=${{ env.DOTNET_VERSION }}" >> "$GITHUB_OUTPUT"
+              echo "coverage-path=${{ env.COVERAGE_PATH }}" >> "$GITHUB_OUTPUT"
 
   run-unit-tests:
       name: Run Unit Tests
@@ -71,7 +71,7 @@ jobs:
           id: get-acr-server
           run: |
             loginServer=$(az acr list --resource-group ${{ secrets.AZURE_RG_NAME_DEV }} --query "[0].loginServer" -o tsv)
-            echo "::set-output name=loginServer::$loginServer"
+            echo "loginServer=$loginServer" > "$GITHUB_OUTPUT"
 
   lint:
         name: Run Bicep Linter

--- a/.github/workflows/deploy-sleep-api.yml
+++ b/.github/workflows/deploy-sleep-api.yml
@@ -19,17 +19,17 @@ env:
 
 jobs:
     env-setup:
-          name: Setup Environment
-          runs-on: ubuntu-latest
-          outputs:
-            dotnet-version: ${{ steps.set-output-defaults.outputs.dotnet-version }}
-            coverage-path: ${{ steps.set-output-defaults.outputs.coverage-path }}
-          steps:
-            - name: set outputs with default values
-              id: set-output-defaults
-              run: |
-                echo "::set-output name=dotnet-version::${{ env.DOTNET_VERSION }}"
-                echo "::set-output name=coverage-path::${{ env.COVERAGE_PATH }}"
+        name: Setup Environment
+        runs-on: ubuntu-latest
+        outputs:
+          dotnet-version: ${{ steps.set-output-defaults.outputs.dotnet-version }}
+          coverage-path: ${{ steps.set-output-defaults.outputs.coverage-path }}
+        steps:
+          - name: set outputs with default values
+            id: set-output-defaults
+            run: |
+              echo "dotnet-version=${{ env.DOTNET_VERSION }}" >> "$GITHUB_OUTPUT"
+              echo "coverage-path=${{ env.COVERAGE_PATH }}" >> "$GITHUB_OUTPUT"
 
     run-unit-tests:
           name: Run Unit Tests
@@ -71,7 +71,7 @@ jobs:
             id: get-acr-server
             run: |
               loginServer=$(az acr list --resource-group ${{ secrets.AZURE_RG_NAME_DEV }} --query "[0].loginServer" -o tsv)
-              echo "::set-output name=loginServer::$loginServer"
+              echo "loginServer=$loginServer" > "$GITHUB_OUTPUT"
 
     lint:
         name: Run Bicep Linter

--- a/.github/workflows/deploy-sleep-service.yml
+++ b/.github/workflows/deploy-sleep-service.yml
@@ -28,8 +28,8 @@ jobs:
           - name: set outputs with default values
             id: set-output-defaults
             run: |
-              echo "::set-output name=dotnet-version::${{ env.DOTNET_VERSION }}"
-              echo "::set-output name=coverage-path::${{ env.COVERAGE_PATH }}"
+              echo "dotnet-version=${{ env.DOTNET_VERSION }}" >> "$GITHUB_OUTPUT"
+              echo "coverage-path=${{ env.COVERAGE_PATH }}" >> "$GITHUB_OUTPUT"
 
     run-unit-tests:
         name: Run Unit Tests
@@ -71,7 +71,7 @@ jobs:
           id: get-acr-server
           run: |
             loginServer=$(az acr list --resource-group ${{ secrets.AZURE_RG_NAME_DEV }} --query "[0].loginServer" -o tsv)
-            echo "::set-output name=loginServer::$loginServer"
+            echo "loginServer=$loginServer" > "$GITHUB_OUTPUT"
 
     lint:
         name: Run Bicep Linter

--- a/.github/workflows/deploy-weight-api.yml
+++ b/.github/workflows/deploy-weight-api.yml
@@ -19,17 +19,17 @@ env:
 
 jobs:
     env-setup:
-          name: Setup Environment
-          runs-on: ubuntu-latest
-          outputs:
-            dotnet-version: ${{ steps.set-output-defaults.outputs.dotnet-version }}
-            coverage-path: ${{ steps.set-output-defaults.outputs.coverage-path }}
-          steps:
-            - name: set outputs with default values
-              id: set-output-defaults
-              run: |
-                echo "::set-output name=dotnet-version::${{ env.DOTNET_VERSION }}"
-                echo "::set-output name=coverage-path::${{ env.COVERAGE_PATH }}"
+        name: Setup Environment
+        runs-on: ubuntu-latest
+        outputs:
+          dotnet-version: ${{ steps.set-output-defaults.outputs.dotnet-version }}
+          coverage-path: ${{ steps.set-output-defaults.outputs.coverage-path }}
+        steps:
+          - name: set outputs with default values
+            id: set-output-defaults
+            run: |
+              echo "dotnet-version=${{ env.DOTNET_VERSION }}" >> "$GITHUB_OUTPUT"
+              echo "coverage-path=${{ env.COVERAGE_PATH }}" >> "$GITHUB_OUTPUT"
 
     run-unit-tests:
           name: Run Unit Tests
@@ -71,7 +71,7 @@ jobs:
             id: get-acr-server
             run: |
               loginServer=$(az acr list --resource-group ${{ secrets.AZURE_RG_NAME_DEV }} --query "[0].loginServer" -o tsv)
-              echo "::set-output name=loginServer::$loginServer"
+              echo "loginServer=$loginServer" > "$GITHUB_OUTPUT"
 
     lint:
         name: Run Bicep Linter

--- a/.github/workflows/deploy-weight-service.yml
+++ b/.github/workflows/deploy-weight-service.yml
@@ -28,8 +28,8 @@ jobs:
           - name: set outputs with default values
             id: set-output-defaults
             run: |
-              echo "::set-output name=dotnet-version::${{ env.DOTNET_VERSION }}"
-              echo "::set-output name=coverage-path::${{ env.COVERAGE_PATH }}"
+              echo "dotnet-version=${{ env.DOTNET_VERSION }}" >> "$GITHUB_OUTPUT"
+              echo "coverage-path=${{ env.COVERAGE_PATH }}" >> "$GITHUB_OUTPUT"
 
     run-unit-tests:
         name: Run Unit Tests
@@ -71,7 +71,7 @@ jobs:
           id: get-acr-server
           run: |
             loginServer=$(az acr list --resource-group ${{ secrets.AZURE_RG_NAME_DEV }} --query "[0].loginServer" -o tsv)
-            echo "::set-output name=loginServer::$loginServer"
+            echo "loginServer=$loginServer" > "$GITHUB_OUTPUT"
 
     lint:
         name: Run Bicep Linter

--- a/.github/workflows/task-purge-old-images.yml
+++ b/.github/workflows/task-purge-old-images.yml
@@ -29,7 +29,7 @@ jobs:
               id: getacrname
               run: |
                   acrName=$(az acr list --resource-group ${{ secrets.AZURE_RG_NAME_DEV }} --query "[0].name" -o tsv)
-                  echo "::set-output name=acrName::$acrName"    
+                  echo "acrName=$acrName" >> "$GITHUB_OUTPUT"  
 
             - name: Login to Azure Container Registry
               run: az acr login --name ${{ steps.getacrname.outputs.acrName }}

--- a/.github/workflows/template-acr-push-image.yml
+++ b/.github/workflows/template-acr-push-image.yml
@@ -46,13 +46,13 @@ jobs:
           id: getacrname
           run: |
             acrName=$(az acr list --resource-group ${{ secrets.resource-group-name }} --query "[0].name" -o tsv)
-            echo "::set-output name=acrName::$acrName"
+            echo "acrName=$acrName" >> "$GITHUB_OUPUT"
   
         - name: Get ACR Server
           id: getacrserver
           run: |
             loginServer=$(az acr list --resource-group ${{ secrets.resource-group-name }} --query "[0].loginServer" -o tsv)
-            echo "::set-output name=loginServer::$loginServer"
+            echo "loginServer=$loginServer" >> "$GITHUB_OUTPUT"
   
         - name: Login to Azure Container Registry
           run: az acr login --name ${{ steps.getacrname.outputs.acrName }}


### PR DESCRIPTION
This pull request includes updates to multiple GitHub Actions workflows to replace the deprecated `::set-output` command with the new `$GITHUB_OUTPUT` environment file for setting output values. The most important changes are:

Updates to output commands:

* [`.github/workflows/deploy-activity-api.yml`](diffhunk://#diff-678d6cd7866beb45956fda554cce64ac37b5c8e5bc8c29b108095019a5f74a4aL31-R32): Replaced `::set-output` with `$GITHUB_OUTPUT` for `dotnet-version`, `coverage-path`, and `loginServer` outputs. [[1]](diffhunk://#diff-678d6cd7866beb45956fda554cce64ac37b5c8e5bc8c29b108095019a5f74a4aL31-R32) [[2]](diffhunk://#diff-678d6cd7866beb45956fda554cce64ac37b5c8e5bc8c29b108095019a5f74a4aL74-R74)
* [`.github/workflows/deploy-activity-service.yml`](diffhunk://#diff-f765ef9d6ae648d54fb34240b5e2c2492ae487ebf81d6a7f6f9ae024f2214697L31-R32): Replaced `::set-output` with `$GITHUB_OUTPUT` for `dotnet-version`, `coverage-path`, and `loginServer` outputs. [[1]](diffhunk://#diff-f765ef9d6ae648d54fb34240b5e2c2492ae487ebf81d6a7f6f9ae024f2214697L31-R32) [[2]](diffhunk://#diff-f765ef9d6ae648d54fb34240b5e2c2492ae487ebf81d6a7f6f9ae024f2214697L74-R74)
* [`.github/workflows/deploy-auth-service.yml`](diffhunk://#diff-972e9ed1b80fa39d3125023bcec26fe0d5c56149db1a38327e8c8bbe2f872001L31-R32): Replaced `::set-output` with `$GITHUB_OUTPUT` for `dotnet-version`, `coverage-path`, and `loginServer` outputs. [[1]](diffhunk://#diff-972e9ed1b80fa39d3125023bcec26fe0d5c56149db1a38327e8c8bbe2f872001L31-R32) [[2]](diffhunk://#diff-972e9ed1b80fa39d3125023bcec26fe0d5c56149db1a38327e8c8bbe2f872001L74-R74)
* [`.github/workflows/deploy-sleep-api.yml`](diffhunk://#diff-493c09d6d34f086040c3c58c5efa9d7c0e1f440ac7030e1d0697013e22ef453fL31-R32): Replaced `::set-output` with `$GITHUB_OUTPUT` for `dotnet-version`, `coverage-path`, and `loginServer` outputs. [[1]](diffhunk://#diff-493c09d6d34f086040c3c58c5efa9d7c0e1f440ac7030e1d0697013e22ef453fL31-R32) [[2]](diffhunk://#diff-493c09d6d34f086040c3c58c5efa9d7c0e1f440ac7030e1d0697013e22ef453fL74-R74)
* [`.github/workflows/deploy-sleep-service.yml`](diffhunk://#diff-d41b4451a8db11684d3f08152db4701f69560c0e12fb637e8306107f856deef0L31-R32): Replaced `::set-output` with `$GITHUB_OUTPUT` for `dotnet-version`, `coverage-path`, and `loginServer` outputs. [[1]](diffhunk://#diff-d41b4451a8db11684d3f08152db4701f69560c0e12fb637e8306107f856deef0L31-R32) [[2]](diffhunk://#diff-d41b4451a8db11684d3f08152db4701f69560c0e12fb637e8306107f856deef0L74-R74)
* [`.github/workflows/deploy-weight-api.yml`](diffhunk://#diff-52670e8014f533517c2a7ab86bd653e9d7b892fbafb5c302803720a1cd628e5bL31-R32): Replaced `::set-output` with `$GITHUB_OUTPUT` for `dotnet-version`, `coverage-path`, and `loginServer` outputs. [[1]](diffhunk://#diff-52670e8014f533517c2a7ab86bd653e9d7b892fbafb5c302803720a1cd628e5bL31-R32) [[2]](diffhunk://#diff-52670e8014f533517c2a7ab86bd653e9d7b892fbafb5c302803720a1cd628e5bL74-R74)
* [`.github/workflows/deploy-weight-service.yml`](diffhunk://#diff-61fabd8b6ada48fb8f5d08da00a477f3a7e1eced628ec652a260e9b76c331c69L31-R32): Replaced `::set-output` with `$GITHUB_OUTPUT` for `dotnet-version`, `coverage-path`, and `loginServer` outputs. [[1]](diffhunk://#diff-61fabd8b6ada48fb8f5d08da00a477f3a7e1eced628ec652a260e9b76c331c69L31-R32) [[2]](diffhunk://#diff-61fabd8b6ada48fb8f5d08da00a477f3a7e1eced628ec652a260e9b76c331c69L74-R74)
* [`.github/workflows/task-purge-old-images.yml`](diffhunk://#diff-1e572873763e9d83d31ddf2abdd0d45751092411bceb6387f4f9d5ca7152ff10L32-R32): Replaced `::set-output` with `$GITHUB_OUTPUT` for `acrName` output.
* [`.github/workflows/template-acr-push-image.yml`](diffhunk://#diff-dfb46cc1a5ca83293ed3f9858cf4d4b3defd36f8dd5066db78fe726386b4da87L49-R55): Replaced `::set-output` with `$GITHUB_OUTPUT` for `acrName` and `loginServer` outputs.

resolves #41 