### PR TITLE
Upgrading Sleep Svc to .NET 9

### DIFF
--- a/.github/workflows/deploy-activity-service.yml
+++ b/.github/workflows/deploy-activity-service.yml
@@ -43,7 +43,7 @@ jobs:
     build-container-image-dev:
         name: Build and Push Container Image
         needs: run-unit-tests
-        uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@feature/activity-upgrade-to-net9
+        uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
         with:
           working-directory: ./src/Biotrackr.Activity.Svc
           app-name: biotrackr-activity-svc

--- a/.github/workflows/deploy-sleep-service.yml
+++ b/.github/workflows/deploy-sleep-service.yml
@@ -14,7 +14,7 @@ permissions:
     pull-requests: write
 
 env:
-  DOTNET_VERSION: 8.0.x
+  DOTNET_VERSION: 9.0.x
   COVERAGE_PATH: ${{ github.workspace }}/coverage
 
 jobs:

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/Biotrackr.Sleep.Svc.UnitTests.csproj
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/Biotrackr.Sleep.Svc.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,13 +11,19 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="ILogger.Moq" Version="1.1.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="8.4.0" />
+    <PackageReference Include="ILogger.Moq" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.csproj
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Biotrackr.Sleep.Svc-c15c52f5-97d8-45e7-b032-02ccd5fa7063</UserSecretsId>
@@ -9,18 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
   </ItemGroup>
 </Project>

--- a/src/Biotrackr.Sleep.Svc/Dockerfile
+++ b/src/Biotrackr.Sleep.Svc/Dockerfile
@@ -1,13 +1,13 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
 USER $APP_UID
 WORKDIR /app
 
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.csproj", "Biotrackr.Sleep.Svc/"]


### PR DESCRIPTION
This pull request updates the Biotrackr Sleep Service to use .NET 9.0, along with related dependency and configuration updates. The changes ensure compatibility with the latest .NET version and improve the maintainability of the project by upgrading key packages.

### .NET Version Upgrades:
* Updated the target framework to `.NET 9.0` in `Biotrackr.Sleep.Svc` and its unit test project (`src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.csproj`, `src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/Biotrackr.Sleep.Svc.UnitTests.csproj`). [[1]](diffhunk://#diff-933aa655545a6c76b3630ef7527cb7dae7305357c09c063248899c22d6e598aeL4-R24) [[2]](diffhunk://#diff-10a64c8ec453eba097cdbde4381e8b7375625994be68d494bb5d03aad6bc693eL4-R4)
* Updated the `DOTNET_VERSION` environment variable in the `deploy-sleep-service.yml` workflow to `9.0.x` (`.github/workflows/deploy-sleep-service.yml`).
* Updated the base and SDK images in the `Dockerfile` for `Biotrackr.Sleep.Svc` to use `.NET 9.0` (`src/Biotrackr.Sleep.Svc/Dockerfile`).

### Dependency Updates:
* Upgraded multiple NuGet package dependencies in both the main service and unit test projects to their latest compatible versions, including `Azure.Identity`, `FluentAssertions`, `Moq`, and others (`src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.csproj`, `src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/Biotrackr.Sleep.Svc.UnitTests.csproj`). [[1]](diffhunk://#diff-933aa655545a6c76b3630ef7527cb7dae7305357c09c063248899c22d6e598aeL4-R24) [[2]](diffhunk://#diff-10a64c8ec453eba097cdbde4381e8b7375625994be68d494bb5d03aad6bc693eL14-R26)

### Workflow Configuration:
* Updated the `build-container-image-dev` workflow to use the `main` branch for the reusable workflow instead of the `feature/activity-upgrade-to-net9` branch (`.github/workflows/deploy-activity-service.yml`).