### PR TITLE
Upgrading Weight.Svc to .NET 9

### DIFF
--- a/.github/workflows/deploy-weight-service.yml
+++ b/.github/workflows/deploy-weight-service.yml
@@ -14,7 +14,7 @@ permissions:
     pull-requests: write
 
 env:
-  DOTNET_VERSION: 8.0.x
+  DOTNET_VERSION: 9.0.x
   COVERAGE_PATH: ${{ github.workspace }}/coverage
 
 jobs:

--- a/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.UnitTests/Biotrackr.Weight.Svc.UnitTests.csproj
+++ b/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.UnitTests/Biotrackr.Weight.Svc.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,13 +11,19 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="ILogger.Moq" Version="1.1.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="8.4.0" />
+    <PackageReference Include="ILogger.Moq" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.csproj
+++ b/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Biotrackr.Weight.Svc-962f5121-cddd-49ae-afbf-540af42178ae</UserSecretsId>
@@ -9,18 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
   </ItemGroup>
 </Project>

--- a/src/Biotrackr.Weight.Svc/Dockerfile
+++ b/src/Biotrackr.Weight.Svc/Dockerfile
@@ -1,13 +1,13 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
 USER $APP_UID
 WORKDIR /app
 
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.csproj", "Biotrackr.Weight.Svc/"]


### PR DESCRIPTION
This pull request upgrades the Biotrackr.Weight.Svc project and its dependencies to use .NET 9.0, updates package versions for both the main service and its unit tests, and adjusts the Dockerfile to reflect the new runtime and SDK versions.

### .NET Version Upgrade:
* Updated the `.NET` version from 8.0 to 9.0 in the `DOTNET_VERSION` environment variable in `.github/workflows/deploy-weight-service.yml`.
* Changed the `TargetFramework` to `net9.0` in both `Biotrackr.Weight.Svc.csproj` and `Biotrackr.Weight.Svc.UnitTests.csproj`. [[1]](diffhunk://#diff-db6a9938135b04a300f6b7a18105cb75c340f768440390fa1d68e7307d6f9ef5L4-R4) [[2]](diffhunk://#diff-67e7eb4560c3e211c343641a39249f642b99c83b03dee00797cab15ff697aa75L4-R24)

### Package Updates:
* Upgraded multiple NuGet package dependencies in `Biotrackr.Weight.Svc.csproj`, such as `Azure.Identity` (1.13.1 → 1.14.1) and `Microsoft.Extensions.Hosting` (9.0.0 → 9.0.6).
* Updated testing-related packages in `Biotrackr.Weight.Svc.UnitTests.csproj`, including `FluentAssertions` (7.0.0 → 8.4.0) and `xunit` (2.5.3 → 2.9.3). Added `PrivateAssets` and `IncludeAssets` metadata for some packages.

### Dockerfile Adjustments:
* Updated the base image and SDK image in the `Dockerfile` to use .NET 9.0 runtime and SDK, respectively.