### PR TITLE
Upgrading Sleep.Api to .NET 9

### DIFF
--- a/.github/workflows/deploy-sleep-api.yml
+++ b/.github/workflows/deploy-sleep-api.yml
@@ -14,7 +14,7 @@ permissions:
     pull-requests: write
 
 env:
-  DOTNET_VERSION: 8.0.x
+  DOTNET_VERSION: 9.0.x
   COVERAGE_PATH: ${{ github.workspace }}/coverage
 
 jobs:

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/Biotrackr.Sleep.Api.UnitTests.csproj
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/Biotrackr.Sleep.Api.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,13 +11,19 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="ILogger.Moq" Version="1.1.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="8.4.0" />
+    <PackageReference Include="ILogger.Moq" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.csproj
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Biotrackr.Sleep.Api/Dockerfile
+++ b/src/Biotrackr.Sleep.Api/Dockerfile
@@ -1,14 +1,14 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.csproj", "Biotrackr.Sleep.Api/"]


### PR DESCRIPTION
This pull request updates the Biotrackr Sleep API project to target .NET 9.0 and upgrades associated dependencies to their latest compatible versions. The changes also include updates to the Dockerfile to use .NET 9.0 images and refine package references for better compatibility and functionality.

### Framework and environment updates:
* Updated the `.github/workflows/deploy-sleep-api.yml` file to use `DOTNET_VERSION: 9.0.x` for deployment workflows.
* Changed the `TargetFramework` in `Biotrackr.Sleep.Api.csproj` and `Biotrackr.Sleep.Api.UnitTests.csproj` from `net8.0` to `net9.0`. [[1]](diffhunk://#diff-2d313d7b7ffeb389d4cc41df70c7505bd23e34764d04757218089d2ac9c693a2L4-R18) [[2]](diffhunk://#diff-6889c95a1ad46765058ef414ab90667def7766c4ceed957c7097c940b3ceea70L4-R4)
* Updated the `Dockerfile` to use .NET 9.0 images (`aspnet:9.0` and `sdk:9.0`) for base and build stages.

### Dependency updates:
* Upgraded test-related dependencies in `Biotrackr.Sleep.Api.UnitTests.csproj` (e.g., `coverlet.collector`, `FluentAssertions`, `Moq`, `xunit`) to newer versions, adding `PrivateAssets` and `IncludeAssets` attributes for better dependency management.
* Updated runtime dependencies in `Biotrackr.Sleep.Api.csproj` (e.g., `Azure.Identity`, `Microsoft.AspNetCore.OpenApi`, `Microsoft.Azure.Cosmos`, `Swashbuckle.AspNetCore`) to their latest versions.