### PR TITLE
Updating Weight.Api to .NET 9

### DIFF
--- a/.github/workflows/deploy-weight-api.yml
+++ b/.github/workflows/deploy-weight-api.yml
@@ -14,7 +14,7 @@ permissions:
     pull-requests: write
 
 env:
-  DOTNET_VERSION: 8.0.x
+  DOTNET_VERSION: 9.0.x
   COVERAGE_PATH: ${{ github.workspace }}/coverage
 
 jobs:

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/Biotrackr.Weight.Api.UnitTests.csproj
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/Biotrackr.Weight.Api.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,13 +11,19 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="ILogger.Moq" Version="1.1.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="8.4.0" />
+    <PackageReference Include="ILogger.Moq" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Biotrackr.Weight.Api.csproj
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Biotrackr.Weight.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>6364e6cc-abc2-4420-8db5-9755a191d3c9</UserSecretsId>
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Biotrackr.Weight.Api/Dockerfile
+++ b/src/Biotrackr.Weight.Api/Dockerfile
@@ -1,7 +1,7 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
@@ -9,7 +9,7 @@ EXPOSE 8081
 
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Biotrackr.Weight.Api/Biotrackr.Weight.Api.csproj", "Biotrackr.Weight.Api/"]


### PR DESCRIPTION
This pull request upgrades the project from .NET 8.0 to .NET 9.0, updates associated dependencies, and adjusts the Docker configuration accordingly. These changes ensure compatibility with the latest framework version and improve dependency management.

### Framework Upgrade

* Updated `.NET` version from `8.0` to `9.0` across the project, including the `DOTNET_VERSION` environment variable in `.github/workflows/deploy-weight-api.yml` [[1]](diffhunk://#diff-52670e8014f533517c2a7ab86bd653e9d7b892fbafb5c302803720a1cd628e5bL17-R17) the `TargetFramework` in `Biotrackr.Weight.Api.csproj` [[2]](diffhunk://#diff-a1fbc1ffe8be08d39a0b4d6641f40d4a27605bff96c309ffe0b32e5b6f3bce6aL4-R19) and `Biotrackr.Weight.Api.UnitTests.csproj` [[3]](diffhunk://#diff-8e2d37ee5b07ea37fa92baa1acd8c7e9512c9f2fbfbbeb21ab825fe8cdf18bd9L4-R4).

### Dependency Updates

* Upgraded various NuGet package dependencies in `Biotrackr.Weight.Api.csproj`, including `Azure.Identity`, `Microsoft.AspNetCore.OpenApi`, `Microsoft.Azure.Cosmos`, and others, to ensure compatibility with .NET 9.0.
* Updated test-related dependencies in `Biotrackr.Weight.Api.UnitTests.csproj`, such as `coverlet.collector`, `FluentAssertions`, and `xunit`, to newer versions, adding `PrivateAssets` and `IncludeAssets` attributes where necessary.

### Docker Configuration

* Updated the base images in the `Dockerfile` to use `.NET 9.0` for both the runtime (`aspnet`) and the SDK (`sdk`) to align with the framework upgrade.