### PR TITLE
Improving test coverage in Auth.Svc

### DIFF
--- a/.github/workflows/deploy-auth-service.yml
+++ b/.github/workflows/deploy-auth-service.yml
@@ -5,8 +5,9 @@ on:
         branches:
             - main
         paths:
-            - 'infra/apps/auth-service/*'
-            - 'src/Biotrackr.Auth.Svc/*'
+            - 'infra/apps/auth-service/**'
+            - 'src/Biotrackr.Auth.Svc/**'
+            - '.github/workflows/deploy-auth-service.yml'
 
 permissions:
     contents: read

--- a/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.UnitTests/Biotrackr.Auth.Svc.UnitTests.csproj
+++ b/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.UnitTests/Biotrackr.Auth.Svc.UnitTests.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.4.0" />
+    <PackageReference Include="ILogger.Moq" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.UnitTests/ModelTests/RefreshTokenResponseShould.cs
+++ b/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.UnitTests/ModelTests/RefreshTokenResponseShould.cs
@@ -1,0 +1,37 @@
+﻿using Biotrackr.Auth.Svc.Models;
+using FluentAssertions;
+using System.Text.Json;
+
+namespace Biotrackr.Auth.Svc.UnitTests.ModelTests
+{
+    public class RefreshTokenResponseShould
+    {
+        [Fact]
+        public void DeserializeCorrectlyFromFitbitApiResponse()
+        {
+            // ARRANGE
+            var jsonResponse = """
+            {
+                "access_token": "test_access_token",
+                "expires_in": 3600,
+                "refresh_token": "test_refresh_token",
+                "scope": "activity",
+                "token_type": "Bearer",
+                "user_id": "123456"
+            }
+            """;
+
+            // ACT
+            var result = JsonSerializer.Deserialize<RefreshTokenResponse>(jsonResponse);
+
+            // ASSERT
+            result.Should().NotBeNull();
+            result.AccessToken.Should().Be("test_access_token");
+            result.ExpiresIn.Should().Be(3600);
+            result.RefreshToken.Should().Be("test_refresh_token");
+            result.Scope.Should().Be("activity");
+            result.TokenType.Should().Be("Bearer");
+            result.UserType.Should().Be("123456");
+        }
+    }
+}

--- a/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.UnitTests/ServiceTests/RefreshTokenServiceShould.cs
+++ b/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.UnitTests/ServiceTests/RefreshTokenServiceShould.cs
@@ -21,6 +21,7 @@ namespace Biotrackr.Auth.Svc.UnitTests.ServiceTests
 
         private const string RefreshTokenSecretName = "RefreshToken";
         private const string FitbitCredentialsSecretName = "FitbitCredentials";
+        private const string AccessTokenSecretName = "AccessToken";
 
         public RefreshTokenServiceShould()
         {
@@ -33,7 +34,7 @@ namespace Biotrackr.Auth.Svc.UnitTests.ServiceTests
         }
 
         [Fact]
-        public async Task RefreshTokensWhenRefreshTokensIsCalled()
+        public async Task RefreshTokensSuccessfullyWhenValidSecretsAndHttpResponseProvided()
         {
             // ARRANGE
             var fixture = new Fixture();
@@ -50,10 +51,51 @@ namespace Biotrackr.Auth.Svc.UnitTests.ServiceTests
             // ASSERT
             result.AccessToken.Should().Be(mockRefreshTokenResponse.AccessToken);
             result.RefreshToken.Should().Be(mockRefreshTokenResponse.RefreshToken);
+            result.ExpiresIn.Should().Be(mockRefreshTokenResponse.ExpiresIn);
+            result.Scope.Should().Be(mockRefreshTokenResponse.Scope);
+            result.TokenType.Should().Be(mockRefreshTokenResponse.TokenType);
+            result.UserType.Should().Be(mockRefreshTokenResponse.UserType);
         }
 
         [Fact]
-        public async Task SaveRefreshTokensWhenSaveTokensIsCalled()
+        public async Task MakeCorrectHttpRequestWhenRefreshTokensIsCalled()
+        {
+            // ARRANGE
+            var fixture = new Fixture();
+            var mockRefreshTokenResponse = fixture.Create<RefreshTokenResponse>();
+            var mockFitbitRefreshToken = "testFitbitRefreshToken";
+            var mockFitbitCredential = "testFitbitCredential";
+            HttpRequestMessage? capturedRequest = null;
+
+            SetupSecretClientMocks(mockFitbitRefreshToken, mockFitbitCredential);
+
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((request, _) => capturedRequest = request)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(JsonSerializer.Serialize(mockRefreshTokenResponse))
+                });
+
+            // ACT
+            await _sut.RefreshTokens();
+
+            // ASSERT
+            capturedRequest.Should().NotBeNull();
+            capturedRequest!.Method.Should().Be(HttpMethod.Post);
+            capturedRequest.RequestUri.Should().NotBeNull();
+            capturedRequest.RequestUri!.AbsoluteUri.Should().Contain("https://api.fitbit.com/oauth2/token");
+            capturedRequest.RequestUri.Query.Should().Contain($"grant_type=refresh_token&refresh_token={mockFitbitRefreshToken}");
+            capturedRequest.Headers.Authorization.Should().NotBeNull();
+            capturedRequest.Headers.Authorization!.Scheme.Should().Be("Basic");
+            capturedRequest.Headers.Authorization.Parameter.Should().Be(mockFitbitCredential);
+            capturedRequest.Content.Should().NotBeNull();
+            capturedRequest.Content!.Headers.ContentType!.MediaType.Should().Be("application/x-www-form-urlencoded");
+        }
+
+        [Fact]
+        public async Task SaveBothTokensWhenSaveTokensIsCalled()
         {
             // ARRANGE
             var fixture = new Fixture();
@@ -63,40 +105,175 @@ namespace Biotrackr.Auth.Svc.UnitTests.ServiceTests
                 .ReturnsAsync(new Mock<Response<KeyVaultSecret>>().Object);
 
             // ACT
-            Func<Task> saveTokenAction = async () => await _sut.SaveTokens(mockTokenResponse);
+            await _sut.SaveTokens(mockTokenResponse);
 
             // ASSERT
-            await saveTokenAction.Should().NotThrowAsync<Exception>();
-            _mockSecretClient.Verify(x => x.SetSecretAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            _mockSecretClient.Verify(x => x.SetSecretAsync(RefreshTokenSecretName, mockTokenResponse.RefreshToken, It.IsAny<CancellationToken>()), Times.Once);
+            _mockSecretClient.Verify(x => x.SetSecretAsync(AccessTokenSecretName, mockTokenResponse.AccessToken, It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
-        public async Task CatchAndThrowExceptionWhenGetSecretFailsInRefreshTokens()
+        public async Task LogInformationMessagesWhenSaveTokensIsSuccessful()
         {
             // ARRANGE
-            _mockSecretClient.Setup(x => x.GetSecretAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
+            var fixture = new Fixture();
+            var mockTokenResponse = fixture.Create<RefreshTokenResponse>();
+
+            _mockSecretClient.Setup(x => x.SetSecretAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Mock<Response<KeyVaultSecret>>().Object);
+
+            // ACT
+            await _sut.SaveTokens(mockTokenResponse);
+
+            // ASSERT
+            _mockLogger.VerifyLog(l => l.LogInformation("Attempting to save tokens to secret store"), Times.Once);
+            _mockLogger.VerifyLog(l => l.LogInformation("Tokens saved to secret store"), Times.Once);
+        }
+
+        [Fact]
+        public async Task LogInformationWhenHttpRequestIsSuccessful()
+        {
+            // ARRANGE
+            var fixture = new Fixture();
+            var mockRefreshTokenResponse = fixture.Create<RefreshTokenResponse>();
+            var mockFitbitRefreshToken = "testFitbitRefreshToken";
+            var mockFitbitCredential = "testFitbitCredential";
+
+            SetupSecretClientMocks(mockFitbitRefreshToken, mockFitbitCredential);
+            SetupHttpMessageHandlerMock(mockRefreshTokenResponse);
+
+            // ACT
+            await _sut.RefreshTokens();
+
+            // ASSERT
+            _mockLogger.VerifyLog(l => l.LogInformation("Fitbit API called successfully. Parsing response"), Times.Once);
+        }
+
+        [Fact]
+        public async Task ThrowExceptionAndLogErrorWhenRefreshTokenSecretNotFound()
+        {
+            // ARRANGE
+            _mockSecretClient.Setup(x => x.GetSecretAsync(RefreshTokenSecretName, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Response.FromValue<KeyVaultSecret>(null!, new Mock<Response>().Object));
 
             // ACT
             Func<Task> refreshTokenAction = async () => await _sut.RefreshTokens();
 
             // ASSERT
-            await refreshTokenAction.Should().ThrowAsync<Exception>();
+            await refreshTokenAction.Should().ThrowAsync<NullReferenceException>();
+            _mockLogger.VerifyLog(l => l.LogError(It.IsAny<Exception>(), $"Exception thrown in {nameof(RefreshTokenService.RefreshTokens)}"), Times.Once);
         }
 
         [Fact]
-        public async Task CatchAndThrowExceptionWhenSaveSecretFailsInSaveTokens()
+        public async Task ThrowExceptionAndLogErrorWhenFitbitCredentialsSecretNotFound()
+        {
+            // ARRANGE
+            var mockFitbitRefreshToken = "testFitbitRefreshToken";
+
+            _mockSecretClient.Setup(x => x.GetSecretAsync(RefreshTokenSecretName, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Response.FromValue(new KeyVaultSecret(RefreshTokenSecretName, mockFitbitRefreshToken), new Mock<Response>().Object));
+            _mockSecretClient.Setup(x => x.GetSecretAsync(FitbitCredentialsSecretName, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Response.FromValue<KeyVaultSecret>(null!, new Mock<Response>().Object));
+
+            // ACT
+            Func<Task> refreshTokenAction = async () => await _sut.RefreshTokens();
+
+            // ASSERT
+            await refreshTokenAction.Should().ThrowAsync<NullReferenceException>();
+            _mockLogger.VerifyLog(l => l.LogError(It.IsAny<Exception>(), $"Exception thrown in {nameof(RefreshTokenService.RefreshTokens)}"), Times.Once);
+        }
+
+        [Fact]
+        public async Task ThrowHttpRequestExceptionAndLogErrorWhenHttpRequestFails()
+        {
+            // ARRANGE
+            var mockFitbitRefreshToken = "testFitbitRefreshToken";
+            var mockFitbitCredential = "testFitbitCredential";
+
+            SetupSecretClientMocks(mockFitbitRefreshToken, mockFitbitCredential);
+
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Unauthorized,
+                    Content = new StringContent("Unauthorized")
+                });
+
+            // ACT
+            Func<Task> refreshTokenAction = async () => await _sut.RefreshTokens();
+
+            // ASSERT
+            await refreshTokenAction.Should().ThrowAsync<HttpRequestException>();
+            _mockLogger.VerifyLog(l => l.LogError(It.IsAny<Exception>(), $"Exception thrown in {nameof(RefreshTokenService.RefreshTokens)}"), Times.Once);
+        }
+
+        [Fact]
+        public async Task ThrowExceptionAndLogErrorWhenSaveTokensFails()
         {
             // ARRANGE
             var fixture = new Fixture();
             var mockTokenResponse = fixture.Create<RefreshTokenResponse>();
+            var testException = new Exception("Key Vault error");
+
             _mockSecretClient.Setup(x => x.SetSecretAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new Exception());
+                .ThrowsAsync(testException);
 
             // ACT
-            Func<Task> refreshTokenAction = async () => await _sut.SaveTokens(mockTokenResponse);
+            Func<Task> saveTokenAction = async () => await _sut.SaveTokens(mockTokenResponse);
 
             // ASSERT
-            await refreshTokenAction.Should().ThrowAsync<Exception>();
+            await saveTokenAction.Should().ThrowAsync<Exception>().WithMessage("Key Vault error");
+            _mockLogger.VerifyLog(l => l.LogError(testException, $"Exception thrown in {nameof(RefreshTokenService.SaveTokens)}"), Times.Once);
+        }
+
+        [Fact]
+        public async Task ThrowJsonExceptionWhenInvalidJsonResponseReceived()
+        {
+            // ARRANGE
+            var mockFitbitRefreshToken = "testFitbitRefreshToken";
+            var mockFitbitCredential = "testFitbitCredential";
+
+            SetupSecretClientMocks(mockFitbitRefreshToken, mockFitbitCredential);
+
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{ invalid json }")
+                });
+
+            // ACT
+            Func<Task> refreshTokenAction = async () => await _sut.RefreshTokens();
+
+            // ASSERT
+            await refreshTokenAction.Should().ThrowAsync<JsonException>();
+            _mockLogger.VerifyLog(l => l.LogError(It.IsAny<Exception>(), $"Exception thrown in {nameof(RefreshTokenService.RefreshTokens)}"), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleEmptyResponseFromFitbitApi()
+        {
+            // ARRANGE
+            var mockFitbitRefreshToken = "testFitbitRefreshToken";
+            var mockFitbitCredential = "testFitbitCredential";
+
+            SetupSecretClientMocks(mockFitbitRefreshToken, mockFitbitCredential);
+
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("")
+                });
+
+            // ACT
+            Func<Task> refreshTokenAction = async () => await _sut.RefreshTokens();
+
+            // ASSERT
+            await refreshTokenAction.Should().ThrowAsync<JsonException>();
         }
 
         private void SetupSecretClientMocks(string mockFitbitRefreshToken, string mockFitbitCredential)

--- a/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.UnitTests/WorkerTests/AuthWorkerShould.cs
+++ b/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.UnitTests/WorkerTests/AuthWorkerShould.cs
@@ -1,0 +1,159 @@
+﻿using AutoFixture;
+using Biotrackr.Auth.Svc.Models;
+using Biotrackr.Auth.Svc.Services.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Biotrackr.Auth.Svc.UnitTests.WorkerTests
+{
+    public class AuthWorkerShould
+    {
+        private readonly Mock<IRefreshTokenService> _mockRefreshTokenService;
+        private readonly Mock<ILogger<AuthWorker>> _mockLogger;
+        private readonly Mock<IHostApplicationLifetime> _mockAppLifeTime;
+        private readonly AuthWorker _sut;
+
+        public AuthWorkerShould()
+        {
+            _mockRefreshTokenService = new Mock<IRefreshTokenService>();
+            _mockLogger = new Mock<ILogger<AuthWorker>>();
+            _mockAppLifeTime = new Mock<IHostApplicationLifetime>();
+            _sut = new AuthWorker(_mockRefreshTokenService.Object, _mockLogger.Object, _mockAppLifeTime.Object);
+        }
+
+        [Fact]
+        public async Task RefreshAndSaveTokensSuccessfullyWhenExecuteAsyncIsCalled()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var mockRefreshTokenResponse = fixture.Create<RefreshTokenResponse>();
+            var completionSource = new TaskCompletionSource<bool>();
+
+            _mockRefreshTokenService.Setup(s => s.RefreshTokens())
+                .ReturnsAsync(mockRefreshTokenResponse);
+
+            _mockRefreshTokenService.Setup(s => s.SaveTokens(mockRefreshTokenResponse))
+                .Returns(Task.CompletedTask);
+
+            _mockAppLifeTime.Setup(l => l.StopApplication())
+                .Callback(() => completionSource.SetResult(true));
+
+            // Act
+            await _sut.StartAsync(CancellationToken.None);
+
+            await completionSource.Task.WaitAsync(TimeSpan.FromSeconds(5)); // Wait for the task to complete
+
+            await _sut.StopAsync(CancellationToken.None);
+
+            // Assert
+            _mockRefreshTokenService.Verify(s => s.RefreshTokens(), Times.Once);
+            _mockRefreshTokenService.Verify(s => s.SaveTokens(mockRefreshTokenResponse), Times.Once);
+            _mockAppLifeTime.Verify(l => l.StopApplication(), Times.Once);
+        }
+
+        [Fact]
+        public async Task LogErrorAndStopApplicationWhenRefreshTokensThrowsException()
+        {
+            // Arrange
+            var completionSource = new TaskCompletionSource<bool>();
+            var testException = new Exception("Test exception");
+
+            _mockRefreshTokenService.Setup(s => s.RefreshTokens())
+                .ThrowsAsync(testException);
+
+            _mockAppLifeTime.Setup(l => l.StopApplication())
+                .Callback(() => completionSource.SetResult(true));
+
+            // Act
+            await _sut.StartAsync(CancellationToken.None);
+            await completionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await _sut.StopAsync(CancellationToken.None);
+
+            // Assert
+            _mockLogger.VerifyLog(logger => logger.LogError($"Exception thrown: {testException.Message}"), Times.Once);
+            _mockAppLifeTime.Verify(l => l.StopApplication(), Times.Once);
+        }
+
+        [Fact]
+        public async Task LogErrorAndStopApplicationWhenSaveTokensThrowsException()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var mockRefreshTokenResponse = fixture.Create<RefreshTokenResponse>();
+            var completionSource = new TaskCompletionSource<bool>();
+            var testException = new Exception("Test exception");
+
+            _mockRefreshTokenService.Setup(s => s.RefreshTokens())
+                .ReturnsAsync(mockRefreshTokenResponse);
+            _mockRefreshTokenService.Setup(s => s.SaveTokens(mockRefreshTokenResponse))
+                .ThrowsAsync(testException);
+
+            _mockAppLifeTime.Setup(l => l.StopApplication())
+                .Callback(() => completionSource.SetResult(true));
+
+            // Act
+            await _sut.StartAsync(CancellationToken.None);
+            await completionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await _sut.StopAsync(CancellationToken.None);
+
+            // Assert
+            _mockLogger.VerifyLog(l => l.LogError($"Exception thrown: {testException.Message}"), Times.Once);
+            _mockAppLifeTime.Verify(l => l.StopApplication(), Times.Once);
+        }
+
+        [Fact]
+        public async Task LogInformationMessagesInCorrectOrder()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var mockRefreshTokenResponse = fixture.Create<RefreshTokenResponse>();
+            var completionSource = new TaskCompletionSource<bool>();
+
+            _mockRefreshTokenService.Setup(s => s.RefreshTokens())
+                .ReturnsAsync(mockRefreshTokenResponse);
+            _mockRefreshTokenService.Setup(s => s.SaveTokens(mockRefreshTokenResponse))
+                .Returns(Task.CompletedTask);
+            _mockAppLifeTime.Setup(l => l.StopApplication())
+                .Callback(() => completionSource.SetResult(true));
+
+            // Act
+            await _sut.StartAsync(CancellationToken.None);
+            await completionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await _sut.StopAsync(CancellationToken.None);
+
+            // Assert
+            _mockLogger.VerifyLog(l => l.LogInformation(It.Is<string>(s => s.Contains("Attempting to refresh FitBit Tokens"))), Times.Once);
+            _mockLogger.VerifyLog(l => l.LogInformation(It.Is<string>(s => s.Contains("FitBit Tokens refresh successful"))), Times.Once);
+            _mockLogger.VerifyLog(l => l.LogInformation(It.Is<string>(s => s.Contains("FitBit Tokens saved successfully"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleCancellationTokenProperly()
+        {
+            // Arrange
+            using var cts = new CancellationTokenSource();
+            var completionSource = new TaskCompletionSource<bool>();
+
+            _mockRefreshTokenService.Setup(s => s.RefreshTokens())
+                .Returns(async () =>
+                {
+                    await Task.Delay(100, cts.Token); // This will throw when cancelled
+                    return new RefreshTokenResponse();
+                });
+
+            _mockAppLifeTime.Setup(l => l.StopApplication())
+                .Callback(() => completionSource.SetResult(true));
+
+            // Act
+            await _sut.StartAsync(cts.Token);
+            cts.Cancel(); // Cancel the operation
+
+            await completionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await _sut.StopAsync(CancellationToken.None);
+
+            // Assert
+            _mockAppLifeTime.Verify(l => l.StopApplication(), Times.Once);
+        }
+    }
+}

--- a/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc/AuthWorker.cs
+++ b/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc/AuthWorker.cs
@@ -1,7 +1,5 @@
 using Biotrackr.Auth.Svc.Models;
 using Biotrackr.Auth.Svc.Services.Interfaces;
-using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.DataContracts;
 
 namespace Biotrackr.Auth.Svc
 {

--- a/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc/Models/RefreshTokenResponse.cs
+++ b/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc/Models/RefreshTokenResponse.cs
@@ -1,9 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Biotrackr.Auth.Svc.Models
 {
-    [ExcludeFromCodeCoverage]
     public class RefreshTokenResponse
     {
         [JsonPropertyName("access_token")]


### PR DESCRIPTION
This pull request introduces significant enhancements to the unit tests and logging for the `Biotrackr.Auth.Svc` project, focusing on improving test coverage, error handling, and logging. The changes include adding new test cases, refining existing ones, and introducing a new test suite for the `AuthWorker` class. Additionally, minor refactoring and dependency updates were made to improve maintainability.

### Unit Test Enhancements:

* Added a new test suite `AuthWorkerShould` to validate the behavior of the `AuthWorker` class, including scenarios for successful token refresh, error handling, and proper cancellation token handling.
* Improved the `RefreshTokenServiceShould` test suite by adding tests for HTTP request validation, logging, and error scenarios such as missing secrets, invalid JSON responses, and failed secret saves. [[1]](diffhunk://#diff-180168c953ef93b84eb22c31ddb328d1010c278016d741bd1cd04796636921eeR24) [[2]](diffhunk://#diff-180168c953ef93b84eb22c31ddb328d1010c278016d741bd1cd04796636921eeL36-R37) [[3]](diffhunk://#diff-180168c953ef93b84eb22c31ddb328d1010c278016d741bd1cd04796636921eeR54-R98) [[4]](diffhunk://#diff-180168c953ef93b84eb22c31ddb328d1010c278016d741bd1cd04796636921eeL66-R276)
* Added a new test `RefreshTokenResponseShould` to verify the deserialization of `RefreshTokenResponse` from a Fitbit API response.

### Logging Improvements:

* Enhanced logging in `RefreshTokenService` to provide detailed information and error messages for operations like token refresh, secret saves, and HTTP requests.
* Added logging in `AuthWorker` to track the execution flow and handle exceptions gracefully during token refresh and save operations.

### Dependency Updates:

* Added the `ILogger.Moq` package to the test project to enable mocking of logging functionality in unit tests.

### Code Refactoring:

* Removed unused `Microsoft.ApplicationInsights` dependencies from `AuthWorker.cs` to clean up the code.
* Removed the `[ExcludeFromCodeCoverage]` attribute from `RefreshTokenResponse` to include it in code coverage metrics.