### PR TITLE
Adding support for OFFSET/LIMIT pagination in Activity.Api

### DIFF
--- a/infra/apps/activity-api/main.bicep
+++ b/infra/apps/activity-api/main.bicep
@@ -109,7 +109,31 @@ resource activityApiGetAll 'Microsoft.ApiManagement/service/apis/operations@2024
     displayName: 'GetAllActivities'
     method: 'GET'
     urlTemplate: '/'
-    description: 'Get all Activity Summaries' 
+    description: 'Get all Activity Summaries'
+    request: {
+      queryParameters: [
+        {
+          name: 'pageNumber'
+          description: 'The page number to retrieve (default: 1)'
+          type: 'integer'
+          required: false
+          defaultValue: '1'
+          values: [
+            
+          ]
+        }
+        {
+          name: 'pageSize'
+          description: 'The number of items per page (default: 20, max: 100)'
+          type: 'integer'
+          required: false
+          defaultValue: '20'
+          values: [
+            
+          ]
+        }
+      ]
+    } 
   }
 }
 

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests/Biotrackr.Activity.Api.UnitTests.csproj
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests/Biotrackr.Activity.Api.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests/ModelTests/PaginationRequestShould.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests/ModelTests/PaginationRequestShould.cs
@@ -1,0 +1,65 @@
+﻿using Biotrackr.Activity.Api.Models;
+using FluentAssertions;
+
+namespace Biotrackr.Activity.Api.UnitTests.ModelTests
+{
+    public class PaginationRequestShould
+    {
+        [Fact]
+        public void SetDefaultValues_WhenCreated()
+        {
+            // Act
+            var request = new PaginationRequest();
+
+            // Assert
+            request.PageNumber.Should().Be(1);
+            request.PageSize.Should().Be(20);
+            request.Skip.Should().Be(0);
+        }
+
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(-1, 1)]
+        [InlineData(-10, 1)]
+        public void SetPageNumberToOne_WhenInvalidValueProvided(int invalidPageNumber, int expectedPageNumber)
+        {
+            // Act
+            var request = new PaginationRequest { PageNumber = invalidPageNumber };
+
+            // Assert
+            request.PageNumber.Should().Be(expectedPageNumber);
+        }
+
+        [Theory]
+        [InlineData(0, 20)]
+        [InlineData(-1, 20)]
+        [InlineData(101, 100)]
+        [InlineData(200, 100)]
+        public void ClampPageSize_WhenInvalidValueProvided(int invalidPageSize, int expectedPageSize)
+        {
+            // Act
+            var request = new PaginationRequest { PageSize = invalidPageSize };
+
+            // Assert
+            request.PageSize.Should().Be(expectedPageSize);
+        }
+
+        [Theory]
+        [InlineData(1, 20, 0)]
+        [InlineData(2, 20, 20)]
+        [InlineData(3, 15, 30)]
+        [InlineData(5, 10, 40)]
+        public void CalculateCorrectSkipValue(int pageNumber, int pageSize, int expectedSkip)
+        {
+            // Act
+            var request = new PaginationRequest
+            {
+                PageNumber = pageNumber,
+                PageSize = pageSize
+            };
+
+            // Assert
+            request.Skip.Should().Be(expectedSkip);
+        }
+    }
+}

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests/ModelTests/PaginationResponseShould.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests/ModelTests/PaginationResponseShould.cs
@@ -1,0 +1,63 @@
+﻿using Biotrackr.Activity.Api.Models;
+using FluentAssertions;
+
+namespace Biotrackr.Activity.Api.UnitTests.ModelTests
+{
+    public class PaginationResponseShould
+    {
+        [Theory]
+        [InlineData(50, 20, 3)]  // 50 total, 20 per page = 3 pages
+        [InlineData(100, 20, 5)] // 100 total, 20 per page = 5 pages
+        [InlineData(19, 20, 1)]  // 19 total, 20 per page = 1 page
+        [InlineData(0, 20, 0)]   // 0 total = 0 pages
+        public void CalculateCorrectTotalPages(int totalCount, int pageSize, int expectedTotalPages)
+        {
+            // Act
+            var response = new PaginationResponse<string>
+            {
+                TotalCount = totalCount,
+                PageSize = pageSize
+            };
+
+            // Assert
+            response.TotalPages.Should().Be(expectedTotalPages);
+        }
+
+        [Theory]
+        [InlineData(1, 20, 100, false)] // First page
+        [InlineData(2, 20, 100, true)]  // Middle page
+        [InlineData(5, 20, 100, true)]  // Last page
+        public void DetermineHasPreviousPageCorrectly(int pageNumber, int pageSize, int totalCount, bool expectedHasPrevious)
+        {
+            // Act
+            var response = new PaginationResponse<string>
+            {
+                PageNumber = pageNumber,
+                PageSize = pageSize,
+                TotalCount = totalCount
+            };
+
+            // Assert
+            response.HasPreviousPage.Should().Be(expectedHasPrevious);
+        }
+
+        [Theory]
+        [InlineData(1, 20, 100, true)]  // First page, more pages available
+        [InlineData(4, 20, 100, true)]  // Middle page, more pages available
+        [InlineData(5, 20, 100, false)] // Last page, no more pages
+        [InlineData(1, 20, 15, false)]  // Only page
+        public void DetermineHasNextPageCorrectly(int pageNumber, int pageSize, int totalCount, bool expectedHasNext)
+        {
+            // Act
+            var response = new PaginationResponse<string>
+            {
+                PageNumber = pageNumber,
+                PageSize = pageSize,
+                TotalCount = totalCount
+            };
+
+            // Assert
+            response.HasNextPage.Should().Be(expectedHasNext);
+        }
+    }
+}

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/EndpointHandlers/ActivityHandlers.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/EndpointHandlers/ActivityHandlers.cs
@@ -18,9 +18,18 @@ namespace Biotrackr.Activity.Api.EndpointHandlers
             return TypedResults.Ok(activity);
         }
 
-        public static async Task<Ok<List<ActivityDocument>>> GetAllActivities(ICosmosRepository cosmosRepository)
+        public static async Task<Ok<PaginationResponse<ActivityDocument>>> GetAllActivities(
+            ICosmosRepository cosmosRepository,
+            int? pageNumber = null,
+            int? pageSize = null)
         {
-            var activities = await cosmosRepository.GetAllActivitySummaries();
+            var paginationRequest = new PaginationRequest
+            {
+                PageNumber = pageNumber ?? 1,
+                PageSize = pageSize ?? 20
+            };
+
+            var activities = await cosmosRepository.GetAllActivitySummaries(paginationRequest);
             return TypedResults.Ok(activities);
         }
     }

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Models/PaginationRequest.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Models/PaginationRequest.cs
@@ -1,0 +1,33 @@
+﻿namespace Biotrackr.Activity.Api.Models
+{
+    public class PaginationRequest
+    {
+        private int _pageNumber = 1;
+        private int _pageSize = 20;
+
+        public int PageNumber
+        {
+            get => _pageNumber;
+            set => _pageNumber = value < 1 ? 1 : value;
+        }
+
+        public int PageSize
+        {
+            get => _pageSize;
+            set => _pageSize = value < 1 ? 20 : value > 100 ? 100 : value;
+        }
+
+        public int Skip => (PageNumber - 1) * PageSize;
+    }
+
+    public class PaginationResponse<T>
+    {
+        public List<T> Items { get; set; } = new List<T>();
+        public int TotalCount { get; set; }
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
+        public int TotalPages => (int)Math.Ceiling((double)TotalCount / PageSize);
+        public bool HasPreviousPage => PageNumber > 1;
+        public bool HasNextPage => PageNumber < TotalPages;
+    }
+}

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Repositories/CosmosRepository.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Repositories/CosmosRepository.cs
@@ -59,7 +59,7 @@ namespace Biotrackr.Activity.Api.Repositories
 
                 var totalCount = await GetTotalActivityCount();
 
-                QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM c ORDER BY c_ts DESC OFFSET @offset LIMIT @limit")
+                QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM c ORDER BY c._ts DESC OFFSET @offset LIMIT @limit")
                     .WithParameter("@offset", request.Skip)
                     .WithParameter("@limit", request.PageSize);
 

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Repositories/Interfaces/ICosmosRepository.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Repositories/Interfaces/ICosmosRepository.cs
@@ -5,6 +5,6 @@ namespace Biotrackr.Activity.Api.Repositories.Interfaces
     public interface ICosmosRepository
     {
         Task<ActivityDocument> GetActivitySummaryByDate(string date);
-        Task<List<ActivityDocument>> GetAllActivitySummaries();
+        Task<PaginationResponse<ActivityDocument>> GetAllActivitySummaries(PaginationRequest request);
     }
 }


### PR DESCRIPTION
This pull request introduces pagination functionality to the `GetAllActivitySummaries` endpoint in the `Biotrackr.Activity.Api` project. The changes include updates to the API definition, endpoint handlers, repository methods, and unit tests to support paginated responses. Additionally, new models for handling pagination requests and responses have been implemented.

### Pagination Implementation:

* **API Definition Update**: Added query parameters `pageNumber` and `pageSize` to the `activityApiGetAll` resource in `main.bicep` to enable pagination in API requests.

* **Endpoint Handler Changes**: Modified the `GetAllActivities` method in `ActivityHandlers` to accept optional `pageNumber` and `pageSize` parameters and use the new `PaginationRequest` model to fetch paginated results.

* **Repository Method Update**: Updated the `GetAllActivitySummaries` method in `CosmosRepository` to support pagination by calculating `OFFSET` and `LIMIT` values based on the `PaginationRequest`. Added logging for pagination parameters.

### Pagination Models:

* **New Models**: Introduced `PaginationRequest` and `PaginationResponse` classes in `Models`. These handle pagination logic, such as clamping invalid values and calculating metadata like `TotalPages`, `HasPreviousPage`, and `HasNextPage`.

### Unit Test Enhancements:

* **Endpoint Tests**: Refactored unit tests for `ActivityHandlers` to validate the behavior of pagination parameters and default values, ensuring correct handling of paginated responses.

* **Repository Tests**: Added comprehensive tests for the `GetAllActivitySummaries` method in `CosmosRepository` to verify correct pagination metadata, query behavior, and error handling.

* **Model Tests**: Created new unit tests for `PaginationRequest` and `PaginationResponse` to ensure proper validation, default value assignment, and metadata calculations. [[1]](diffhunk://#diff-8fc0788c95528f7b468867c9719932ecac86991575b8514bc9dec161302280e5R1-R65) [[2]](diffhunk://#diff-bfcd8db6c2e6023e04bc23bc4bb5414c50cb592f48296d7bd4473a0346b578e4R1-R63)