### PR TITLE
Adding OFFSET/LIMIT pagination support in Sleep.Api

### DIFF
--- a/infra/apps/sleep-api/main.bicep
+++ b/infra/apps/sleep-api/main.bicep
@@ -109,7 +109,31 @@ resource sleepApiGetAll 'Microsoft.ApiManagement/service/apis/operations@2024-06
     displayName: 'GetAllSleeps'
     method: 'GET'
     urlTemplate: '/'
-    description: 'Gets all sleep documents' 
+    description: 'Gets all sleep documents'
+    request: {
+      queryParameters: [
+        {
+          name: 'pageNumber'
+          description: 'The page number to retrieve (default: 1)'
+          type: 'integer'
+          required: false
+          defaultValue: '1'
+          values: [
+            
+          ]
+        }
+        {
+          name: 'pageSize'
+          description: 'The number of items per page (default: 20, max: 100)'
+          type: 'integer'
+          required: false
+          defaultValue: '20'
+          values: [
+            
+          ]
+        }
+      ]
+    }  
   }
 }
 

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/Biotrackr.Sleep.Api.UnitTests.csproj
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/Biotrackr.Sleep.Api.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/EndpointHandlerTests/SleepHandlersShould.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/EndpointHandlerTests/SleepHandlersShould.cs
@@ -5,11 +5,6 @@ using Biotrackr.Sleep.Api.Repositories.Interfaces;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Moq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Biotrackr.Sleep.Api.UnitTests.EndpointHandlerTests
 {
@@ -38,6 +33,9 @@ namespace Biotrackr.Sleep.Api.UnitTests.EndpointHandlerTests
 
             // Assert
             result.Result.Should().BeOfType<Ok<SleepDocument>>();
+            var okResult = result.Result as Ok<SleepDocument>;
+            okResult.Value.Should().BeEquivalentTo(sleepDocument);
+            okResult.Value.Date.Should().Be(date);
         }
 
         [Fact]
@@ -55,16 +53,350 @@ namespace Biotrackr.Sleep.Api.UnitTests.EndpointHandlerTests
         }
 
         [Fact]
-        public async Task GetAllSleeps_ShouldReturnListOfSleepDocuments()
+        public async Task GetSleepByDate_ShouldCallRepositoryWithCorrectDate()
+        {
+            // Arrange
+            var date = "2023-05-15";
+            var fixture = new Fixture();
+            var sleepDocument = fixture.Create<SleepDocument>();
+            sleepDocument.Date = date;
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepSummaryByDate(date)).ReturnsAsync(sleepDocument);
+
+            // Act
+            await SleepHandlers.GetSleepByDate(_cosmosRepositoryMock.Object, date);
+
+            // Assert
+            _cosmosRepositoryMock.Verify(x => x.GetSleepSummaryByDate(date), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetSleepByDate_ShouldPropagateException_WhenRepositoryThrowsException()
+        {
+            // Arrange
+            var date = "2022-01-01";
+            var expectedException = new InvalidOperationException("Database connection failed");
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepSummaryByDate(date))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => SleepHandlers.GetSleepByDate(_cosmosRepositoryMock.Object, date));
+
+            actualException.Should().Be(expectedException);
+            actualException.Message.Should().Be("Database connection failed");
+        }
+
+        [Fact]
+        public async Task GetSleepByDate_ShouldPropagateArgumentException_WhenRepositoryThrowsArgumentException()
+        {
+            // Arrange
+            var date = "invalid-date";
+            var expectedException = new ArgumentException("Invalid date format", nameof(date));
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepSummaryByDate(date))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<ArgumentException>(
+                () => SleepHandlers.GetSleepByDate(_cosmosRepositoryMock.Object, date));
+
+            actualException.Should().Be(expectedException);
+            actualException.ParamName.Should().Be("date");
+        }
+
+        [Fact]
+        public async Task GetSleepByDate_ShouldPropagateTaskCanceledException_WhenOperationIsCanceled()
+        {
+            // Arrange
+            var date = "2022-01-01";
+            var expectedException = new TaskCanceledException("Operation was canceled");
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepSummaryByDate(date))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<TaskCanceledException>(
+                () => SleepHandlers.GetSleepByDate(_cosmosRepositoryMock.Object, date));
+
+            actualException.Should().Be(expectedException);
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldReturnPaginationResponseWithSleepDocuments()
         {
             // Arrange
             var fixture = new Fixture();
-            var sleepDocuments = fixture.CreateMany<SleepDocument>().ToList();
-            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments()).ReturnsAsync(sleepDocuments);
+            var sleepDocuments = fixture.CreateMany<SleepDocument>(5).ToList();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = sleepDocuments,
+                TotalCount = 10,
+                PageNumber = 1,
+                PageSize = 20
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(It.IsAny<PaginationRequest>()))
+                .ReturnsAsync(paginationResponse);
+
             // Act
             var result = await SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object);
+
             // Assert
-            result.Should().BeOfType<Ok<List<SleepDocument>>>();
+            result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            var okResult = result as Ok<PaginationResponse<SleepDocument>>;
+            okResult.Value.Should().BeEquivalentTo(paginationResponse);
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldReturnPaginatedResult_WhenPaginationParametersProvided()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var sleepDocuments = fixture.CreateMany<SleepDocument>(10).ToList();
+            var paginatedResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = sleepDocuments,
+                PageNumber = 2,
+                PageSize = 10,
+                TotalCount = 50
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(It.IsAny<PaginationRequest>()))
+                                .ReturnsAsync(paginatedResponse);
+
+            // Act
+            var result = await SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object, 2, 10);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            var okResult = result as Ok<PaginationResponse<SleepDocument>>;
+            okResult.Value.Should().BeEquivalentTo(paginatedResponse);
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldUseDefaultPaginationParameters_WhenNotProvided()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = fixture.CreateMany<SleepDocument>().ToList(),
+                TotalCount = 5,
+                PageNumber = 1,
+                PageSize = 20
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == 20)))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            _cosmosRepositoryMock.Verify(x => x.GetAllSleepDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == 20)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldUseProvidedPaginationParameters()
+        {
+            // Arrange
+            var pageNumber = 2;
+            var pageSize = 10;
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = fixture.CreateMany<SleepDocument>().ToList(),
+                TotalCount = 25,
+                PageNumber = pageNumber,
+                PageSize = pageSize
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == pageNumber && p.PageSize == pageSize)))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object, pageNumber, pageSize);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            var okResult = result as Ok<PaginationResponse<SleepDocument>>;
+            okResult.Value.PageNumber.Should().Be(pageNumber);
+            okResult.Value.PageSize.Should().Be(pageSize);
+
+            _cosmosRepositoryMock.Verify(x => x.GetAllSleepDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == pageNumber && p.PageSize == pageSize)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldUseDefaultPageSize_WhenOnlyPageNumberProvided()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var paginatedResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = fixture.CreateMany<SleepDocument>(20).ToList(),
+                PageNumber = 2,
+                PageSize = 20,
+                TotalCount = 100
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(
+                It.Is<PaginationRequest>(r => r.PageNumber == 2 && r.PageSize == 20)))
+                                .ReturnsAsync(paginatedResponse);
+
+            // Act
+            var result = await SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object, 2, null);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            _cosmosRepositoryMock.Verify(x => x.GetAllSleepDocuments(
+                It.Is<PaginationRequest>(r => r.PageNumber == 2 && r.PageSize == 20)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldUseDefaultPageNumber_WhenOnlyPageSizeProvided()
+        {
+            // Arrange
+            var pageSize = 15;
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = fixture.CreateMany<SleepDocument>().ToList(),
+                TotalCount = 30,
+                PageNumber = 1,
+                PageSize = pageSize
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == pageSize)))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object, null, pageSize);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            _cosmosRepositoryMock.Verify(x => x.GetAllSleepDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == pageSize)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldCallRepositoryWithCorrectPaginationRequest()
+        {
+            // Arrange
+            var pageNumber = 3;
+            var pageSize = 25;
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = fixture.CreateMany<SleepDocument>().ToList(),
+                TotalCount = 100,
+                PageNumber = pageNumber,
+                PageSize = pageSize
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(It.IsAny<PaginationRequest>()))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            await SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object, pageNumber, pageSize);
+
+            // Assert
+            _cosmosRepositoryMock.Verify(x => x.GetAllSleepDocuments(
+                It.Is<PaginationRequest>(r =>
+                    r.PageNumber == pageNumber &&
+                    r.PageSize == pageSize)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldPropagateException_WhenRepositoryThrowsException()
+        {
+            // Arrange
+            var expectedException = new InvalidOperationException("Database connection failed");
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object));
+
+            actualException.Should().Be(expectedException);
+            actualException.Message.Should().Be("Database connection failed");
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldPropagateArgumentException_WhenRepositoryThrowsArgumentException()
+        {
+            // Arrange
+            var expectedException = new ArgumentException("Invalid pagination parameters");
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<ArgumentException>(
+                () => SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object, 2, 10));
+
+            actualException.Should().Be(expectedException);
+            actualException.Message.Should().Be("Invalid pagination parameters");
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldPropagateTimeoutException_WhenRepositoryTimesOut()
+        {
+            // Arrange
+            var expectedException = new TimeoutException("Request timed out");
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<TimeoutException>(
+                () => SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object, 1, 20));
+
+            actualException.Should().Be(expectedException);
+            actualException.Message.Should().Be("Request timed out");
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldPropagateTaskCanceledException_WhenOperationIsCanceled()
+        {
+            // Arrange
+            var expectedException = new TaskCanceledException("Operation was canceled");
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<TaskCanceledException>(
+                () => SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object));
+
+            actualException.Should().Be(expectedException);
+        }
+
+        [Fact]
+        public async Task GetAllSleeps_ShouldStillCallRepository_EvenWhenExceptionExpected()
+        {
+            // Arrange
+            var expectedException = new InvalidOperationException("Test exception");
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllSleepDocuments(It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => SleepHandlers.GetAllSleeps(_cosmosRepositoryMock.Object, 1, 10));
+
+            // Verify the repository was still called with correct parameters
+            _cosmosRepositoryMock.Verify(x => x.GetAllSleepDocuments(
+                It.Is<PaginationRequest>(r => r.PageNumber == 1 && r.PageSize == 10)), Times.Once);
         }
     }
 }

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/ModelTests/PaginationRequestShould.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/ModelTests/PaginationRequestShould.cs
@@ -1,0 +1,65 @@
+﻿using Biotrackr.Sleep.Api.Models;
+using FluentAssertions;
+
+namespace Biotrackr.Sleep.Api.UnitTests.ModelTests
+{
+    public class PaginationRequestShould
+    {
+        [Fact]
+        public void SetDefaultValues_WhenCreated()
+        {
+            // Act
+            var request = new PaginationRequest();
+
+            // Assert
+            request.PageNumber.Should().Be(1);
+            request.PageSize.Should().Be(20);
+            request.Skip.Should().Be(0);
+        }
+
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(-1, 1)]
+        [InlineData(-10, 1)]
+        public void SetPageNumberToOne_WhenInvalidValueProvided(int invalidPageNumber, int expectedPageNumber)
+        {
+            // Act
+            var request = new PaginationRequest { PageNumber = invalidPageNumber };
+
+            // Assert
+            request.PageNumber.Should().Be(expectedPageNumber);
+        }
+
+        [Theory]
+        [InlineData(0, 20)]
+        [InlineData(-1, 20)]
+        [InlineData(101, 100)]
+        [InlineData(200, 100)]
+        public void ClampPageSize_WhenInvalidValueProvided(int invalidPageSize, int expectedPageSize)
+        {
+            // Act
+            var request = new PaginationRequest { PageSize = invalidPageSize };
+
+            // Assert
+            request.PageSize.Should().Be(expectedPageSize);
+        }
+
+        [Theory]
+        [InlineData(1, 20, 0)]
+        [InlineData(2, 20, 20)]
+        [InlineData(3, 15, 30)]
+        [InlineData(5, 10, 40)]
+        public void CalculateCorrectSkipValue(int pageNumber, int pageSize, int expectedSkip)
+        {
+            // Act
+            var request = new PaginationRequest
+            {
+                PageNumber = pageNumber,
+                PageSize = pageSize
+            };
+
+            // Assert
+            request.Skip.Should().Be(expectedSkip);
+        }
+    }
+}

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/ModelTests/PaginationResponseShould.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/ModelTests/PaginationResponseShould.cs
@@ -1,0 +1,63 @@
+﻿using Biotrackr.Sleep.Api.Models;
+using FluentAssertions;
+
+namespace Biotrackr.Sleep.Api.UnitTests.ModelTests
+{
+    public class PaginationResponseShould
+    {
+        [Theory]
+        [InlineData(50, 20, 3)]  // 50 total, 20 per page = 3 pages
+        [InlineData(100, 20, 5)] // 100 total, 20 per page = 5 pages
+        [InlineData(19, 20, 1)]  // 19 total, 20 per page = 1 page
+        [InlineData(0, 20, 0)]   // 0 total = 0 pages
+        public void CalculateCorrectTotalPages(int totalCount, int pageSize, int expectedTotalPages)
+        {
+            // Act
+            var response = new PaginationResponse<string>
+            {
+                TotalCount = totalCount,
+                PageSize = pageSize
+            };
+
+            // Assert
+            response.TotalPages.Should().Be(expectedTotalPages);
+        }
+
+        [Theory]
+        [InlineData(1, 20, 100, false)] // First page
+        [InlineData(2, 20, 100, true)]  // Middle page
+        [InlineData(5, 20, 100, true)]  // Last page
+        public void DetermineHasPreviousPageCorrectly(int pageNumber, int pageSize, int totalCount, bool expectedHasPrevious)
+        {
+            // Act
+            var response = new PaginationResponse<string>
+            {
+                PageNumber = pageNumber,
+                PageSize = pageSize,
+                TotalCount = totalCount
+            };
+
+            // Assert
+            response.HasPreviousPage.Should().Be(expectedHasPrevious);
+        }
+
+        [Theory]
+        [InlineData(1, 20, 100, true)]  // First page, more pages available
+        [InlineData(4, 20, 100, true)]  // Middle page, more pages available
+        [InlineData(5, 20, 100, false)] // Last page, no more pages
+        [InlineData(1, 20, 15, false)]  // Only page
+        public void DetermineHasNextPageCorrectly(int pageNumber, int pageSize, int totalCount, bool expectedHasNext)
+        {
+            // Act
+            var response = new PaginationResponse<string>
+            {
+                PageNumber = pageNumber,
+                PageSize = pageSize,
+                TotalCount = totalCount
+            };
+
+            // Assert
+            response.HasNextPage.Should().Be(expectedHasNext);
+        }
+    }
+}

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/RepositoryTests/CosmosRepositoryShould.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/RepositoryTests/CosmosRepositoryShould.cs
@@ -2,17 +2,11 @@
 using Biotrackr.Sleep.Api.Configuration;
 using Biotrackr.Sleep.Api.Models;
 using Biotrackr.Sleep.Api.Repositories;
-using Biotrackr.Sleep.Api.Repositories.Interfaces;
 using FluentAssertions;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Biotrackr.Sleep.Api.UnitTests.RepositoryTests
 {
@@ -108,12 +102,239 @@ namespace Biotrackr.Sleep.Api.UnitTests.RepositoryTests
         }
 
         [Fact]
-        public async Task GetAllSleepDocuments_ShouldReturnListOfSleepDocuments()
+        public async Task GetAllSleepDocuments_ShouldReturnPaginationResponseWithSleepDocuments()
         {
             // Arrange
             var fixture = new Fixture();
-            var sleepDocuments = fixture.CreateMany<SleepDocument>().ToList();
+            var sleepDocuments = fixture.CreateMany<SleepDocument>(5).ToList();
+            var totalCount = 10;
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 5 };
 
+            SetupMocksForPagination(sleepDocuments, totalCount);
+
+            // Act
+            var result = await _repository.GetAllSleepDocuments(request);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Items.Should().BeEquivalentTo(sleepDocuments);
+            result.TotalCount.Should().Be(totalCount);
+            result.PageNumber.Should().Be(request.PageNumber);
+            result.PageSize.Should().Be(request.PageSize);
+        }
+
+        [Fact]
+        public async Task GetAllSleepDocuments_ShouldReturnEmptyPaginationResponse_WhenNoSleepDocumentsExist()
+        {
+            // Arrange
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 5 };
+
+            SetupMocksForPagination(new List<SleepDocument>(), 0);
+
+            // Act
+            var result = await _repository.GetAllSleepDocuments(request);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Items.Should().BeEmpty();
+            result.TotalCount.Should().Be(0);
+            result.PageNumber.Should().Be(request.PageNumber);
+            result.PageSize.Should().Be(request.PageSize);
+        }
+
+        [Fact]
+        public async Task GetAllSleepDocuments_ShouldLogErrorAndThrowException_WhenExceptionOccurs()
+        {
+            // Arrange
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 5 };
+            var exceptionMessage = "Test Exception";
+
+            // Setup count query to succeed
+            var countFeedResponse = new Mock<FeedResponse<int>>();
+            countFeedResponse.Setup(f => f.GetEnumerator()).Returns(new List<int> { 10 }.GetEnumerator());
+
+            var mockCountIterator = new Mock<FeedIterator<int>>();
+            mockCountIterator.SetupSequence(i => i.HasMoreResults)
+                .Returns(true)
+                .Returns(false);
+            mockCountIterator.Setup(i => i.ReadNextAsync(default))
+                .ReturnsAsync(countFeedResponse.Object);
+
+            _containerMock.Setup(c => c.GetItemQueryIterator<int>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("COUNT")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Returns(mockCountIterator.Object);
+
+            // Setup main query to throw exception
+            _containerMock.Setup(c => c.GetItemQueryIterator<SleepDocument>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("ORDER BY")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Throws(new Exception(exceptionMessage));
+
+            // Act
+            Func<Task> act = async () => await _repository.GetAllSleepDocuments(request);
+
+            // Assert
+            await act.Should().ThrowAsync<Exception>().WithMessage(exceptionMessage);
+            _loggerMock.VerifyLog(logger => logger.LogError($"Exception thrown in GetAllSleepDocuments: Test Exception"));
+        }
+
+        [Fact]
+        public async Task GetAllSleepDocuments_ShouldReturnPaginatedResults()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var sleepDocuments = fixture.CreateMany<SleepDocument>(10).ToList();
+            var totalCount = 100;
+            var request = new PaginationRequest { PageNumber = 2, PageSize = 10 };
+
+            SetupMocksForPagination(sleepDocuments, totalCount);
+
+            // Act
+            var result = await _repository.GetAllSleepDocuments(request);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Items.Should().BeEquivalentTo(sleepDocuments);
+            result.PageNumber.Should().Be(2);
+            result.PageSize.Should().Be(10);
+            result.TotalCount.Should().Be(100);
+            result.TotalPages.Should().Be(10);
+            result.HasPreviousPage.Should().BeTrue();
+            result.HasNextPage.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetAllSleepDocuments_ShouldReturnCorrectPaginationMetadata_ForFirstPage()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var sleepDocuments = fixture.CreateMany<SleepDocument>(20).ToList();
+            var totalCount = 50;
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 20 };
+
+            SetupMocksForPagination(sleepDocuments, totalCount);
+
+            // Act
+            var result = await _repository.GetAllSleepDocuments(request);
+
+            // Assert
+            result.PageNumber.Should().Be(1);
+            result.PageSize.Should().Be(20);
+            result.TotalCount.Should().Be(50);
+            result.TotalPages.Should().Be(3);
+            result.HasPreviousPage.Should().BeFalse();
+            result.HasNextPage.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetAllSleepDocuments_ShouldReturnCorrectPaginationMetadata_ForLastPage()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var sleepDocuments = fixture.CreateMany<SleepDocument>(10).ToList();
+            var totalCount = 50;
+            var request = new PaginationRequest { PageNumber = 3, PageSize = 20 };
+
+            SetupMocksForPagination(sleepDocuments, totalCount);
+
+            // Act
+            var result = await _repository.GetAllSleepDocuments(request);
+
+            // Assert
+            result.PageNumber.Should().Be(3);
+            result.PageSize.Should().Be(20);
+            result.TotalCount.Should().Be(50);
+            result.TotalPages.Should().Be(3);
+            result.HasPreviousPage.Should().BeTrue();
+            result.HasNextPage.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task GetAllSleepDocuments_ShouldUseCorrectOffsetAndLimit()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var sleepDocuments = fixture.CreateMany<SleepDocument>(15).ToList();
+            var request = new PaginationRequest { PageNumber = 3, PageSize = 15 };
+
+            SetupMocksForPagination(sleepDocuments, 100);
+
+            // Act
+            await _repository.GetAllSleepDocuments(request);
+
+            // Assert
+            _containerMock.Verify(x => x.GetItemQueryIterator<SleepDocument>(
+                It.Is<QueryDefinition>(q =>
+                    q.QueryText.Contains("OFFSET @offset LIMIT @limit")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllSleepDocuments_ShouldHandleEmptyResults()
+        {
+            // Arrange
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 20 };
+
+            SetupMocksForPagination(new List<SleepDocument>(), 0);
+
+            // Act
+            var result = await _repository.GetAllSleepDocuments(request);
+
+            // Assert
+            result.Items.Should().BeEmpty();
+            result.TotalCount.Should().Be(0);
+            result.TotalPages.Should().Be(0);
+            result.HasPreviousPage.Should().BeFalse();
+            result.HasNextPage.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task GetAllSleepDocuments_ShouldUsePaginationParametersCorrectly()
+        {
+            // Arrange
+            var request = new PaginationRequest { PageNumber = 2, PageSize = 10 };
+            var expectedSkip = 10; // (2-1) * 10
+            var sleepDocuments = new List<SleepDocument>();
+            var totalCount = 25;
+
+            SetupMocksForPagination(sleepDocuments, totalCount);
+
+            // Act
+            var result = await _repository.GetAllSleepDocuments(request);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.PageNumber.Should().Be(2);
+            result.PageSize.Should().Be(10);
+            result.TotalCount.Should().Be(totalCount);
+
+            // Verify that the correct query was constructed with pagination parameters
+            _containerMock.Verify(c => c.GetItemQueryIterator<SleepDocument>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("OFFSET") && q.QueryText.Contains("LIMIT")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllSleepDocuments_ShouldContinueWhenCountQueryFails()
+        {
+            // Arrange
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 5 };
+            var fixture = new Fixture();
+            var sleepDocuments = fixture.CreateMany<SleepDocument>(3).ToList();
+
+            // Setup count query to fail (GetTotalSleepCount will return 0)
+            _containerMock.Setup(c => c.GetItemQueryIterator<int>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("COUNT")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Throws(new Exception("Count query failed"));
+
+            // Setup for sleep documents query to succeed
             var feedResponse = new Mock<FeedResponse<SleepDocument>>();
             feedResponse.Setup(f => f.GetEnumerator()).Returns(sleepDocuments.GetEnumerator());
 
@@ -124,53 +345,52 @@ namespace Biotrackr.Sleep.Api.UnitTests.RepositoryTests
             mockFeedIterator.Setup(i => i.ReadNextAsync(default))
                 .ReturnsAsync(feedResponse.Object);
 
-            _containerMock.Setup(c => c.GetItemQueryIterator<SleepDocument>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>()))
+            _containerMock.Setup(c => c.GetItemQueryIterator<SleepDocument>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("ORDER BY")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
                 .Returns(mockFeedIterator.Object);
 
             // Act
-            var result = await _repository.GetAllSleepDocuments();
+            var result = await _repository.GetAllSleepDocuments(request);
 
             // Assert
-            result.Should().BeEquivalentTo(sleepDocuments);
+            result.Should().NotBeNull();
+            result.Items.Should().BeEquivalentTo(sleepDocuments);
+            result.TotalCount.Should().Be(0); // Should be 0 because count query failed
+            result.PageNumber.Should().Be(request.PageNumber);
+            result.PageSize.Should().Be(request.PageSize);
         }
 
-        [Fact]
-        public async Task GetAllSleepDocuments_ShouldReturnEmptyList_WhenNoSleepDocumentsExist()
+        private void SetupMocksForPagination(List<SleepDocument> sleepDocuments, int totalCount)
         {
-            // Arrange
-            var feedResponse = new Mock<FeedResponse<SleepDocument>>();
-            feedResponse.Setup(f => f.GetEnumerator()).Returns(new List<SleepDocument>().GetEnumerator());
+            // Mock the count query
+            var countFeedResponse = new Mock<FeedResponse<int>>();
+            countFeedResponse.Setup(x => x.GetEnumerator()).Returns(new List<int> { totalCount }.GetEnumerator());
 
-            var mockFeedIterator = new Mock<FeedIterator<SleepDocument>>();
-            mockFeedIterator.SetupSequence(i => i.HasMoreResults)
-                .Returns(true)
-                .Returns(false);
-            mockFeedIterator.Setup(i => i.ReadNextAsync(default))
-                .ReturnsAsync(feedResponse.Object);
+            var countIterator = new Mock<FeedIterator<int>>();
+            countIterator.SetupSequence(x => x.HasMoreResults).Returns(true).Returns(false);
+            countIterator.Setup(x => x.ReadNextAsync(default)).ReturnsAsync(countFeedResponse.Object);
 
-            _containerMock.Setup(c => c.GetItemQueryIterator<SleepDocument>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>()))
-                .Returns(mockFeedIterator.Object);
+            // Mock the data query
+            var dataFeedResponse = new Mock<FeedResponse<SleepDocument>>();
+            dataFeedResponse.Setup(x => x.GetEnumerator()).Returns(sleepDocuments.GetEnumerator());
 
-            // Act
-            var result = await _repository.GetAllSleepDocuments();
+            var dataIterator = new Mock<FeedIterator<SleepDocument>>();
+            dataIterator.SetupSequence(x => x.HasMoreResults).Returns(true).Returns(false);
+            dataIterator.Setup(x => x.ReadNextAsync(default)).ReturnsAsync(dataFeedResponse.Object);
 
-            // Assert
-            result.Should().BeEmpty();
-        }
+            _containerMock.Setup(x => x.GetItemQueryIterator<int>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("COUNT")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Returns(countIterator.Object);
 
-        [Fact]
-        public async Task GetAllSleepDocuments_ShouldLogErrorAndThrowException_WhenExceptionOccurs()
-        {
-            // Arrange
-            var exceptionMessage = "Test Exception";
-            _containerMock.Setup(c => c.GetItemQueryIterator<SleepDocument>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>()))
-                          .Throws(new Exception(exceptionMessage));
-            // Act
-            Func<Task> act = async () => await _repository.GetAllSleepDocuments();
-
-            // Assert
-            await act.Should().ThrowAsync<Exception>().WithMessage(exceptionMessage);
-            _loggerMock.VerifyLog(logger => logger.LogError($"Exception thrown in GetAllSleepDocuments: Test Exception"));
+            _containerMock.Setup(x => x.GetItemQueryIterator<SleepDocument>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("OFFSET") && q.QueryText.Contains("LIMIT")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Returns(dataIterator.Object);
         }
     }
 }

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/EndpointHandlers/SleepHandlers.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/EndpointHandlers/SleepHandlers.cs
@@ -19,10 +19,18 @@ namespace Biotrackr.Sleep.Api.EndpointHandlers
             return TypedResults.Ok(sleep);
         }
 
-        public static async Task<Ok<List<SleepDocument>>> GetAllSleeps(
-            ICosmosRepository cosmosRepository)
+        public static async Task<Ok<PaginationResponse<SleepDocument>>> GetAllSleeps(
+            ICosmosRepository cosmosRepository,
+            int? pageNumber = null,
+            int? pageSize = null)
         {
-            var sleeps = await cosmosRepository.GetAllSleepDocuments();
+            var paginationRequest = new PaginationRequest
+            {
+                PageNumber = pageNumber ?? 1,
+                PageSize = pageSize ?? 20
+            };
+
+            var sleeps = await cosmosRepository.GetAllSleepDocuments(paginationRequest);
             return TypedResults.Ok(sleeps);
         }
     }

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Models/PaginationRequest.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Models/PaginationRequest.cs
@@ -1,0 +1,33 @@
+﻿namespace Biotrackr.Sleep.Api.Models
+{
+    public class PaginationRequest
+    {
+        private int _pageNumber = 1;
+        private int _pageSize = 20;
+
+        public int PageNumber
+        {
+            get => _pageNumber;
+            set => _pageNumber = value < 1 ? 1 : value;
+        }
+
+        public int PageSize
+        {
+            get => _pageSize;
+            set => _pageSize = value < 1 ? 20 : value > 100 ? 100 : value;
+        }
+
+        public int Skip => (PageNumber - 1) * PageSize;
+    }
+
+    public class PaginationResponse<T>
+    {
+        public List<T> Items { get; set; } = new List<T>();
+        public int TotalCount { get; set; }
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
+        public int TotalPages => (int)Math.Ceiling((double)TotalCount / PageSize);
+        public bool HasPreviousPage => PageNumber > 1;
+        public bool HasNextPage => PageNumber < TotalPages;
+    }
+}

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Program.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Program.cs
@@ -1,8 +1,8 @@
 using Azure.Identity;
 using Biotrackr.Sleep.Api.Configuration;
 using Biotrackr.Sleep.Api.Extensions;
-using Biotrackr.Sleep.Api.Repositories.Interfaces;
 using Biotrackr.Sleep.Api.Repositories;
+using Biotrackr.Sleep.Api.Repositories.Interfaces;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.OpenApi.Models;

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Repositories/Interfaces/ICosmosRepository.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Repositories/Interfaces/ICosmosRepository.cs
@@ -5,6 +5,6 @@ namespace Biotrackr.Sleep.Api.Repositories.Interfaces
     public interface ICosmosRepository
     {
         Task<SleepDocument> GetSleepSummaryByDate(string date);
-        Task<List<SleepDocument>> GetAllSleepDocuments();
+        Task<PaginationResponse<SleepDocument>> GetAllSleepDocuments(PaginationRequest request);
     }
 }


### PR DESCRIPTION
This pull request introduces pagination support for the `GetAllSleeps` API endpoint, refines unit tests for better coverage, and adds new tests for pagination models. It also includes minor cleanup and formatting adjustments across the codebase.

This PR address #66 

### API Enhancements
* Added optional query parameters (`pageNumber` and `pageSize`) to the `GetAllSleeps` API endpoint in `main.bicep`, enabling pagination support. Default values are set to `1` for `pageNumber` and `20` for `pageSize`.

### Unit Test Improvements
#### Endpoint Tests
* Enhanced `GetSleepByDate_ShouldReturnOk_WhenSleepDocumentIsFound` to verify returned `SleepDocument` properties.
* Added comprehensive tests for `GetSleepByDate` to handle various scenarios, including repository exceptions, invalid arguments, and operation cancellations.
* Introduced new tests for `GetAllSleeps` to validate pagination behavior, including default parameters, provided parameters, and exception handling.

#### Model Tests
* Added tests for `PaginationRequest` to ensure default values, clamping of invalid inputs, and correct calculation of `Skip` values.
* Added tests for `PaginationResponse` to verify total pages calculation and correct determination of `HasPreviousPage` and `HasNextPage` properties.

### Code Cleanup
* Removed unused `using` statements in several test files for better readability. [[1]](diffhunk://#diff-a5933c34f697fda771e04ba5295267390213bbdddaffad0391b66ea81602127fL8-L12) [[2]](diffhunk://#diff-504eb600f83522c03163f2c5716d90826b3878a277b0265dca99f1808222cee4L5-L15)

### Formatting Adjustments
* Fixed encoding issue in the project file `Biotrackr.Sleep.Api.UnitTests.csproj`.