### PR TITLE
Adding OFFSET/LIMIT pagination support in Weight.Api

### DIFF
--- a/infra/apps/weight-api/main.bicep
+++ b/infra/apps/weight-api/main.bicep
@@ -110,6 +110,30 @@ resource weightApiGetAll 'Microsoft.ApiManagement/service/apis/operations@2024-0
     method: 'GET'
     urlTemplate: '/'
     description: 'Gets all weight documents' 
+    request: {
+      queryParameters: [
+        {
+          name: 'pageNumber'
+          description: 'The page number to retrieve (default: 1)'
+          type: 'integer'
+          required: false
+          defaultValue: '1'
+          values: [
+            
+          ]
+        }
+        {
+          name: 'pageSize'
+          description: 'The number of items per page (default: 20, max: 100)'
+          type: 'integer'
+          required: false
+          defaultValue: '20'
+          values: [
+            
+          ]
+        }
+      ]
+    } 
   }
 }
 

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/Biotrackr.Weight.Api.UnitTests.csproj
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/Biotrackr.Weight.Api.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/EndpointHandlerTests/WeightHandlersShould.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/EndpointHandlerTests/WeightHandlersShould.cs
@@ -18,21 +18,7 @@ namespace Biotrackr.Weight.Api.UnitTests.EndpointHandlerTests
         }
 
         [Fact]
-        public async Task GetAllWeights_ShouldReturnListOfWeightDocuments()
-        {
-            // Arrange
-            var fixture = new Fixture();
-            var weightDocuments = fixture.CreateMany<WeightDocument>().ToList();
-            _cosmosRepositoryMock.Setup(c => c.GetAllWeightDocuments()).ReturnsAsync(weightDocuments);
-            // Act
-            var result = await WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object);
-            // Assert
-            result.Should().BeOfType<Ok<List<WeightDocument>>>();
-            result.Value.Should().BeEquivalentTo(weightDocuments);
-        }
-
-        [Fact]
-        public async Task GetWeightByDate_ShouldReturnOk_WhenWeightIsFound()
+        public async Task GetWeightByDate_ShouldReturnOk_WhenWeightDocumentIsFound()
         {
             // Arrange
             var date = "2022-01-01";
@@ -40,27 +26,377 @@ namespace Biotrackr.Weight.Api.UnitTests.EndpointHandlerTests
             var weightDocument = fixture.Create<WeightDocument>();
             weightDocument.Date = date;
 
-            _cosmosRepositoryMock.Setup(c => c.GetWeightDocumentByDate(date)).ReturnsAsync(weightDocument);
+            _cosmosRepositoryMock.Setup(x => x.GetWeightDocumentByDate(date)).ReturnsAsync(weightDocument);
 
             // Act
             var result = await WeightHandlers.GetWeightByDate(_cosmosRepositoryMock.Object, date);
 
             // Assert
             result.Result.Should().BeOfType<Ok<WeightDocument>>();
+            var okResult = result.Result as Ok<WeightDocument>;
+            okResult.Value.Should().BeEquivalentTo(weightDocument);
+            okResult.Value.Date.Should().Be(date);
         }
 
         [Fact]
-        public async Task GetWeightByDate_ShouldReturnNotFound_WhenWeightIsNotFound()
+        public async Task GetWeightByDate_ShouldReturnNotFound_WhenWeightDocumentIsNotFound()
         {
             // Arrange
             var date = "2022-01-01";
-            _cosmosRepositoryMock.Setup(c => c.GetWeightDocumentByDate(date)).ReturnsAsync((WeightDocument)null);
+            _cosmosRepositoryMock.Setup(x => x.GetWeightDocumentByDate(date)).ReturnsAsync((WeightDocument)null);
 
             // Act
             var result = await WeightHandlers.GetWeightByDate(_cosmosRepositoryMock.Object, date);
 
             // Assert
             result.Result.Should().BeOfType<NotFound>();
+        }
+
+        [Fact]
+        public async Task GetWeightByDate_ShouldCallRepositoryWithCorrectDate()
+        {
+            // Arrange
+            var date = "2023-05-15";
+            var fixture = new Fixture();
+            var weightDocument = fixture.Create<WeightDocument>();
+            weightDocument.Date = date;
+
+            _cosmosRepositoryMock.Setup(x => x.GetWeightDocumentByDate(date)).ReturnsAsync(weightDocument);
+
+            // Act
+            await WeightHandlers.GetWeightByDate(_cosmosRepositoryMock.Object, date);
+
+            // Assert
+            _cosmosRepositoryMock.Verify(x => x.GetWeightDocumentByDate(date), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetWeightByDate_ShouldPropagateException_WhenRepositoryThrowsException()
+        {
+            // Arrange
+            var date = "2022-01-01";
+            var expectedException = new InvalidOperationException("Database connection failed");
+
+            _cosmosRepositoryMock.Setup(x => x.GetWeightDocumentByDate(date))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => WeightHandlers.GetWeightByDate(_cosmosRepositoryMock.Object, date));
+
+            actualException.Should().Be(expectedException);
+            actualException.Message.Should().Be("Database connection failed");
+        }
+
+        [Fact]
+        public async Task GetWeightByDate_ShouldPropagateArgumentException_WhenRepositoryThrowsArgumentException()
+        {
+            // Arrange
+            var date = "invalid-date";
+            var expectedException = new ArgumentException("Invalid date format", nameof(date));
+
+            _cosmosRepositoryMock.Setup(x => x.GetWeightDocumentByDate(date))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<ArgumentException>(
+                () => WeightHandlers.GetWeightByDate(_cosmosRepositoryMock.Object, date));
+
+            actualException.Should().Be(expectedException);
+            actualException.ParamName.Should().Be("date");
+        }
+
+        [Fact]
+        public async Task GetWeightByDate_ShouldPropagateTaskCanceledException_WhenOperationIsCanceled()
+        {
+            // Arrange
+            var date = "2022-01-01";
+            var expectedException = new TaskCanceledException("Operation was canceled");
+
+            _cosmosRepositoryMock.Setup(x => x.GetWeightDocumentByDate(date))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<TaskCanceledException>(
+                () => WeightHandlers.GetWeightByDate(_cosmosRepositoryMock.Object, date));
+
+            actualException.Should().Be(expectedException);
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldReturnPaginationResponseWithWeightDocuments()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var weightDocuments = fixture.CreateMany<WeightDocument>(5).ToList();
+            var paginationResponse = new PaginationResponse<WeightDocument>
+            {
+                Items = weightDocuments,
+                TotalCount = 10,
+                PageNumber = 1,
+                PageSize = 20
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(It.IsAny<PaginationRequest>()))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<WeightDocument>>>();
+            var okResult = result as Ok<PaginationResponse<WeightDocument>>;
+            okResult.Value.Should().BeEquivalentTo(paginationResponse);
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldReturnPaginatedResult_WhenPaginationParametersProvided()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var weightDocuments = fixture.CreateMany<WeightDocument>(10).ToList();
+            var paginatedResponse = new PaginationResponse<WeightDocument>
+            {
+                Items = weightDocuments,
+                PageNumber = 2,
+                PageSize = 10,
+                TotalCount = 50
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(It.IsAny<PaginationRequest>()))
+                                .ReturnsAsync(paginatedResponse);
+
+            // Act
+            var result = await WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object, 2, 10);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<WeightDocument>>>();
+            var okResult = result as Ok<PaginationResponse<WeightDocument>>;
+            okResult.Value.Should().BeEquivalentTo(paginatedResponse);
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldUseDefaultPaginationParameters_WhenNotProvided()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<WeightDocument>
+            {
+                Items = fixture.CreateMany<WeightDocument>().ToList(),
+                TotalCount = 5,
+                PageNumber = 1,
+                PageSize = 20
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == 20)))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<WeightDocument>>>();
+            _cosmosRepositoryMock.Verify(x => x.GetAllWeightDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == 20)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldUseProvidedPaginationParameters()
+        {
+            // Arrange
+            var pageNumber = 2;
+            var pageSize = 10;
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<WeightDocument>
+            {
+                Items = fixture.CreateMany<WeightDocument>().ToList(),
+                TotalCount = 25,
+                PageNumber = pageNumber,
+                PageSize = pageSize
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == pageNumber && p.PageSize == pageSize)))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object, pageNumber, pageSize);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<WeightDocument>>>();
+            var okResult = result as Ok<PaginationResponse<WeightDocument>>;
+            okResult.Value.PageNumber.Should().Be(pageNumber);
+            okResult.Value.PageSize.Should().Be(pageSize);
+
+            _cosmosRepositoryMock.Verify(x => x.GetAllWeightDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == pageNumber && p.PageSize == pageSize)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldUseDefaultPageSize_WhenOnlyPageNumberProvided()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var paginatedResponse = new PaginationResponse<WeightDocument>
+            {
+                Items = fixture.CreateMany<WeightDocument>(20).ToList(),
+                PageNumber = 2,
+                PageSize = 20,
+                TotalCount = 100
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(
+                It.Is<PaginationRequest>(r => r.PageNumber == 2 && r.PageSize == 20)))
+                                .ReturnsAsync(paginatedResponse);
+
+            // Act
+            var result = await WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object, 2, null);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<WeightDocument>>>();
+            _cosmosRepositoryMock.Verify(x => x.GetAllWeightDocuments(
+                It.Is<PaginationRequest>(r => r.PageNumber == 2 && r.PageSize == 20)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldUseDefaultPageNumber_WhenOnlyPageSizeProvided()
+        {
+            // Arrange
+            var pageSize = 15;
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<WeightDocument>
+            {
+                Items = fixture.CreateMany<WeightDocument>().ToList(),
+                TotalCount = 30,
+                PageNumber = 1,
+                PageSize = pageSize
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == pageSize)))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object, null, pageSize);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<WeightDocument>>>();
+            _cosmosRepositoryMock.Verify(x => x.GetAllWeightDocuments(It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == pageSize)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldCallRepositoryWithCorrectPaginationRequest()
+        {
+            // Arrange
+            var pageNumber = 3;
+            var pageSize = 25;
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<WeightDocument>
+            {
+                Items = fixture.CreateMany<WeightDocument>().ToList(),
+                TotalCount = 100,
+                PageNumber = pageNumber,
+                PageSize = pageSize
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(It.IsAny<PaginationRequest>()))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            await WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object, pageNumber, pageSize);
+
+            // Assert
+            _cosmosRepositoryMock.Verify(x => x.GetAllWeightDocuments(
+                It.Is<PaginationRequest>(r =>
+                    r.PageNumber == pageNumber &&
+                    r.PageSize == pageSize)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldPropagateException_WhenRepositoryThrowsException()
+        {
+            // Arrange
+            var expectedException = new InvalidOperationException("Database connection failed");
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object));
+
+            actualException.Should().Be(expectedException);
+            actualException.Message.Should().Be("Database connection failed");
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldPropagateArgumentException_WhenRepositoryThrowsArgumentException()
+        {
+            // Arrange
+            var expectedException = new ArgumentException("Invalid pagination parameters");
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<ArgumentException>(
+                () => WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object, 2, 10));
+
+            actualException.Should().Be(expectedException);
+            actualException.Message.Should().Be("Invalid pagination parameters");
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldPropagateTimeoutException_WhenRepositoryTimesOut()
+        {
+            // Arrange
+            var expectedException = new TimeoutException("Request timed out");
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<TimeoutException>(
+                () => WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object, 1, 20));
+
+            actualException.Should().Be(expectedException);
+            actualException.Message.Should().Be("Request timed out");
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldPropagateTaskCanceledException_WhenOperationIsCanceled()
+        {
+            // Arrange
+            var expectedException = new TaskCanceledException("Operation was canceled");
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<TaskCanceledException>(
+                () => WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object));
+
+            actualException.Should().Be(expectedException);
+        }
+
+        [Fact]
+        public async Task GetAllWeights_ShouldStillCallRepository_EvenWhenExceptionExpected()
+        {
+            // Arrange
+            var expectedException = new InvalidOperationException("Test exception");
+
+            _cosmosRepositoryMock.Setup(x => x.GetAllWeightDocuments(It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => WeightHandlers.GetAllWeights(_cosmosRepositoryMock.Object, 1, 10));
+
+            // Verify the repository was still called with correct parameters
+            _cosmosRepositoryMock.Verify(x => x.GetAllWeightDocuments(
+                It.Is<PaginationRequest>(r => r.PageNumber == 1 && r.PageSize == 10)), Times.Once);
         }
     }
 }

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/ModelTests/PaginationRequestShould.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/ModelTests/PaginationRequestShould.cs
@@ -1,0 +1,65 @@
+﻿using Biotrackr.Weight.Api.Models;
+using FluentAssertions;
+
+namespace Biotrackr.Weight.Api.UnitTests.ModelTests
+{
+    public class PaginationRequestShould
+    {
+        [Fact]
+        public void SetDefaultValues_WhenCreated()
+        {
+            // Act
+            var request = new PaginationRequest();
+
+            // Assert
+            request.PageNumber.Should().Be(1);
+            request.PageSize.Should().Be(20);
+            request.Skip.Should().Be(0);
+        }
+
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(-1, 1)]
+        [InlineData(-10, 1)]
+        public void SetPageNumberToOne_WhenInvalidValueProvided(int invalidPageNumber, int expectedPageNumber)
+        {
+            // Act
+            var request = new PaginationRequest { PageNumber = invalidPageNumber };
+
+            // Assert
+            request.PageNumber.Should().Be(expectedPageNumber);
+        }
+
+        [Theory]
+        [InlineData(0, 20)]
+        [InlineData(-1, 20)]
+        [InlineData(101, 100)]
+        [InlineData(200, 100)]
+        public void ClampPageSize_WhenInvalidValueProvided(int invalidPageSize, int expectedPageSize)
+        {
+            // Act
+            var request = new PaginationRequest { PageSize = invalidPageSize };
+
+            // Assert
+            request.PageSize.Should().Be(expectedPageSize);
+        }
+
+        [Theory]
+        [InlineData(1, 20, 0)]
+        [InlineData(2, 20, 20)]
+        [InlineData(3, 15, 30)]
+        [InlineData(5, 10, 40)]
+        public void CalculateCorrectSkipValue(int pageNumber, int pageSize, int expectedSkip)
+        {
+            // Act
+            var request = new PaginationRequest
+            {
+                PageNumber = pageNumber,
+                PageSize = pageSize
+            };
+
+            // Assert
+            request.Skip.Should().Be(expectedSkip);
+        }
+    }
+}

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/ModelTests/PaginationResponseShould.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/ModelTests/PaginationResponseShould.cs
@@ -1,0 +1,63 @@
+﻿using Biotrackr.Weight.Api.Models;
+using FluentAssertions;
+
+namespace Biotrackr.Weight.Api.UnitTests.ModelTests
+{
+    public class PaginationResponseShould
+    {
+        [Theory]
+        [InlineData(50, 20, 3)]  // 50 total, 20 per page = 3 pages
+        [InlineData(100, 20, 5)] // 100 total, 20 per page = 5 pages
+        [InlineData(19, 20, 1)]  // 19 total, 20 per page = 1 page
+        [InlineData(0, 20, 0)]   // 0 total = 0 pages
+        public void CalculateCorrectTotalPages(int totalCount, int pageSize, int expectedTotalPages)
+        {
+            // Act
+            var response = new PaginationResponse<string>
+            {
+                TotalCount = totalCount,
+                PageSize = pageSize
+            };
+
+            // Assert
+            response.TotalPages.Should().Be(expectedTotalPages);
+        }
+
+        [Theory]
+        [InlineData(1, 20, 100, false)] // First page
+        [InlineData(2, 20, 100, true)]  // Middle page
+        [InlineData(5, 20, 100, true)]  // Last page
+        public void DetermineHasPreviousPageCorrectly(int pageNumber, int pageSize, int totalCount, bool expectedHasPrevious)
+        {
+            // Act
+            var response = new PaginationResponse<string>
+            {
+                PageNumber = pageNumber,
+                PageSize = pageSize,
+                TotalCount = totalCount
+            };
+
+            // Assert
+            response.HasPreviousPage.Should().Be(expectedHasPrevious);
+        }
+
+        [Theory]
+        [InlineData(1, 20, 100, true)]  // First page, more pages available
+        [InlineData(4, 20, 100, true)]  // Middle page, more pages available
+        [InlineData(5, 20, 100, false)] // Last page, no more pages
+        [InlineData(1, 20, 15, false)]  // Only page
+        public void DetermineHasNextPageCorrectly(int pageNumber, int pageSize, int totalCount, bool expectedHasNext)
+        {
+            // Act
+            var response = new PaginationResponse<string>
+            {
+                PageNumber = pageNumber,
+                PageSize = pageSize,
+                TotalCount = totalCount
+            };
+
+            // Assert
+            response.HasNextPage.Should().Be(expectedHasNext);
+        }
+    }
+}

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/RepositoryTests/CosmosRepositoryShould.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests/RepositoryTests/CosmosRepositoryShould.cs
@@ -12,109 +12,50 @@ namespace Biotrackr.Weight.Api.UnitTests.RepositoryTests
 {
     public class CosmosRepositoryShould
     {
-        private readonly Mock<CosmosClient> _mockCosmosClient;
-        private readonly Mock<Container> _mockContainer;
-        private readonly Mock<IOptions<Settings>> _mockSettings;
-        private readonly Mock<ILogger<CosmosRepository>> _mockLogger;
-        private readonly CosmosRepository _cosmosRepository;
+        private readonly Mock<CosmosClient> _cosmosClientMock;
+        private readonly Mock<Container> _containerMock;
+        private readonly Mock<IOptions<Settings>> _optionsMock;
+        private readonly Mock<ILogger<CosmosRepository>> _loggerMock;
+
+        private readonly CosmosRepository _repository;
 
         public CosmosRepositoryShould()
         {
-            _mockCosmosClient = new Mock<CosmosClient>();
-            _mockContainer = new Mock<Container>();
-            _mockSettings = new Mock<IOptions<Settings>>();
-            _mockLogger = new Mock<ILogger<CosmosRepository>>();
-
-            var settings = new Settings
+            _cosmosClientMock = new Mock<CosmosClient>();
+            _containerMock = new Mock<Container>();
+            _optionsMock = new Mock<IOptions<Settings>>();
+            _optionsMock.Setup(x => x.Value).Returns(new Settings
             {
                 DatabaseName = "TestDatabase",
                 ContainerName = "TestContainer"
-            };
+            });
 
-            _mockSettings.Setup(s => s.Value).Returns(settings);
-            _mockCosmosClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockContainer.Object);
-
-            _cosmosRepository = new CosmosRepository(_mockCosmosClient.Object, _mockSettings.Object, _mockLogger.Object);
-        }
-
-        [Fact]
-        public async Task GetAllWeightDocuments_ShouldReturnListOfWeightDocuments()
-        {
-            // Arrange
-            var fixture = new Fixture();
-            var weightDocuments = fixture.CreateMany<WeightDocument>().ToList();
-
-            var feedResponse = new Mock<FeedResponse<WeightDocument>>();
-            feedResponse.Setup(f => f.GetEnumerator()).Returns(weightDocuments.GetEnumerator());
-
-            var mockFeedIterator = new Mock<FeedIterator<WeightDocument>>();
-            mockFeedIterator.SetupSequence(i => i.HasMoreResults)
-                .Returns(true)
-                .Returns(false);
-            mockFeedIterator.Setup(i => i.ReadNextAsync(default))
-                .ReturnsAsync(feedResponse.Object);
-
-            _mockContainer.Setup(c => c.GetItemQueryIterator<WeightDocument>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>()))
-                .Returns(mockFeedIterator.Object);
-
-            // Act
-            var result = await _cosmosRepository.GetAllWeightDocuments();
-
-            // Assert
-            result.Should().BeEquivalentTo(weightDocuments);
-        }
-
-        [Fact]
-        public async Task GetAllWeightDocuments_ShouldLogErrorAndThrowException_WhenExceptionOccurs()
-        {
-            // Arrange
-            var exceptionMessage = "Test exception";
-            var mockFeedIterator = new Mock<FeedIterator<WeightDocument>>();
-            mockFeedIterator.Setup(i => i.HasMoreResults).Returns(true);
-            mockFeedIterator.Setup(i => i.ReadNextAsync(default)).ThrowsAsync(new Exception(exceptionMessage));
-
-            _mockContainer.Setup(c => c.GetItemQueryIterator<WeightDocument>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>()))
-                .Returns(mockFeedIterator.Object);
-
-            // Act
-            Func<Task> act = async () => await _cosmosRepository.GetAllWeightDocuments();
-
-            // Assert
-            await act.Should().ThrowAsync<Exception>().WithMessage(exceptionMessage);
-            _mockLogger.Verify(
-                x => x.Log(
-                    LogLevel.Error,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Exception thrown in {nameof(CosmosRepository.GetAllWeightDocuments)}: {exceptionMessage}")),
-                    It.IsAny<Exception>(),
-                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
-                Times.Once);
+            _cosmosClientMock.Setup(x => x.GetContainer(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(_containerMock.Object);
+            _loggerMock = new Mock<ILogger<CosmosRepository>>();
+            _repository = new CosmosRepository(_cosmosClientMock.Object, _optionsMock.Object, _loggerMock.Object);
         }
 
         [Fact]
         public async Task GetWeightDocumentByDate_ShouldReturnWeightDocument()
         {
             // Arrange
+            var date = "2022-01-01";
             var fixture = new Fixture();
             var weightDocument = fixture.Create<WeightDocument>();
-            var date = "2022-01-01";
             weightDocument.Date = date;
 
             var feedResponse = new Mock<FeedResponse<WeightDocument>>();
-            feedResponse.Setup(f => f.GetEnumerator()).Returns(new List<WeightDocument> { weightDocument }.GetEnumerator());
+            feedResponse.Setup(x => x.GetEnumerator()).Returns(new List<WeightDocument> { weightDocument }.GetEnumerator());
 
-            var mockFeedIterator = new Mock<FeedIterator<WeightDocument>>();
-            mockFeedIterator.SetupSequence(i => i.HasMoreResults)
-                .Returns(true)
-                .Returns(false);
-            mockFeedIterator.Setup(i => i.ReadNextAsync(default))
-                .ReturnsAsync(feedResponse.Object);
+            var iterator = new Mock<FeedIterator<WeightDocument>>();
+            iterator.SetupSequence(x => x.HasMoreResults).Returns(true).Returns(false);
+            iterator.Setup(x => x.ReadNextAsync(default)).ReturnsAsync(feedResponse.Object);
 
-            _mockContainer.Setup(c => c.GetItemQueryIterator<WeightDocument>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>()))
-                .Returns(mockFeedIterator.Object);
+            _containerMock.Setup(x => x.GetItemQueryIterator<WeightDocument>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>())).Returns(iterator.Object);
 
             // Act
-            var result = await _cosmosRepository.GetWeightDocumentByDate(date);
+            var result = await _repository.GetWeightDocumentByDate(date);
 
             // Assert
             result.Should().BeEquivalentTo(weightDocument);
@@ -128,19 +69,16 @@ namespace Biotrackr.Weight.Api.UnitTests.RepositoryTests
             var date = "2022-01-01";
 
             var feedResponse = new Mock<FeedResponse<WeightDocument>>();
-            feedResponse.Setup(f => f.GetEnumerator()).Returns(new List<WeightDocument>().GetEnumerator());
+            feedResponse.Setup(x => x.GetEnumerator()).Returns(new List<WeightDocument>().GetEnumerator());
 
-            var mockFeedIterator = new Mock<FeedIterator<WeightDocument>>();
-            mockFeedIterator.SetupSequence(i => i.HasMoreResults)
-                .Returns(true)
-                .Returns(false);
-            mockFeedIterator.Setup(i => i.ReadNextAsync(default))
-                .ReturnsAsync(feedResponse.Object);
-            _mockContainer.Setup(c => c.GetItemQueryIterator<WeightDocument>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>()))
-                .Returns(mockFeedIterator.Object);
+            var iterator = new Mock<FeedIterator<WeightDocument>>();
+            iterator.SetupSequence(x => x.HasMoreResults).Returns(true).Returns(false);
+            iterator.Setup(x => x.ReadNextAsync(default)).ReturnsAsync(feedResponse.Object);
+
+            _containerMock.Setup(x => x.GetItemQueryIterator<WeightDocument>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>())).Returns(iterator.Object);
 
             // Act
-            var result = await _cosmosRepository.GetWeightDocumentByDate(date);
+            var result = await _repository.GetWeightDocumentByDate(date);
 
             // Assert
             result.Should().BeNull();
@@ -150,22 +88,17 @@ namespace Biotrackr.Weight.Api.UnitTests.RepositoryTests
         public async Task GetWeightDocumentByDate_ShouldLogErrorAndThrowException_WhenExceptionOccurs()
         {
             // Arrange
-            var exceptionMessage = "Test exception";
             var date = "2022-01-01";
-
-            var mockFeedIterator = new Mock<FeedIterator<WeightDocument>>();
-            mockFeedIterator.Setup(i => i.HasMoreResults).Returns(true);
-            mockFeedIterator.Setup(i => i.ReadNextAsync(default)).ThrowsAsync(new Exception(exceptionMessage));
-
-            _mockContainer.Setup(c => c.GetItemQueryIterator<WeightDocument>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>()))
-                .Returns(mockFeedIterator.Object);
+            var exceptionMessage = "Test Exception";
+            _containerMock.Setup(c => c.GetItemQueryIterator<WeightDocument>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>()))
+                          .Throws(new Exception(exceptionMessage));
 
             // Act
-            Func<Task> act = async () => await _cosmosRepository.GetWeightDocumentByDate(date);
+            Func<Task> act = async () => await _repository.GetWeightDocumentByDate(date);
 
             // Assert
             await act.Should().ThrowAsync<Exception>().WithMessage(exceptionMessage);
-            _mockLogger.Verify(
+            _loggerMock.Verify(
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
@@ -173,6 +106,305 @@ namespace Biotrackr.Weight.Api.UnitTests.RepositoryTests
                     It.IsAny<Exception>(),
                     It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
                 Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllWeightDocuments_ShouldReturnPaginationResponseWithWeightDocuments()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var weightDocuments = fixture.CreateMany<WeightDocument>(5).ToList();
+            var totalCount = 10;
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 5 };
+
+            SetupMocksForPagination(weightDocuments, totalCount);
+
+            // Act
+            var result = await _repository.GetAllWeightDocuments(request);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Items.Should().BeEquivalentTo(weightDocuments);
+            result.TotalCount.Should().Be(totalCount);
+            result.PageNumber.Should().Be(request.PageNumber);
+            result.PageSize.Should().Be(request.PageSize);
+        }
+
+        [Fact]
+        public async Task GetAllWeightDocuments_ShouldReturnEmptyPaginationResponse_WhenNoWeightDocumentsExist()
+        {
+            // Arrange
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 5 };
+
+            SetupMocksForPagination(new List<WeightDocument>(), 0);
+
+            // Act
+            var result = await _repository.GetAllWeightDocuments(request);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Items.Should().BeEmpty();
+            result.TotalCount.Should().Be(0);
+            result.PageNumber.Should().Be(request.PageNumber);
+            result.PageSize.Should().Be(request.PageSize);
+        }
+
+        [Fact]
+        public async Task GetAllWeightDocuments_ShouldLogErrorAndThrowException_WhenExceptionOccurs()
+        {
+            // Arrange
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 5 };
+            var exceptionMessage = "Test Exception";
+
+            // Setup count query to succeed
+            var countFeedResponse = new Mock<FeedResponse<int>>();
+            countFeedResponse.Setup(f => f.GetEnumerator()).Returns(new List<int> { 10 }.GetEnumerator());
+
+            var mockCountIterator = new Mock<FeedIterator<int>>();
+            mockCountIterator.SetupSequence(i => i.HasMoreResults)
+                .Returns(true)
+                .Returns(false);
+            mockCountIterator.Setup(i => i.ReadNextAsync(default))
+                .ReturnsAsync(countFeedResponse.Object);
+
+            _containerMock.Setup(c => c.GetItemQueryIterator<int>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("COUNT")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Returns(mockCountIterator.Object);
+
+            // Setup main query to throw exception
+            _containerMock.Setup(c => c.GetItemQueryIterator<WeightDocument>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("ORDER BY")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Throws(new Exception(exceptionMessage));
+
+            // Act
+            Func<Task> act = async () => await _repository.GetAllWeightDocuments(request);
+
+            // Assert
+            await act.Should().ThrowAsync<Exception>().WithMessage(exceptionMessage);
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Exception thrown in {nameof(CosmosRepository.GetAllWeightDocuments)}: {exceptionMessage}")),
+                    It.IsAny<Exception>(),
+                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllWeightDocuments_ShouldReturnPaginatedResults()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var weightDocuments = fixture.CreateMany<WeightDocument>(10).ToList();
+            var totalCount = 100;
+            var request = new PaginationRequest { PageNumber = 2, PageSize = 10 };
+
+            SetupMocksForPagination(weightDocuments, totalCount);
+
+            // Act
+            var result = await _repository.GetAllWeightDocuments(request);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Items.Should().BeEquivalentTo(weightDocuments);
+            result.PageNumber.Should().Be(2);
+            result.PageSize.Should().Be(10);
+            result.TotalCount.Should().Be(100);
+            result.TotalPages.Should().Be(10);
+            result.HasPreviousPage.Should().BeTrue();
+            result.HasNextPage.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetAllWeightDocuments_ShouldReturnCorrectPaginationMetadata_ForFirstPage()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var weightDocuments = fixture.CreateMany<WeightDocument>(20).ToList();
+            var totalCount = 50;
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 20 };
+
+            SetupMocksForPagination(weightDocuments, totalCount);
+
+            // Act
+            var result = await _repository.GetAllWeightDocuments(request);
+
+            // Assert
+            result.PageNumber.Should().Be(1);
+            result.PageSize.Should().Be(20);
+            result.TotalCount.Should().Be(50);
+            result.TotalPages.Should().Be(3);
+            result.HasPreviousPage.Should().BeFalse();
+            result.HasNextPage.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetAllWeightDocuments_ShouldReturnCorrectPaginationMetadata_ForLastPage()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var weightDocuments = fixture.CreateMany<WeightDocument>(10).ToList();
+            var totalCount = 50;
+            var request = new PaginationRequest { PageNumber = 3, PageSize = 20 };
+
+            SetupMocksForPagination(weightDocuments, totalCount);
+
+            // Act
+            var result = await _repository.GetAllWeightDocuments(request);
+
+            // Assert
+            result.PageNumber.Should().Be(3);
+            result.PageSize.Should().Be(20);
+            result.TotalCount.Should().Be(50);
+            result.TotalPages.Should().Be(3);
+            result.HasPreviousPage.Should().BeTrue();
+            result.HasNextPage.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task GetAllWeightDocuments_ShouldUseCorrectOffsetAndLimit()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var weightDocuments = fixture.CreateMany<WeightDocument>(15).ToList();
+            var request = new PaginationRequest { PageNumber = 3, PageSize = 15 };
+
+            SetupMocksForPagination(weightDocuments, 100);
+
+            // Act
+            await _repository.GetAllWeightDocuments(request);
+
+            // Assert
+            _containerMock.Verify(x => x.GetItemQueryIterator<WeightDocument>(
+                It.Is<QueryDefinition>(q =>
+                    q.QueryText.Contains("OFFSET @offset LIMIT @limit")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllWeightDocuments_ShouldHandleEmptyResults()
+        {
+            // Arrange
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 20 };
+
+            SetupMocksForPagination(new List<WeightDocument>(), 0);
+
+            // Act
+            var result = await _repository.GetAllWeightDocuments(request);
+
+            // Assert
+            result.Items.Should().BeEmpty();
+            result.TotalCount.Should().Be(0);
+            result.TotalPages.Should().Be(0);
+            result.HasPreviousPage.Should().BeFalse();
+            result.HasNextPage.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task GetAllWeightDocuments_ShouldUsePaginationParametersCorrectly()
+        {
+            // Arrange
+            var request = new PaginationRequest { PageNumber = 2, PageSize = 10 };
+            var expectedSkip = 10; // (2-1) * 10
+            var weightDocuments = new List<WeightDocument>();
+            var totalCount = 25;
+
+            SetupMocksForPagination(weightDocuments, totalCount);
+
+            // Act
+            var result = await _repository.GetAllWeightDocuments(request);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.PageNumber.Should().Be(2);
+            result.PageSize.Should().Be(10);
+            result.TotalCount.Should().Be(totalCount);
+
+            // Verify that the correct query was constructed with pagination parameters
+            _containerMock.Verify(c => c.GetItemQueryIterator<WeightDocument>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("OFFSET") && q.QueryText.Contains("LIMIT")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllWeightDocuments_ShouldContinueWhenCountQueryFails()
+        {
+            // Arrange
+            var request = new PaginationRequest { PageNumber = 1, PageSize = 5 };
+            var fixture = new Fixture();
+            var weightDocuments = fixture.CreateMany<WeightDocument>(3).ToList();
+
+            // Setup count query to fail (GetTotalWeightCount will return 0)
+            _containerMock.Setup(c => c.GetItemQueryIterator<int>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("COUNT")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Throws(new Exception("Count query failed"));
+
+            // Setup for weight documents query to succeed
+            var feedResponse = new Mock<FeedResponse<WeightDocument>>();
+            feedResponse.Setup(f => f.GetEnumerator()).Returns(weightDocuments.GetEnumerator());
+
+            var mockFeedIterator = new Mock<FeedIterator<WeightDocument>>();
+            mockFeedIterator.SetupSequence(i => i.HasMoreResults)
+                .Returns(true)
+                .Returns(false);
+            mockFeedIterator.Setup(i => i.ReadNextAsync(default))
+                .ReturnsAsync(feedResponse.Object);
+
+            _containerMock.Setup(c => c.GetItemQueryIterator<WeightDocument>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("ORDER BY")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Returns(mockFeedIterator.Object);
+
+            // Act
+            var result = await _repository.GetAllWeightDocuments(request);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Items.Should().BeEquivalentTo(weightDocuments);
+            result.TotalCount.Should().Be(0); // Should be 0 because count query failed
+            result.PageNumber.Should().Be(request.PageNumber);
+            result.PageSize.Should().Be(request.PageSize);
+        }
+
+        private void SetupMocksForPagination(List<WeightDocument> weightDocuments, int totalCount)
+        {
+            // Mock the count query
+            var countFeedResponse = new Mock<FeedResponse<int>>();
+            countFeedResponse.Setup(x => x.GetEnumerator()).Returns(new List<int> { totalCount }.GetEnumerator());
+
+            var countIterator = new Mock<FeedIterator<int>>();
+            countIterator.SetupSequence(x => x.HasMoreResults).Returns(true).Returns(false);
+            countIterator.Setup(x => x.ReadNextAsync(default)).ReturnsAsync(countFeedResponse.Object);
+
+            // Mock the data query
+            var dataFeedResponse = new Mock<FeedResponse<WeightDocument>>();
+            dataFeedResponse.Setup(x => x.GetEnumerator()).Returns(weightDocuments.GetEnumerator());
+
+            var dataIterator = new Mock<FeedIterator<WeightDocument>>();
+            dataIterator.SetupSequence(x => x.HasMoreResults).Returns(true).Returns(false);
+            dataIterator.Setup(x => x.ReadNextAsync(default)).ReturnsAsync(dataFeedResponse.Object);
+
+            _containerMock.Setup(x => x.GetItemQueryIterator<int>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("COUNT")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Returns(countIterator.Object);
+
+            _containerMock.Setup(x => x.GetItemQueryIterator<WeightDocument>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("OFFSET") && q.QueryText.Contains("LIMIT")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Returns(dataIterator.Object);
         }
     }
 }

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/EndpointHandlers/WeightHandlers.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/EndpointHandlers/WeightHandlers.cs
@@ -6,10 +6,18 @@ namespace Biotrackr.Weight.Api.EndpointHandlers
 {
     public static class WeightHandlers
     {
-        public static async Task<Ok<List<WeightDocument>>> GetAllWeights(
-            ICosmosRepository cosmosRepository)
+        public static async Task<Ok<PaginationResponse<WeightDocument>>> GetAllWeights(
+            ICosmosRepository cosmosRepository,
+            int? pageNumber = null,
+            int? pageSize = null)
         {
-            var weightDocuments = await cosmosRepository.GetAllWeightDocuments();
+            var paginationRequest = new PaginationRequest
+            {
+                PageNumber = pageNumber ?? 1,
+                PageSize = pageSize ?? 20
+            };
+
+            var weightDocuments = await cosmosRepository.GetAllWeightDocuments(paginationRequest);
             return TypedResults.Ok(weightDocuments);
         }
 

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Models/PaginationRequest.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Models/PaginationRequest.cs
@@ -1,0 +1,33 @@
+﻿namespace Biotrackr.Weight.Api.Models
+{
+    public class PaginationRequest
+    {
+        private int _pageNumber = 1;
+        private int _pageSize = 20;
+
+        public int PageNumber
+        {
+            get => _pageNumber;
+            set => _pageNumber = value < 1 ? 1 : value;
+        }
+
+        public int PageSize
+        {
+            get => _pageSize;
+            set => _pageSize = value < 1 ? 20 : value > 100 ? 100 : value;
+        }
+
+        public int Skip => (PageNumber - 1) * PageSize;
+    }
+
+    public class PaginationResponse<T>
+    {
+        public List<T> Items { get; set; } = new List<T>();
+        public int TotalCount { get; set; }
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
+        public int TotalPages => (int)Math.Ceiling((double)TotalCount / PageSize);
+        public bool HasPreviousPage => PageNumber > 1;
+        public bool HasNextPage => PageNumber < TotalPages;
+    }
+}

--- a/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Repositories/Interfaces/ICosmosRepository.cs
+++ b/src/Biotrackr.Weight.Api/Biotrackr.Weight.Api/Repositories/Interfaces/ICosmosRepository.cs
@@ -4,7 +4,7 @@ namespace Biotrackr.Weight.Api.Repositories.Interfaces
 {
     public interface ICosmosRepository
     {
-        Task<List<WeightDocument>> GetAllWeightDocuments();
+        Task<PaginationResponse<WeightDocument>> GetAllWeightDocuments(PaginationRequest request);
         Task<WeightDocument> GetWeightDocumentByDate(string date);
     }
 }


### PR DESCRIPTION
This pull request introduces pagination support for the weight API, refactors endpoint handlers, and adds comprehensive unit tests for both the pagination models and endpoint logic. The changes improve the API's ability to handle large datasets efficiently and ensure robust error handling and validation.

This PR addresses: #67 

### Pagination Support in Weight API

* Added query parameters `pageNumber` and `pageSize` to the `GET /` endpoint in `main.bicep` to enable pagination for weight documents retrieval. Default values and constraints are included.

### Refactored Endpoint Handlers

* Updated `WeightHandlers.GetAllWeights` to support paginated responses, including default and custom pagination parameters. Improved error handling for repository exceptions.

### Unit Tests for Pagination Models

* Added tests for `PaginationRequest` to validate default values, clamping of invalid inputs, and calculation of skip values.
* Added tests for `PaginationResponse` to ensure correct calculation of total pages and determination of `HasPreviousPage` and `HasNextPage` flags.

### Unit Tests for Endpoint Logic

* Enhanced tests for `WeightHandlers.GetWeightByDate` and `WeightHandlers.GetAllWeights` to cover various scenarios, including successful responses, exception propagation, and repository call verification.

### Minor Changes

* Fixed encoding issue in `Biotrackr.Weight.Api.UnitTests.csproj`.