### PR TITLE
Adding base urls for Api's to App Configuration

### DIFF
--- a/infra/apps/activity-api/main.bicep
+++ b/infra/apps/activity-api/main.bicep
@@ -45,6 +45,7 @@ resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
 }
 
 var apiProductName = 'Activity'
+var activityApiEndpointConfigName = 'ActivityApi:BaseUrl'
 
 module activityApi '../../modules/host/container-app-http.bicep' = {
   name: 'activity-api'
@@ -173,5 +174,14 @@ module activityApiProduct '../../modules/apim/apim-products.bicep' = {
     apimName: apim.name
     productName: apiProductName
     apiName: activityApimApi.name
+  }
+}
+
+
+resource activityApiEndpointSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2025-02-01-preview' = {
+  name: activityApiEndpointConfigName
+  parent: appConfig
+  properties: {
+    value: '${apim.properties.gatewayUrl}/activity'
   }
 }

--- a/infra/apps/activity-api/main.bicep
+++ b/infra/apps/activity-api/main.bicep
@@ -45,7 +45,7 @@ resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
 }
 
 var apiProductName = 'Activity'
-var activityApiEndpointConfigName = 'ActivityApi:BaseUrl'
+var activityApiEndpointConfigName = 'Biotrackr:ActivityApiUrl'
 
 module activityApi '../../modules/host/container-app-http.bicep' = {
   name: 'activity-api'

--- a/infra/apps/sleep-api/main.bicep
+++ b/infra/apps/sleep-api/main.bicep
@@ -45,7 +45,7 @@ resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
 }
 
 var apiProductName = 'Sleep'
-var sleepApiEndpointConfigName = 'SleepApi:BaseUrl'
+var sleepApiEndpointConfigName = 'Biotrackr:SleepApiUrl'
 
 module sleepApi '../../modules/host/container-app-http.bicep' = {
   name: 'sleep-api'

--- a/infra/apps/sleep-api/main.bicep
+++ b/infra/apps/sleep-api/main.bicep
@@ -45,6 +45,7 @@ resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
 }
 
 var apiProductName = 'Sleep'
+var sleepApiEndpointConfigName = 'SleepApi:BaseUrl'
 
 module sleepApi '../../modules/host/container-app-http.bicep' = {
   name: 'sleep-api'
@@ -173,5 +174,13 @@ module sleepApiProduct '../../modules/apim/apim-products.bicep' = {
     apiName: sleepApimApi.name
     apimName: apim.name
     productName: apiProductName
+  }
+}
+
+resource sleepApiEndpointSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2025-02-01-preview' = {
+  name: sleepApiEndpointConfigName
+  parent: appConfig
+  properties: {
+    value: '${apim.properties.gatewayUrl}/sleep'
   }
 }

--- a/infra/apps/weight-api/main.bicep
+++ b/infra/apps/weight-api/main.bicep
@@ -45,6 +45,7 @@ resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
 }
 
 var apiProductName = 'Weight'
+var weightApiEndpointConfigName = 'WeightApi:BaseUrl'
 
 module weightApi '../../modules/host/container-app-http.bicep' = {
   name: 'weight-api'
@@ -171,5 +172,13 @@ module weightApiProduct '../../modules/apim/apim-products.bicep' = {
     apiName: weightApimApi.name
     apimName: apim.name
     productName: apiProductName
+  }
+}
+
+resource weightApiEndpointSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2025-02-01-preview' = {
+  name: weightApiEndpointConfigName
+  parent: appConfig
+  properties: {
+    value: '${apim.properties.gatewayUrl}/weight'
   }
 }

--- a/infra/apps/weight-api/main.bicep
+++ b/infra/apps/weight-api/main.bicep
@@ -45,7 +45,7 @@ resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
 }
 
 var apiProductName = 'Weight'
-var weightApiEndpointConfigName = 'WeightApi:BaseUrl'
+var weightApiEndpointConfigName = 'Biotrackr:WeightApiUrl'
 
 module weightApi '../../modules/host/container-app-http.bicep' = {
   name: 'weight-api'


### PR DESCRIPTION
This pull request introduces configuration updates across multiple APIs (`activity-api`, `sleep-api`, and `weight-api`) to define endpoint settings in Azure App Configuration. These changes ensure each API has a dedicated key-value entry for its base URL, enhancing manageability and consistency.

### Configuration Updates for API Endpoints:

* **Activity API**:
  - Added a variable `activityApiEndpointConfigName` to define the key name for the API's base URL in Azure App Configuration. (`infra/apps/activity-api/main.bicep`, [infra/apps/activity-api/main.bicepR48](diffhunk://#diff-97bd90f954a37e249e028237c0853552fbe664a6a9ed6d200109a990933128afR48))
  - Created a new resource `activityApiEndpointSetting` in Azure App Configuration to store the base URL for the Activity API (`${apim.properties.gatewayUrl}/activity`). (`infra/apps/activity-api/main.bicep`, [infra/apps/activity-api/main.bicepR179-R187](diffhunk://#diff-97bd90f954a37e249e028237c0853552fbe664a6a9ed6d200109a990933128afR179-R187))

* **Sleep API**:
  - Added a variable `sleepApiEndpointConfigName` to define the key name for the API's base URL in Azure App Configuration. (`infra/apps/sleep-api/main.bicep`, [infra/apps/sleep-api/main.bicepR48](diffhunk://#diff-8b8b25618a4cfc2df69bad24dcd1d562f040b73990928c11776fb94d9015c260R48))
  - Created a new resource `sleepApiEndpointSetting` in Azure App Configuration to store the base URL for the Sleep API (`${apim.properties.gatewayUrl}/sleep`). (`infra/apps/sleep-api/main.bicep`, [infra/apps/sleep-api/main.bicepR179-R186](diffhunk://#diff-8b8b25618a4cfc2df69bad24dcd1d562f040b73990928c11776fb94d9015c260R179-R186))

* **Weight API**:
  - Added a variable `weightApiEndpointConfigName` to define the key name for the API's base URL in Azure App Configuration. (`infra/apps/weight-api/main.bicep`, [infra/apps/weight-api/main.bicepR48](diffhunk://#diff-19e930c0140f71b356489ec010642d685de1b3926404509033137991661541feR48))
  - Created a new resource `weightApiEndpointSetting` in Azure App Configuration to store the base URL for the Weight API (`${apim.properties.gatewayUrl}/weight`). (`infra/apps/weight-api/main.bicep`, [infra/apps/weight-api/main.bicepR177-R184](diffhunk://#diff-19e930c0140f71b356489ec010642d685de1b3926404509033137991661541feR177-R184))