### PR TITLE
Adding Date Range endpoint for Sleep API

### DIFF
--- a/infra/apps/sleep-api/main.bicep
+++ b/infra/apps/sleep-api/main.bicep
@@ -157,6 +157,51 @@ resource sleepApiGetByDate 'Microsoft.ApiManagement/service/apis/operations@2024
   }
 }
 
+resource sleepApiGetByDateRange 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  name: 'sleep-getbydaterange'
+  parent: sleepApimApi
+  properties: {
+    displayName: 'GetSleepsByDateRange'
+    method: 'GET'
+    urlTemplate: '/range/{startDate}/{endDate}'
+    description: 'Gets paginated sleep documents within a date range'
+    templateParameters: [
+      {
+        name: 'startDate'
+        description: 'The start date for the range in YYYY-MM-DD format'
+        type: 'string'
+        required: true
+      }
+      {
+        name: 'endDate'
+        description: 'The end date for the range in YYYY-MM-DD format'
+        type: 'string'
+        required: true
+      }
+    ]
+    request: {
+      queryParameters: [
+        {
+          name: 'pageNumber'
+          description: 'The page number to retrieve (default: 1)'
+          type: 'integer'
+          required: false
+          defaultValue: '1'
+          values: []
+        }
+        {
+          name: 'pageSize'
+          description: 'The number of items per page (default: 20, max: 100)'
+          type: 'integer'
+          required: false
+          defaultValue: '20'
+          values: []
+        }
+      ]
+    }
+  }
+}
+
 resource sleepApiHealthCheck 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
   name: 'sleep-healthcheck'
   parent: sleepApimApi

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/EndpointHandlerTests/SleepHandlersShould.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests/EndpointHandlerTests/SleepHandlersShould.cs
@@ -398,5 +398,462 @@ namespace Biotrackr.Sleep.Api.UnitTests.EndpointHandlerTests
             _cosmosRepositoryMock.Verify(x => x.GetAllSleepDocuments(
                 It.Is<PaginationRequest>(r => r.PageNumber == 1 && r.PageSize == 10)), Times.Once);
         }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldReturnOkWithPaginationResponse_WhenValidDatesProvided()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var fixture = new Fixture();
+            var sleepDocuments = fixture.CreateMany<SleepDocument>(5).ToList();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = sleepDocuments,
+                TotalCount = 10,
+                PageNumber = 1,
+                PageSize = 20
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.IsAny<PaginationRequest>()))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate);
+
+            // Assert
+            result.Result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            var okResult = result.Result as Ok<PaginationResponse<SleepDocument>>;
+            okResult.Value.Should().BeEquivalentTo(paginationResponse);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldReturnBadRequest_WhenStartDateIsInvalid()
+        {
+            // Arrange
+            var startDate = "invalid-date";
+            var endDate = "2022-01-31";
+
+            // Act
+            var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate);
+
+            // Assert
+            result.Result.Should().BeOfType<BadRequest>();
+            _cosmosRepositoryMock.Verify(x => x.GetSleepDocumentsByDateRange(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PaginationRequest>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldReturnBadRequest_WhenEndDateIsInvalid()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "invalid-date";
+
+            // Act
+            var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate);
+
+            // Assert
+            result.Result.Should().BeOfType<BadRequest>();
+            _cosmosRepositoryMock.Verify(x => x.GetSleepDocumentsByDateRange(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PaginationRequest>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldReturnBadRequest_WhenBothDatesAreInvalid()
+        {
+            // Arrange
+            var startDate = "invalid-start-date";
+            var endDate = "invalid-end-date";
+
+            // Act
+            var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate);
+
+            // Assert
+            result.Result.Should().BeOfType<BadRequest>();
+            _cosmosRepositoryMock.Verify(x => x.GetSleepDocumentsByDateRange(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PaginationRequest>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldReturnBadRequest_WhenStartDateIsAfterEndDate()
+        {
+            // Arrange
+            var startDate = "2022-01-31";
+            var endDate = "2022-01-01";
+
+            // Act
+            var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate);
+
+            // Assert
+            result.Result.Should().BeOfType<BadRequest>();
+            _cosmosRepositoryMock.Verify(x => x.GetSleepDocumentsByDateRange(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PaginationRequest>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldReturnOk_WhenStartDateEqualsEndDate()
+        {
+            // Arrange
+            var startDate = "2022-01-15";
+            var endDate = "2022-01-15";
+            var fixture = new Fixture();
+            var sleepDocuments = fixture.CreateMany<SleepDocument>(2).ToList();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = sleepDocuments,
+                TotalCount = 2,
+                PageNumber = 1,
+                PageSize = 20
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.IsAny<PaginationRequest>()))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate);
+
+            // Assert
+            result.Result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            var okResult = result.Result as Ok<PaginationResponse<SleepDocument>>;
+            okResult.Value.Should().BeEquivalentTo(paginationResponse);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldUseDefaultPaginationParameters_WhenNotProvided()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = fixture.CreateMany<SleepDocument>().ToList(),
+                TotalCount = 5,
+                PageNumber = 1,
+                PageSize = 20
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == 20)))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate);
+
+            // Assert
+            result.Result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            _cosmosRepositoryMock.Verify(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == 20)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldUseProvidedPaginationParameters()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var pageNumber = 2;
+            var pageSize = 10;
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = fixture.CreateMany<SleepDocument>().ToList(),
+                TotalCount = 25,
+                PageNumber = pageNumber,
+                PageSize = pageSize
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.Is<PaginationRequest>(p =>
+                p.PageNumber == pageNumber && p.PageSize == pageSize)))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate, pageNumber, pageSize);
+
+            // Assert
+            result.Result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            var okResult = result.Result as Ok<PaginationResponse<SleepDocument>>;
+            okResult.Value.PageNumber.Should().Be(pageNumber);
+            okResult.Value.PageSize.Should().Be(pageSize);
+
+            _cosmosRepositoryMock.Verify(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.Is<PaginationRequest>(p =>
+                p.PageNumber == pageNumber && p.PageSize == pageSize)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldUseDefaultPageSize_WhenOnlyPageNumberProvided()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var pageNumber = 3;
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = fixture.CreateMany<SleepDocument>(20).ToList(),
+                PageNumber = pageNumber,
+                PageSize = 20,
+                TotalCount = 100
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate,
+                It.Is<PaginationRequest>(r => r.PageNumber == pageNumber && r.PageSize == 20)))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate, pageNumber, null);
+
+            // Assert
+            result.Result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            _cosmosRepositoryMock.Verify(x => x.GetSleepDocumentsByDateRange(startDate, endDate,
+                It.Is<PaginationRequest>(r => r.PageNumber == pageNumber && r.PageSize == 20)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldUseDefaultPageNumber_WhenOnlyPageSizeProvided()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var pageSize = 15;
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = fixture.CreateMany<SleepDocument>().ToList(),
+                TotalCount = 30,
+                PageNumber = 1,
+                PageSize = pageSize
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == pageSize)))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate, null, pageSize);
+
+            // Assert
+            result.Result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            _cosmosRepositoryMock.Verify(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.Is<PaginationRequest>(p =>
+                p.PageNumber == 1 && p.PageSize == pageSize)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldCallRepositoryWithCorrectParameters()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var pageNumber = 3;
+            var pageSize = 25;
+            var fixture = new Fixture();
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = fixture.CreateMany<SleepDocument>().ToList(),
+                TotalCount = 100,
+                PageNumber = pageNumber,
+                PageSize = pageSize
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PaginationRequest>()))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate, pageNumber, pageSize);
+
+            // Assert
+            _cosmosRepositoryMock.Verify(x => x.GetSleepDocumentsByDateRange(
+                startDate,
+                endDate,
+                It.Is<PaginationRequest>(r =>
+                    r.PageNumber == pageNumber &&
+                    r.PageSize == pageSize)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldReturnEmptyResult_WhenNoSleepDocumentsInRange()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var paginationResponse = new PaginationResponse<SleepDocument>
+            {
+                Items = new List<SleepDocument>(),
+                TotalCount = 0,
+                PageNumber = 1,
+                PageSize = 20
+            };
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.IsAny<PaginationRequest>()))
+                .ReturnsAsync(paginationResponse);
+
+            // Act
+            var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate);
+
+            // Assert
+            result.Result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+            var okResult = result.Result as Ok<PaginationResponse<SleepDocument>>;
+            okResult.Value.Items.Should().BeEmpty();
+            okResult.Value.TotalCount.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldPropagateException_WhenRepositoryThrowsException()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var expectedException = new InvalidOperationException("Database connection failed");
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate));
+
+            actualException.Should().Be(expectedException);
+            actualException.Message.Should().Be("Database connection failed");
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldPropagateArgumentException_WhenRepositoryThrowsArgumentException()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var expectedException = new ArgumentException("Invalid date range parameters");
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<ArgumentException>(
+                () => SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate, 1, 20));
+
+            actualException.Should().Be(expectedException);
+            actualException.Message.Should().Be("Invalid date range parameters");
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldPropagateTimeoutException_WhenRepositoryTimesOut()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var expectedException = new TimeoutException("Request timed out");
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<TimeoutException>(
+                () => SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate, 1, 20));
+
+            actualException.Should().Be(expectedException);
+            actualException.Message.Should().Be("Request timed out");
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldPropagateTaskCanceledException_WhenOperationIsCanceled()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var expectedException = new TaskCanceledException("Operation was canceled");
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<TaskCanceledException>(
+                () => SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate));
+
+            actualException.Should().Be(expectedException);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldHandleVariousValidDateFormats()
+        {
+            // Arrange - Test only reliably valid ISO format dates
+            var testCases = new[]
+            {
+                ("2022-01-01", "2022-01-31"),   // ISO format
+                ("2022-12-31", "2023-01-01"),   // Year boundary
+                ("2022-02-28", "2022-03-01"),   // Month boundary
+                ("2024-02-29", "2024-03-01")    // Leap year test
+            };
+
+            foreach (var (startDate, endDate) in testCases)
+            {
+                var fixture = new Fixture();
+                var paginationResponse = new PaginationResponse<SleepDocument>
+                {
+                    Items = fixture.CreateMany<SleepDocument>(2).ToList(),
+                    TotalCount = 2,
+                    PageNumber = 1,
+                    PageSize = 20
+                };
+
+                _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.IsAny<PaginationRequest>()))
+                    .ReturnsAsync(paginationResponse);
+
+                // Act
+                var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate);
+
+                // Assert
+                result.Result.Should().BeOfType<Ok<PaginationResponse<SleepDocument>>>();
+
+                // Reset the mock for the next iteration
+                _cosmosRepositoryMock.Reset();
+            }
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldHandleVariousInvalidDateFormats()
+        {
+            // Arrange - Test clearly invalid date formats that will definitely fail DateOnly.TryParse
+            var invalidDateCases = new[]
+            {
+                ("2022-13-01", "2022-01-31"), // Invalid month
+                ("2022-01-32", "2022-01-31"), // Invalid day
+                ("2022-02-30", "2022-03-01"), // Invalid day for February
+                ("invalid", "2022-01-31"),     // Completely invalid format
+                ("2022-01-01", "not-a-date"),  // Invalid end date
+                ("", "2022-01-31"),            // Empty start date
+                ("2022-01-01", ""),            // Empty end date
+                ("abc-def-ghi", "2022-01-31"), // Completely invalid
+                ("2022-01-01", "xyz-abc-def")  // Invalid end date format
+            };
+
+            foreach (var (startDate, endDate) in invalidDateCases)
+            {
+                // Act
+                var result = await SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate);
+
+                // Assert
+                result.Result.Should().BeOfType<BadRequest>($"Expected BadRequest for dates: {startDate}, {endDate}");
+            }
+
+            // Verify repository was never called for any invalid dates
+            _cosmosRepositoryMock.Verify(x => x.GetSleepDocumentsByDateRange(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PaginationRequest>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GetSleepsByDateRange_ShouldStillCallRepository_EvenWhenExceptionExpected()
+        {
+            // Arrange
+            var startDate = "2022-01-01";
+            var endDate = "2022-01-31";
+            var expectedException = new InvalidOperationException("Test exception");
+
+            _cosmosRepositoryMock.Setup(x => x.GetSleepDocumentsByDateRange(startDate, endDate, It.IsAny<PaginationRequest>()))
+                .ThrowsAsync(expectedException);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => SleepHandlers.GetSleepsByDateRange(_cosmosRepositoryMock.Object, startDate, endDate, 1, 10));
+
+            // Verify the repository was still called with correct parameters
+            _cosmosRepositoryMock.Verify(x => x.GetSleepDocumentsByDateRange(startDate, endDate,
+                It.Is<PaginationRequest>(r => r.PageNumber == 1 && r.PageSize == 10)), Times.Once);
+        }
     }
 }

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/EndpointHandlers/SleepHandlers.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/EndpointHandlers/SleepHandlers.cs
@@ -33,5 +33,35 @@ namespace Biotrackr.Sleep.Api.EndpointHandlers
             var sleeps = await cosmosRepository.GetAllSleepDocuments(paginationRequest);
             return TypedResults.Ok(sleeps);
         }
+
+        public static async Task<Results<BadRequest, Ok<PaginationResponse<SleepDocument>>>> GetSleepsByDateRange(
+            ICosmosRepository cosmosRepository,
+            string startDate,
+            string endDate,
+            int? pageNumber = null,
+            int? pageSize = null)
+        {
+            // Validate date formats
+            if (!DateOnly.TryParse(startDate, out var parsedStartDate) ||
+                !DateOnly.TryParse(endDate, out var parsedEndDate))
+            {
+                return TypedResults.BadRequest();
+            }
+
+            // Validate date range (start date should be before or equal to end date)
+            if (parsedStartDate > parsedEndDate)
+            {
+                return TypedResults.BadRequest();
+            }
+
+            var paginationRequest = new PaginationRequest
+            {
+                PageNumber = pageNumber ?? 1,
+                PageSize = pageSize ?? 20
+            };
+
+            var activityDocuments = await cosmosRepository.GetSleepDocumentsByDateRange(startDate, endDate, paginationRequest);
+            return TypedResults.Ok(activityDocuments);
+        }
     }
 }

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Extensions/EndpointRouteBuilderExtensions.cs
@@ -20,6 +20,11 @@ namespace Biotrackr.Sleep.Api.Extensions
                 .WithOpenApi()
                 .WithSummary("Gets a sleep document by date")
                 .WithDescription("Gets a sleep document by date from the database");
+            sleepEndpoints.MapGet("/range/{startDate}/{endDate}", SleepHandlers.GetSleepsByDateRange)
+                .WithName("GetSleepsByDateRange")
+                .WithOpenApi()
+                .WithSummary("Gets sleep documents within a date range with pagination")
+                .WithDescription("Gets paginated sleep documents between the specified start and end dates (inclusive). Supports optional pageNumber and pageSize query parameters.");
         }
 
         public static void RegisterHealthCheckEndpoints(this IEndpointRouteBuilder endpointRouteBuilder)

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Repositories/CosmosRepository.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Repositories/CosmosRepository.cs
@@ -119,5 +119,76 @@ namespace Biotrackr.Sleep.Api.Repositories
                 return 0;
             }
         }
+
+        public async Task<PaginationResponse<SleepDocument>> GetSleepDocumentsByDateRange(string startDate, string endDate, PaginationRequest request)
+        {
+            try
+            {
+                _logger.LogInformation($"Fetching sleep documents from {startDate} to {endDate} with pagination: PageNumber={request.PageNumber}, PageSize={request.PageSize}");
+
+                var totalSleepCount = await GetTotalSleepCountByDateRange(startDate, endDate);
+
+                QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM c WHERE c.date >= @startDate AND c.date <= @endDate ORDER BY c._ts DESC OFFSET @offset LIMIT @limit")
+                    .WithParameter("@startDate", startDate)
+                    .WithParameter("@endDate", endDate)
+                    .WithParameter("@offset", request.Skip)
+                    .WithParameter("@limit", request.PageSize);
+
+                QueryRequestOptions queryRequestOptions = new QueryRequestOptions
+                {
+                    PartitionKey = new PartitionKey("Sleep")
+                };
+
+                var iterator = _container.GetItemQueryIterator<SleepDocument>(queryDefinition, requestOptions: queryRequestOptions);
+                var results = new List<SleepDocument>();
+
+                while (iterator.HasMoreResults)
+                {
+                    var response = await iterator.ReadNextAsync();
+                    results.AddRange(response.ToList());
+                }
+
+                _logger.LogInformation($"Fetched {results.Count} sleep documents out of {totalSleepCount} total records.");
+
+                return new PaginationResponse<SleepDocument>
+                {
+                    Items = results,
+                    TotalCount = totalSleepCount,
+                    PageNumber = request.PageNumber,
+                    PageSize = request.PageSize
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Exception thrown in {nameof(GetSleepDocumentsByDateRange)}: {ex.Message}");
+                throw;
+            }
+        }
+
+        private async Task<int> GetTotalSleepCountByDateRange(string startDate, string endDate)
+        {
+            try
+            {
+                QueryDefinition queryDefinition = new QueryDefinition("SELECT VALUE COUNT(1) FROM c WHERE c.date >= @startDate AND c.date <= @endDate")
+                    .WithParameter("@startDate", startDate)
+                    .WithParameter("@endDate", endDate);
+                QueryRequestOptions queryRequestOptions = new QueryRequestOptions
+                {
+                    PartitionKey = new PartitionKey("Sleep")
+                };
+                var iterator = _container.GetItemQueryIterator<int>(queryDefinition, requestOptions: queryRequestOptions);
+                if (iterator.HasMoreResults)
+                {
+                    var response = await iterator.ReadNextAsync();
+                    return response.FirstOrDefault();
+                }
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Exception thrown in {nameof(GetTotalSleepCountByDateRange)}: {ex.Message}");
+                return 0;
+            }
+        }
     }
 }

--- a/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Repositories/Interfaces/ICosmosRepository.cs
+++ b/src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api/Repositories/Interfaces/ICosmosRepository.cs
@@ -6,5 +6,6 @@ namespace Biotrackr.Sleep.Api.Repositories.Interfaces
     {
         Task<SleepDocument> GetSleepSummaryByDate(string date);
         Task<PaginationResponse<SleepDocument>> GetAllSleepDocuments(PaginationRequest request);
+        Task<PaginationResponse<SleepDocument>> GetSleepDocumentsByDateRange(string startDate, string endDate, PaginationRequest request);
     }
 }


### PR DESCRIPTION
This pull request introduces support for retrieving sleep documents within a specified date range, including pagination capabilities. The changes span infrastructure, repository, endpoint, and testing layers to provide a robust API for querying sleep data by date range.

**API and Infrastructure Enhancements:**

* Added a new API Management operation in `main.bicep` to support fetching sleep documents by date range with pagination, including required path and optional query parameters.
* Registered a new endpoint `/range/{startDate}/{endDate}` in the API, with OpenAPI documentation, summary, and description for paginated date range queries.

**Repository and Business Logic:**

* Implemented `GetSleepDocumentsByDateRange` in `CosmosRepository`, including a helper for total count, query construction, error handling, and logging. Also updated the repository interface to expose this method. [[1]](diffhunk://#diff-5533f5f2c2ddb06ab0ceb1eec513656fb339528eba4c539f1b909d40732319e0R122-R192) [[2]](diffhunk://#diff-e302e09eeea1c2bcde982dba62c14c8026791e703ace2b5bf2e31caec24f1885R9)
* Added a new handler method to validate input, invoke the repository, and return results or errors for the date range endpoint.

**Testing Improvements:**

* Added comprehensive unit tests for the new date range functionality, covering pagination, error handling, metadata, and logging. Included a helper to set up mocks for date range queries. [[1]](diffhunk://#diff-504eb600f83522c03163f2c5716d90826b3878a277b0265dca99f1808222cee4R364-R648) [[2]](diffhunk://#diff-504eb600f83522c03163f2c5716d90826b3878a277b0265dca99f1808222cee4R679-R714)

These changes collectively provide a new, well-tested API surface for querying sleep documents by date range, with robust input validation and pagination support.