### PR TITLE
Updating workflow uses in deploy-weight-api.yml

### DIFF
--- a/.github/workflows/deploy-weight-api.yml
+++ b/.github/workflows/deploy-weight-api.yml
@@ -32,7 +32,7 @@ jobs:
     run-unit-tests:
           name: Run Unit Tests with Coverage
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@001-weight-api-tests
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@main
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
             working-directory: ./src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests
@@ -42,7 +42,7 @@ jobs:
     run-contract-tests:
           name: Run API Contract Tests
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-contract-tests.yml@001-weight-api-tests
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-contract-tests.yml@main
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
             working-directory: ./src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.IntegrationTests
@@ -137,7 +137,7 @@ jobs:
     run-e2e-tests:
         name: Run E2E Tests Against Dev
         needs: [deploy-dev, env-setup]
-        uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-e2e-tests.yml@001-weight-api-tests
+        uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-e2e-tests.yml@main
         with:
           dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
           working-directory: ./src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.IntegrationTests


### PR DESCRIPTION
This pull request updates the workflow configuration to use the latest versions of shared workflow templates from the `main` branch instead of a specific branch (`001-weight-api-tests`). This ensures that the workflows always use the most up-to-date templates.

Workflow template updates:

* Updated the `run-unit-tests` job to use the unit test workflow template from the `main` branch.
* Updated the `run-contract-tests` job to use the contract test workflow template from the `main` branch.
* Updated the `run-e2e-tests` job to use the E2E test workflow template from the `main` branch.