### PR TITLE
doc: updating github issue prompt to kick off speckit workflow

### DIFF
--- a/.github/prompts/github.get-issue.prompt.md
+++ b/.github/prompts/github.get-issue.prompt.md
@@ -58,12 +58,17 @@ Retrieve GitHub issues from biotrackr using the GitHub MCP server with support f
 5. **Handle pagination** when results exceed 100 issues (max per page)
 6. **Sort intelligently** based on user intent (recently updated, priority, creation date)
 7. **Provide context** about filters applied and total results count
+8. **For single-issue retrieval**: After displaying issue details, MUST ask the user if they want to assign themselves to the issue
+   - If user confirms assignment: Ask if they want to kick off the spec kit workflow
+   - Use GitHub MCP server to update issue assignment when confirmed
+   - Provide clear confirmation of assignment and next steps
 
 **Output Structure Requirements:**
 - Summary header with total count and filters applied
 - Markdown table with issue details
 - Analysis section with insights and patterns
 - Recommended actions when appropriate
+- Assignment prompt (for single-issue retrieval only)
 <!-- </important-core-instructions> -->
 
 ---
@@ -188,13 +193,14 @@ Your Actions:
 2. Include description, comments count, dates
 3. Show current state and assignee
 4. Provide context about labels and milestone
+5. Ask if user wants to assign themselves (if currently unassigned or reassignable)
 
 Expected Output:
 ## Issue #123: Implement activity tracking API
 
 **State:** open  
 **Labels:** `enhancement`, `p1`, `backend`  
-**Assignee:** @willvelida  
+**Assignee:** none  
 **Created:** 2025-10-15  
 **Updated:** 2025-10-28  
 
@@ -202,6 +208,10 @@ Expected Output:
 Implement REST API endpoints for activity tracking...
 
 **Comments:** 5 comments
+
+---
+
+Would you like to assign yourself to this issue?
 ```
 <!-- </example-get-single-issue> -->
 
@@ -325,6 +335,58 @@ These issues need triage and assignment:
 3. Assign documentation update to tech writer
 ```
 <!-- </example-unassigned-issues> -->
+
+<!-- <example-assign-issue-workflow> -->
+**Example 8: Issue assignment and spec kit workflow**
+
+User Request: "Tell me about issue #67"
+
+Your Actions:
+1. Retrieve full details for issue #67
+2. Display issue information
+3. Ask if user wants to assign themselves
+4. If yes, ask about spec kit workflow
+5. Update issue via GitHub MCP server
+6. Confirm actions taken
+
+Expected Interaction:
+
+**Initial Display:**
+## Issue #67: [Cleanup]: Refactor authentication middleware
+
+**State:** open  
+**Labels:** `cleanup`, `technical-debt`, `p2`  
+**Assignee:** none  
+**Created:** 2025-11-01  
+**Updated:** 2025-11-03  
+
+**Description:**
+The authentication middleware has duplicate code across three files...
+
+**Priority:** Medium  
+**Estimated Effort:** 2-4 hours
+
+---
+
+Would you like to assign yourself to this issue?
+
+**User Response:** "Yes"
+
+**Follow-up Question:**
+Great! Would you like to kick off the spec kit workflow for this issue?
+
+**User Response:** "Yes"
+
+**Confirmation:**
+✅ Successfully assigned issue #67 to @willvelida  
+✅ Spec kit workflow initiated for issue #67
+
+**Next Steps:**
+1. Spec kit workflow will create feature branch and planning artifacts
+2. Review generated spec files in `specs/067-refactor-auth-middleware/`
+3. Begin implementation following the generated plan
+```
+<!-- </example-assign-issue-workflow> -->
 
 ---
 

--- a/.github/prompts/github.raise-pr.prompt.md
+++ b/.github/prompts/github.raise-pr.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: Automate pull request creation for Biotrackr using GitHub MCP server with PR template compliance
-tools: ['github']
+tools: ['github', 'run_in_terminal', 'read_file']
 ---
 
 # GitHub Pull Request Creation Prompt
@@ -62,25 +62,41 @@ Create GitHub pull requests programmatically with:
    - `repo`: "biotrackr"
    - `base`: "main" (default) or specify target branch
 
-3. **Analyze current state before creating PR:**
-   - Get current branch name (`git branch --show-current`)
-   - Extract type and optional issue number from branch name
-   - Get commit history since branching from main
-   - Identify changed files and their purposes
+3. **Execute Git commands using `run_in_terminal` tool:**
+   - MUST use PowerShell syntax (default shell: pwsh.exe)
+   - Get current branch: `git branch --show-current`
+   - Get commit history: `git log main..HEAD --oneline`
+   - Get changed files: `git diff --name-only main...HEAD`
+   - Check merge conflicts: `git diff --check main...HEAD`
+   - Handle command failures gracefully
 
-4. **Follow PR template structure exactly:**
+4. **Read files using `read_file` tool:**
+   - Read PR template: `.github/templates/pull-request-template.md`
+   - Read changed files to understand modifications
+   - Read commit standards: `docs/standards/commit-standards.md`
+   - Analyze file content for accurate change descriptions
+
+5. **Analyze current state before creating PR:**
+   - Execute Git commands to gather branch and commit info
+   - Extract type and optional issue number from branch name
+   - Read changed files to identify key modifications
+   - Identify functions/classes modified in each file
+
+6. **Follow PR template structure exactly:**
+   - Read template file to ensure compliance
    - Use emoji-based change categorization
    - Keep total description under 4000 characters (MANDATORY)
    - Include all template sections
    - Link related issues properly
 
-5. **Handle edge cases gracefully:**
-   - Warn if no commits exist on branch
-   - Detect merge conflicts before creating PR
+7. **Handle edge cases gracefully:**
+   - Warn if no commits exist on branch (check Git output)
+   - Detect merge conflicts before creating PR (git diff --check)
    - Validate base branch exists
    - Check if PR already exists for branch
+   - Handle Git command failures with clear error messages
 
-6. **Interactive workflow:**
+8. **Interactive workflow:**
    - Show PR preview before creation
    - Confirm with user before submitting
    - Provide PR URL after successful creation
@@ -163,19 +179,24 @@ branch="feat/gh-42-cosmos-integration"
 **Step-by-Step PR Creation Process:**
 
 ### 1. Pre-Creation Analysis
-```bash
-# Get current branch
+
+**Use `run_in_terminal` to execute Git commands:**
+
+```powershell
+# PowerShell (default shell)
 git branch --show-current
-
-# Get commits since main
 git log main..HEAD --oneline
-
-# Get changed files
 git diff --name-only main...HEAD
-
-# Check for conflicts
-git merge-base main HEAD
 git diff --check main...HEAD
+```
+
+**Example tool invocation:**
+```json
+{
+  "command": "git branch --show-current",
+  "explanation": "Get current branch name for PR head reference",
+  "isBackground": false
+}
 ```
 
 ### 2. Extract Branch Information
@@ -184,14 +205,26 @@ git diff --check main...HEAD
 - Extract human-readable slug
 
 ### 3. Analyze Changes
+
+**Use `read_file` to understand modifications:**
+- Read each changed file to identify specific changes
+- Extract function/class names that were modified
 - Group changed files by directory/component
-- Identify key functions/classes modified
 - Categorize changes by impact:
   - Core functionality
   - Tests
   - Documentation
   - Configuration
   - Infrastructure
+
+**Example tool invocation:**
+```json
+{
+  "filePath": "/path/to/changed/file.cs",
+  "limit": 100,
+  "offset": 1
+}
+```
 
 ### 4. Generate PR Body
 - **Description Section:** 2-3 sentences summarizing the PR
@@ -238,6 +271,80 @@ Examples:
 
 ---
 
+## Tool Usage
+
+<!-- <important-tool-usage> -->
+**Execute Git Commands:**
+
+Always use `run_in_terminal` for Git operations:
+
+```json
+// Get current branch
+{
+  "command": "git branch --show-current",
+  "explanation": "Get current branch name",
+  "isBackground": false
+}
+
+// Get commit history
+{
+  "command": "git log main..HEAD --oneline --format='%h %s'",
+  "explanation": "Get commits since branching from main",
+  "isBackground": false
+}
+
+// Get changed files
+{
+  "command": "git diff --name-only main...HEAD",
+  "explanation": "List all files changed in this branch",
+  "isBackground": false
+}
+
+// Check for merge conflicts
+{
+  "command": "git diff --check main...HEAD",
+  "explanation": "Detect potential merge conflicts",
+  "isBackground": false
+}
+```
+
+**Read Files:**
+
+Use `read_file` to analyze changed files and templates:
+
+```json
+// Read PR template
+{
+  "filePath": "c:\\Users\\velidawill\\Documents\\OpenSource\\biotrackr\\.github\\templates\\pull-request-template.md"
+}
+
+// Read changed file
+{
+  "filePath": "c:\\Users\\velidawill\\Documents\\OpenSource\\biotrackr\\src\\Biotrackr.Weight.Svc\\Services\\WeightService.cs",
+  "limit": 200,
+  "offset": 1
+}
+
+// Read commit standards
+{
+  "filePath": "c:\\Users\\velidawill\\Documents\\OpenSource\\biotrackr\\docs\\standards\\commit-standards.md"
+}
+```
+
+**Error Handling:**
+
+```powershell
+# Handle Git command failures
+$branch = git branch --show-current 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to get current branch: $branch"
+    exit 1
+}
+```
+<!-- </important-tool-usage> -->
+
+---
+
 ## Usage Examples
 
 <!-- <example-create-simple-pr> -->
@@ -246,11 +353,14 @@ Examples:
 User Request: "Create a pull request for my current changes"
 
 Your Actions:
-1. Get current branch: `feat/add-cleanup-specialist-agent`
-2. Analyze commits and changed files
-3. Extract branch info: type=`feat`, slug=`add-cleanup-specialist-agent`
-4. Generate PR body following template
-5. Call GitHub MCP server with PR details
+1. Execute `run_in_terminal`: `git branch --show-current` → `feat/add-cleanup-specialist-agent`
+2. Execute `run_in_terminal`: `git log main..HEAD --oneline` → Analyze commit messages
+3. Execute `run_in_terminal`: `git diff --name-only main...HEAD` → Get changed files
+4. Execute `read_file` for each changed file → Identify specific modifications
+5. Read PR template: `read_file` → `.github/templates/pull-request-template.md`
+6. Extract branch info: type=`feat`, slug=`add-cleanup-specialist-agent`
+7. Generate PR body following template
+8. Call GitHub MCP server with PR details
 
 Expected Output:
 ```markdown


### PR DESCRIPTION
This pull request updates the GitHub issue retrieval prompt to support interactive assignment workflows for single issues. The main changes add logic and examples for prompting users to assign themselves to issues and optionally initiate a spec kit workflow, improving both usability and clarity in the issue management process.

**Interactive assignment workflow enhancements:**

* Added instructions to prompt users to assign themselves when retrieving a single issue, including follow-up for spec kit workflow initiation and confirmation steps using the GitHub MCP server.
* Updated action steps to explicitly ask users if they want to assign themselves when an issue is unassigned or reassignable.

**Documentation and example updates:**

* Added a detailed example (`example-assign-issue-workflow`) showing the full assignment and spec kit workflow interaction, including user prompts, responses, and confirmation messages.