### PR TITLE
build(deps): bump GitHub Actions dependencies and fix stale branch refs

### DIFF
--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -32,7 +32,7 @@ jobs:
     run-unit-tests:
           name: Run Unit Tests with Coverage
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@013-apim-managed-identity
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@main
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
             working-directory: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.UnitTests
@@ -42,7 +42,7 @@ jobs:
     run-contract-tests:
           name: Run API Contract Tests
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-contract-tests.yml@013-apim-managed-identity
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-contract-tests.yml@main
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
             working-directory: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests
@@ -51,7 +51,7 @@ jobs:
     build-container-image-dev:
           name: Build and Push Container Image
           needs: [run-unit-tests, run-contract-tests]
-          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@013-apim-managed-identity
+          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
           with:
             working-directory: ./src/Biotrackr.Activity.Api
             app-name: biotrackr-activity-api
@@ -84,14 +84,14 @@ jobs:
     lint:
         name: Run Bicep Linter
         needs: retrieve-container-image-dev
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-linter.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-linter.yml@main
         with:
             template-file: './infra/apps/activity-api/main.bicep'
 
     validate:
         name: Validate Template
         needs: [lint, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@main
         with:
           template-file: './infra/apps/activity-api/main.bicep'
           parameters-file: ./infra/apps/activity-api/main.dev.bicepparam 
@@ -106,7 +106,7 @@ jobs:
     preview:
         name: Preview Changes
         needs: [validate, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@main
         with:
           scope: resourceGroup
           template-file: './infra/apps/activity-api/main.bicep'
@@ -121,7 +121,7 @@ jobs:
     deploy-dev:
         name: Deploy Template to Dev
         needs: [preview, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@main
         with:
           template-file: './infra/apps/activity-api/main.bicep'
           parameters-file: ./infra/apps/activity-api/main.dev.bicepparam
@@ -137,7 +137,7 @@ jobs:
     run-e2e-tests:
         name: Run E2E Tests Against Dev
         needs: [deploy-dev, env-setup]
-        uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-e2e-tests.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-e2e-tests.yml@main
         with:
           dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
           working-directory: ./src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests

--- a/.github/workflows/deploy-activity-service.yml
+++ b/.github/workflows/deploy-activity-service.yml
@@ -12,7 +12,7 @@ permissions:
     contents: read
     id-token: write
     pull-requests: write
-    checks: write  # Required for dorny/test-reporter@v1
+    checks: write  # Required for dorny/test-reporter@v2
 
 env:
   DOTNET_VERSION: 9.0.x

--- a/.github/workflows/deploy-auth-service.yml
+++ b/.github/workflows/deploy-auth-service.yml
@@ -56,10 +56,10 @@ jobs:
           working-directory: ./src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.IntegrationTests
       steps:
         - name: Checkout Repository code
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
 
         - name: Setup .NET ${{ needs.env-setup.outputs.dotnet-version }}
-          uses: actions/setup-dotnet@v4
+          uses: actions/setup-dotnet@v5
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
         
@@ -79,7 +79,7 @@ jobs:
               --results-directory ./TestResults
 
         - name: Publish Test Results
-          uses: dorny/test-reporter@v1
+          uses: dorny/test-reporter@v2
           if: always()
           with:
             name: E2E Test Results

--- a/.github/workflows/deploy-food-api.yml
+++ b/.github/workflows/deploy-food-api.yml
@@ -32,7 +32,7 @@ jobs:
     run-unit-tests:
           name: Run Unit Tests with Coverage
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@013-apim-managed-identity
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@main
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
             working-directory: ./src/Biotrackr.Food.Api/Biotrackr.Food.Api.UnitTests
@@ -42,7 +42,7 @@ jobs:
     run-contract-tests:
           name: Run API Contract Tests
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-contract-tests.yml@013-apim-managed-identity
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-contract-tests.yml@main
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
             working-directory: ./src/Biotrackr.Food.Api/Biotrackr.Food.Api.IntegrationTests
@@ -51,7 +51,7 @@ jobs:
     build-container-image-dev:
           name: Build and Push Container Image
           needs: [run-unit-tests, run-contract-tests]
-          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@013-apim-managed-identity
+          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
           with:
             working-directory: ./src/Biotrackr.Food.Api
             app-name: biotrackr-food-api
@@ -84,14 +84,14 @@ jobs:
     lint:
         name: Run Bicep Linter
         needs: retrieve-container-image-dev
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-linter.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-linter.yml@main
         with:
             template-file: './infra/apps/food-api/main.bicep'
 
     validate:
         name: Validate Template
         needs: [lint, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@main
         with:
           template-file: './infra/apps/food-api/main.bicep'
           parameters-file: ./infra/apps/food-api/main.dev.bicepparam 
@@ -106,7 +106,7 @@ jobs:
     preview:
         name: Preview Changes
         needs: [validate, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@main
         with:
           scope: resourceGroup
           template-file: './infra/apps/food-api/main.bicep'
@@ -121,7 +121,7 @@ jobs:
     deploy-dev:
         name: Deploy Template to Dev
         needs: [preview, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@main
         with:
           template-file: './infra/apps/food-api/main.bicep'
           parameters-file: ./infra/apps/food-api/main.dev.bicepparam
@@ -137,7 +137,7 @@ jobs:
     run-e2e-tests:
         name: Run E2E Tests Against Dev
         needs: [deploy-dev, env-setup]
-        uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-e2e-tests.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-e2e-tests.yml@main
         with:
           dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
           working-directory: ./src/Biotrackr.Food.Api/Biotrackr.Food.Api.IntegrationTests

--- a/.github/workflows/deploy-food-service.yml
+++ b/.github/workflows/deploy-food-service.yml
@@ -12,7 +12,7 @@ permissions:
     contents: read
     id-token: write
     pull-requests: write
-    checks: write  # Required for dorny/test-reporter@v1
+    checks: write  # Required for dorny/test-reporter@v2
 
 env:
   DOTNET_VERSION: 9.0.x

--- a/.github/workflows/deploy-mcp-server.yml
+++ b/.github/workflows/deploy-mcp-server.yml
@@ -51,7 +51,7 @@ jobs:
     build-container-image-dev:
           name: Build and Push Container Image
           needs: [run-unit-tests, run-integration-tests]
-          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@feature/add-mcp-server
+          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
           with:
             working-directory: ./src/Biotrackr.Mcp.Server
             app-name: biotrackr-mcp-server

--- a/.github/workflows/deploy-sleep-api.yml
+++ b/.github/workflows/deploy-sleep-api.yml
@@ -35,7 +35,7 @@ jobs:
     run-unit-tests:
           name: Run Unit Tests with Coverage
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@013-apim-managed-identity
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@main
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
             working-directory: ./src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.UnitTests
@@ -45,7 +45,7 @@ jobs:
     run-contract-tests:
           name: Run API Contract Tests
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-contract-tests.yml@013-apim-managed-identity
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-contract-tests.yml@main
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
             working-directory: ./src/Biotrackr.Sleep.Api/Biotrackr.Sleep.Api.IntegrationTests
@@ -100,14 +100,14 @@ jobs:
     lint:
         name: Run Bicep Linter
         needs: retrieve-container-image-dev
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-linter.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-linter.yml@main
         with:
             template-file: './infra/apps/sleep-api/main.bicep'
 
     validate:
         name: Validate Template
         needs: [lint, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@main
         with:
           template-file: './infra/apps/sleep-api/main.bicep'
           parameters-file: ./infra/apps/sleep-api/main.dev.bicepparam 
@@ -122,7 +122,7 @@ jobs:
     preview:
         name: Preview Changes
         needs: [validate, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@main
         with:
           template-file: './infra/apps/sleep-api/main.bicep'
           parameters-file: ./infra/apps/sleep-api/main.dev.bicepparam
@@ -137,7 +137,7 @@ jobs:
     deploy-dev:
         name: Deploy Template to Dev
         needs: [preview, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@main
         with:
           template-file: './infra/apps/sleep-api/main.bicep'
           parameters-file: ./infra/apps/sleep-api/main.dev.bicepparam

--- a/.github/workflows/deploy-sleep-service.yml
+++ b/.github/workflows/deploy-sleep-service.yml
@@ -13,7 +13,7 @@ permissions:
     contents: read
     id-token: write
     pull-requests: write
-    checks: write  # Required for dorny/test-reporter@v1
+    checks: write  # Required for dorny/test-reporter@v2
 
 env:
   DOTNET_VERSION: 9.0.x

--- a/.github/workflows/deploy-weight-api.yml
+++ b/.github/workflows/deploy-weight-api.yml
@@ -32,7 +32,7 @@ jobs:
     run-unit-tests:
           name: Run Unit Tests with Coverage
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@013-apim-managed-identity
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@main
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
             working-directory: ./src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.UnitTests
@@ -42,7 +42,7 @@ jobs:
     run-contract-tests:
           name: Run API Contract Tests
           needs: env-setup
-          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-contract-tests.yml@013-apim-managed-identity
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-contract-tests.yml@main
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
             working-directory: ./src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.IntegrationTests
@@ -51,7 +51,7 @@ jobs:
     build-container-image-dev:
           name: Build and Push Container Image
           needs: [run-unit-tests, run-contract-tests]
-          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@013-apim-managed-identity
+          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
           with:
             working-directory: ./src/Biotrackr.Weight.Api
             app-name: biotrackr-weight-api
@@ -84,14 +84,14 @@ jobs:
     lint:
         name: Run Bicep Linter
         needs: retrieve-container-image-dev
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-linter.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-linter.yml@main
         with:
             template-file: './infra/apps/weight-api/main.bicep'
 
     validate:
         name: Validate Template
         needs: [lint, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@main
         with:
           template-file: './infra/apps/weight-api/main.bicep'
           parameters-file: ./infra/apps/weight-api/main.dev.bicepparam 
@@ -106,7 +106,7 @@ jobs:
     preview:
         name: Preview Changes
         needs: [validate, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@main
         with:
           template-file: './infra/apps/weight-api/main.bicep'
           parameters-file: ./infra/apps/weight-api/main.dev.bicepparam
@@ -121,7 +121,7 @@ jobs:
     deploy-dev:
         name: Deploy Template to Dev
         needs: [preview, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@main
         with:
           template-file: './infra/apps/weight-api/main.bicep'
           parameters-file: ./infra/apps/weight-api/main.dev.bicepparam
@@ -137,7 +137,7 @@ jobs:
     run-e2e-tests:
         name: Run E2E Tests Against Dev
         needs: [deploy-dev, env-setup]
-        uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-e2e-tests.yml@013-apim-managed-identity
+        uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-e2e-tests.yml@main
         with:
           dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
           working-directory: ./src/Biotrackr.Weight.Api/Biotrackr.Weight.Api.IntegrationTests

--- a/.github/workflows/task-purge-old-images.yml
+++ b/.github/workflows/task-purge-old-images.yml
@@ -16,7 +16,7 @@ jobs:
 
         steps:
             - name: Checkout repository code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Azure login
               uses: azure/login@v2

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
         steps:
             - name: Checkout Repository code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - uses: azure/login@v2
               name: Login to Azure
@@ -69,7 +69,7 @@ jobs:
                 echo "::set-output name=appconfigurl::$appconfigurl"
             
             - name: Setup .NET ${{ inputs.dotnet-version }}
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                 dotnet-version: ${{ inputs.dotnet-version }}
             

--- a/.github/workflows/template-acr-push-image.yml
+++ b/.github/workflows/template-acr-push-image.yml
@@ -30,7 +30,7 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
       steps:
         - name: Checkout code
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
   
         - name: Azure login
           uses: azure/login@v2

--- a/.github/workflows/template-bicep-deploy.yml
+++ b/.github/workflows/template-bicep-deploy.yml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
         environment: ${{ inputs.environment }}
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
           name: Checkout Repository Code
 
         - uses: azure/login@v2

--- a/.github/workflows/template-bicep-linter.yml
+++ b/.github/workflows/template-bicep-linter.yml
@@ -12,7 +12,7 @@ jobs:
         name: Lint Bicep Template
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               name: Checkout Repository Code
 
             - name: Run Bicep Linter

--- a/.github/workflows/template-bicep-validate.yml
+++ b/.github/workflows/template-bicep-validate.yml
@@ -30,7 +30,7 @@ jobs:
         name: Validate Bicep Template
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               name: Checkout Repository Code
 
             - uses: azure/login@v2

--- a/.github/workflows/template-bicep-whatif.yml
+++ b/.github/workflows/template-bicep-whatif.yml
@@ -30,7 +30,7 @@ jobs:
         name: Preview Bicep Template Deployment
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
           name: Checkout Repository Code
 
         - uses: azure/login@v2

--- a/.github/workflows/template-dotnet-run-contract-tests.yml
+++ b/.github/workflows/template-dotnet-run-contract-tests.yml
@@ -26,10 +26,10 @@ jobs:
                 working-directory: ${{ inputs.working-directory }}
         steps:
             - name: Checkout Repository code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup .NET ${{ inputs.dotnet-version }}
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                 dotnet-version: ${{ inputs.dotnet-version }}
             
@@ -49,7 +49,7 @@ jobs:
                   --results-directory ./TestResults
 
             - name: Upload Test Results
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: always()
               with:
                 name: contract-test-results-${{ github.run_number }}
@@ -57,7 +57,7 @@ jobs:
                 retention-days: 30
 
             - name: Publish Test Results
-              uses: dorny/test-reporter@v1
+              uses: dorny/test-reporter@v2
               if: always()
               with:
                 name: Contract Test Results

--- a/.github/workflows/template-dotnet-run-e2e-tests.yml
+++ b/.github/workflows/template-dotnet-run-e2e-tests.yml
@@ -53,10 +53,10 @@ jobs:
 
         steps:
             - name: Checkout Repository code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup .NET ${{ inputs.dotnet-version }}
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                 dotnet-version: ${{ inputs.dotnet-version }}
 
@@ -102,7 +102,7 @@ jobs:
                 tenantid: ${{ secrets.tenant-id }}
 
             - name: Upload Test Results
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: always()
               with:
                 name: e2e-test-results-${{ github.run_number }}
@@ -110,7 +110,7 @@ jobs:
                 retention-days: 30
 
             - name: Publish Test Results
-              uses: dorny/test-reporter@v1
+              uses: dorny/test-reporter@v2
               if: always()
               with:
                 name: E2E Test Results

--- a/.github/workflows/template-dotnet-run-unit-tests.yml
+++ b/.github/workflows/template-dotnet-run-unit-tests.yml
@@ -31,10 +31,10 @@ jobs:
                 working-directory: ${{ inputs.working-directory }}
         steps:
             - name: Checkout Repository code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup .NET ${{ inputs.dotnet-version }}
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                 dotnet-version: ${{ inputs.dotnet-version }}
             
@@ -63,7 +63,7 @@ jobs:
                     "-filefilters:-*.g.cs"
 
             - name: Upload Coverage Report
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: always()
               with:
                 name: coverage-report-${{ github.run_number }}


### PR DESCRIPTION
# 📝 Description

Consolidates all valid open Dependabot PRs into a single update and fixes stale branch references across deploy workflows.

## 🔗 Related Issues

Closes #73, Closes #77, Closes #93, Closes #94

## 🚀 Changes

**🔧 config(Bump actions/checkout from v4 to v5)**  
What: Updated `actions/checkout` to v5 across all workflow files  
Why: Keep CI dependencies current with latest major version  
📁 Files: `template-bicep-deploy.yml`, `template-acr-push-image.yml`, `template-aca-api-integration-tests.yml`, `task-purge-old-images.yml`, `template-bicep-validate.yml`, `template-bicep-linter.yml`, `template-bicep-whatif.yml`, `template-dotnet-run-contract-tests.yml`, `template-dotnet-run-e2e-tests.yml`, `template-dotnet-run-unit-tests.yml`, `deploy-auth-service.yml`

**🔧 config(Bump actions/setup-dotnet from v4 to v5)**  
What: Updated `actions/setup-dotnet` to v5  
Why: Keep CI dependencies current with latest major version  
📁 Files: `template-aca-api-integration-tests.yml`, `template-dotnet-run-contract-tests.yml`, `template-dotnet-run-e2e-tests.yml`, `template-dotnet-run-unit-tests.yml`, `deploy-auth-service.yml`

**🔧 config(Bump actions/upload-artifact from v4 to v5)**  
What: Updated `actions/upload-artifact` to v5  
Why: Keep CI dependencies current with latest major version  
📁 Files: `template-dotnet-run-contract-tests.yml`, `template-dotnet-run-e2e-tests.yml`, `template-dotnet-run-unit-tests.yml`

**🔧 config(Bump dorny/test-reporter from v1 to v2)**  
What: Updated `dorny/test-reporter` to v2 and updated comments  
Why: Keep CI dependencies current with latest major version  
📁 Files: `template-dotnet-run-contract-tests.yml`, `template-dotnet-run-e2e-tests.yml`, `deploy-auth-service.yml`, `deploy-activity-service.yml`, `deploy-food-service.yml`, `deploy-sleep-service.yml`

**🐛 fix(Stale branch references in deploy workflows)**  
What: Changed `@feature/add-mcp-server` and `@013-apim-managed-identity` refs to `@main`  
Why: Feature branches were merged but refs were never updated  
📁 Files: `deploy-mcp-server.yml`, `deploy-activity-api.yml`, `deploy-food-api.yml`, `deploy-sleep-api.yml`, `deploy-weight-api.yml`

## 🙏 Additional Context

PR #78 (Trivy 0.32.0 to 0.33.1) was closed as stale since Trivy is already at 0.34.2 on main.