### PR TITLE
fix: make tenantId injection conditional in Bicep workflow templates

### DIFF
--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -97,6 +97,7 @@ jobs:
           parameters-file: ./infra/apps/activity-api/main.dev.bicepparam 
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-activity-api:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -112,6 +113,7 @@ jobs:
           template-file: './infra/apps/activity-api/main.bicep'
           parameters-file: ./infra/apps/activity-api/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-activity-api:${{ github.sha }}"}'
+          inject-tenant-id: true
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -127,6 +129,7 @@ jobs:
           parameters-file: ./infra/apps/activity-api/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-activity-api:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
           environment: dev
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/deploy-food-api.yml
+++ b/.github/workflows/deploy-food-api.yml
@@ -97,6 +97,7 @@ jobs:
           parameters-file: ./infra/apps/food-api/main.dev.bicepparam 
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-food-api:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -112,6 +113,7 @@ jobs:
           template-file: './infra/apps/food-api/main.bicep'
           parameters-file: ./infra/apps/food-api/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-food-api:${{ github.sha }}"}'
+          inject-tenant-id: true
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -127,6 +129,7 @@ jobs:
           parameters-file: ./infra/apps/food-api/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-food-api:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
           environment: dev
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/deploy-mcp-server.yml
+++ b/.github/workflows/deploy-mcp-server.yml
@@ -97,6 +97,7 @@ jobs:
           parameters-file: ./infra/apps/mcp-server/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-mcp-server:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -112,6 +113,7 @@ jobs:
           template-file: './infra/apps/mcp-server/main.bicep'
           parameters-file: ./infra/apps/mcp-server/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-mcp-server:${{ github.sha }}"}'
+          inject-tenant-id: true
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -127,6 +129,7 @@ jobs:
           parameters-file: ./infra/apps/mcp-server/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-mcp-server:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
           environment: dev
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/deploy-sleep-api.yml
+++ b/.github/workflows/deploy-sleep-api.yml
@@ -113,6 +113,7 @@ jobs:
           parameters-file: ./infra/apps/sleep-api/main.dev.bicepparam 
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-sleep-api:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -128,6 +129,7 @@ jobs:
           parameters-file: ./infra/apps/sleep-api/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-sleep-api:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -143,6 +145,7 @@ jobs:
           parameters-file: ./infra/apps/sleep-api/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-sleep-api:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
           environment: dev
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/deploy-weight-api.yml
+++ b/.github/workflows/deploy-weight-api.yml
@@ -97,6 +97,7 @@ jobs:
           parameters-file: ./infra/apps/weight-api/main.dev.bicepparam 
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-weight-api:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -112,6 +113,7 @@ jobs:
           parameters-file: ./infra/apps/weight-api/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-weight-api:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -127,6 +129,7 @@ jobs:
           parameters-file: ./infra/apps/weight-api/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-weight-api:${{ github.sha }}"}'
           scope: resourceGroup
+          inject-tenant-id: true
           environment: dev
         secrets:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/template-bicep-deploy.yml
+++ b/.github/workflows/template-bicep-deploy.yml
@@ -15,6 +15,10 @@ on:
             scope:
                 required: true
                 type: string
+            inject-tenant-id:
+                required: false
+                type: boolean
+                default: false
             environment:
                 required: true
                 type: string
@@ -44,16 +48,18 @@ jobs:
             tenant-id: ${{ secrets.tenant-id }}
             subscription-id: ${{ secrets.subscription-id }}
 
-        - name: Prepare Parameters with Tenant ID
+        - name: Prepare Parameters
           id: prepare-params
           shell: bash
           run: |
-            if [ -n "${{ inputs.parameters }}" ]; then
-              # Merge user parameters with tenantId
-              PARAMS=$(echo '${{ inputs.parameters }}' | jq -c '. + {"tenantId": "${{ secrets.tenant-id }}"}')
+            if [ "${{ inputs.inject-tenant-id }}" = "true" ]; then
+              if [ -n "${{ inputs.parameters }}" ]; then
+                PARAMS=$(echo '${{ inputs.parameters }}' | jq -c '. + {"tenantId": "${{ secrets.tenant-id }}"}')
+              else
+                PARAMS='{"tenantId": "${{ secrets.tenant-id }}"}'
+              fi
             else
-              # Only tenantId
-              PARAMS='{"tenantId": "${{ secrets.tenant-id }}"}'
+              PARAMS='${{ inputs.parameters }}'
             fi
             echo "params=$PARAMS" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/template-bicep-validate.yml
+++ b/.github/workflows/template-bicep-validate.yml
@@ -15,6 +15,10 @@ on:
             scope:
                 required: true
                 type: string
+            inject-tenant-id:
+                required: false
+                type: boolean
+                default: false
         secrets:
             client-id:
                 required: true
@@ -40,16 +44,18 @@ jobs:
                 tenant-id: ${{ secrets.tenant-id }}
                 subscription-id: ${{ secrets.subscription-id }}
 
-            - name: Prepare Parameters with Tenant ID
+            - name: Prepare Parameters
               id: prepare-params
               shell: bash
               run: |
-                if [ -n "${{ inputs.parameters }}" ]; then
-                  # Merge user parameters with tenantId
-                  PARAMS=$(echo '${{ inputs.parameters }}' | jq -c '. + {"tenantId": "${{ secrets.tenant-id }}"}')
+                if [ "${{ inputs.inject-tenant-id }}" = "true" ]; then
+                  if [ -n "${{ inputs.parameters }}" ]; then
+                    PARAMS=$(echo '${{ inputs.parameters }}' | jq -c '. + {"tenantId": "${{ secrets.tenant-id }}"}')
+                  else
+                    PARAMS='{"tenantId": "${{ secrets.tenant-id }}"}'
+                  fi
                 else
-                  # Only tenantId
-                  PARAMS='{"tenantId": "${{ secrets.tenant-id }}"}'
+                  PARAMS='${{ inputs.parameters }}'
                 fi
                 echo "params=$PARAMS" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/template-bicep-whatif.yml
+++ b/.github/workflows/template-bicep-whatif.yml
@@ -15,6 +15,10 @@ on:
             scope:
                 required: true
                 type: string
+            inject-tenant-id:
+                required: false
+                type: boolean
+                default: false
         secrets:
             client-id:
                 required: true
@@ -40,16 +44,18 @@ jobs:
             tenant-id: ${{ secrets.tenant-id }}
             subscription-id: ${{ secrets.subscription-id }}
 
-        - name: Prepare Parameters with Tenant ID
+        - name: Prepare Parameters
           id: prepare-params
           shell: bash
           run: |
-            if [ -n "${{ inputs.parameters }}" ]; then
-              # Merge user parameters with tenantId
-              PARAMS=$(echo '${{ inputs.parameters }}' | jq -c '. + {"tenantId": "${{ secrets.tenant-id }}"}')
+            if [ "${{ inputs.inject-tenant-id }}" = "true" ]; then
+              if [ -n "${{ inputs.parameters }}" ]; then
+                PARAMS=$(echo '${{ inputs.parameters }}' | jq -c '. + {"tenantId": "${{ secrets.tenant-id }}"}')
+              else
+                PARAMS='{"tenantId": "${{ secrets.tenant-id }}"}'
+              fi
             else
-              # Only tenantId
-              PARAMS='{"tenantId": "${{ secrets.tenant-id }}"}'
+              PARAMS='${{ inputs.parameters }}'
             fi
             echo "params=$PARAMS" >> "$GITHUB_OUTPUT"
 

--- a/docs/decision-records/2026-03-04-conditional-tenantid-injection.md
+++ b/docs/decision-records/2026-03-04-conditional-tenantid-injection.md
@@ -1,0 +1,40 @@
+# Decision Record: Make tenantId Injection Conditional in Bicep Workflow Templates
+
+- **Status**: Accepted
+- **Deciders**: Will Velida
+- **Date**: 04 March 2026
+- **Related Docs**: [Issue #158](https://github.com/willvelida/biotrackr/issues/158), [2025-11-12-apim-named-values-for-jwt-config.md](2025-11-12-apim-named-values-for-jwt-config.md)
+
+## Context
+
+The reusable workflow templates `template-bicep-validate.yml`, `template-bicep-whatif.yml`, and `template-bicep-deploy.yml` unconditionally injected a `tenantId` parameter into the Bicep deployment parameters via a "Prepare Parameters with Tenant ID" step. However, only 5 of the 12 Bicep app templates (`activity-api`, `food-api`, `weight-api`, `sleep-api`, `mcp-server`) actually declare `param tenantId string`. The remaining 7 templates (all `*-service` apps, `ui`, and `core`) do not use this parameter.
+
+This caused Bicep validation to fail with error **BCP259** ("The parameter 'tenantId' is assigned in the params file without being declared in the Bicep file") for any workflow targeting a template that doesn't declare `tenantId`.
+
+## Decision
+
+Add a boolean `inject-tenant-id` input (default: `false`) to all three reusable Bicep workflow templates. When `true`, the template merges `tenantId` from the `tenant-id` secret into the deployment parameters. When `false` (default), the template passes through the caller's parameters unchanged.
+
+The 5 API/MCP deploy workflows that need `tenantId` (for APIM named values / JWT configuration) explicitly set `inject-tenant-id: true`. All other deploy workflows use the default `false` and require no changes.
+
+## Consequences
+
+- Bicep validation, what-if, and deploy operations now succeed for all templates regardless of whether they declare a `tenantId` parameter.
+- The `tenantId` injection is opt-in rather than implicit, making the template behaviour more predictable.
+- Adding a new Bicep template that needs `tenantId` requires the caller to explicitly set `inject-tenant-id: true`, which is a clear and discoverable pattern.
+
+## Alternatives Considered
+
+1. **Add `param tenantId string` to all Bicep templates** — Rejected because it introduces unused parameters in templates that have no use for `tenantId`, which is misleading and violates the principle of minimal surface area.
+
+2. **Remove injection entirely; callers pass `tenantId` via `parameters` JSON** — Rejected because it would require callers to embed the tenant ID secret directly in the `parameters` input, which the centralised "Prepare Parameters" step was designed to avoid.
+
+3. **Auto-detect whether the Bicep file declares `tenantId` at workflow runtime** — Rejected as overly complex; it would require parsing Bicep files in the workflow, adding fragility and maintenance overhead for marginal benefit.
+
+## Follow-up Actions
+
+- None required. All affected workflows are updated in this change.
+
+## Notes
+
+The `tenantId` parameter is used by Bicep templates that configure APIM named values for JWT authentication (see decision record `2025-11-12-apim-named-values-for-jwt-config.md`).


### PR DESCRIPTION
# 📝 Description

Makes `tenantId` parameter injection conditional in the reusable Bicep workflow templates to fix BCP259 validation failures for templates that don't declare a `tenantId` parameter.

## 🔗 Related Issues

Closes #158

## 🚀 Changes

**🐛 fix(template-bicep-validate.yml): Add conditional tenantId injection**
What: Added `inject-tenant-id` boolean input (default `false`) and wrapped tenantId injection in a conditional
Why: Unconditional injection caused BCP259 errors for Bicep templates that don't declare `tenantId`
📁 Files: `template-bicep-validate.yml`

**🐛 fix(template-bicep-whatif.yml): Add conditional tenantId injection**
What: Same conditional injection logic as validate template
Why: Same root cause — unconditional tenantId injection
📁 Files: `template-bicep-whatif.yml`

**🐛 fix(template-bicep-deploy.yml): Add conditional tenantId injection**
What: Same conditional injection logic as validate template
Why: Same root cause — unconditional tenantId injection
📁 Files: `template-bicep-deploy.yml`

**🔧 config(deploy-*-api.yml, deploy-mcp-server.yml): Opt in to tenantId injection**
What: Added `inject-tenant-id: true` to validate, preview, and deploy-dev jobs in 5 API/MCP workflows
Why: These templates declare `param tenantId string` for APIM JWT auth config
📁 Files: `deploy-activity-api.yml`, `deploy-food-api.yml`, `deploy-weight-api.yml`, `deploy-sleep-api.yml`, `deploy-mcp-server.yml`

**📚 docs(decision-record): Document conditional tenantId injection decision**
What: Added decision record explaining the approach and alternatives considered
Why: Documents rationale for future reference
📁 Files: `docs/decision-records/2026-03-04-conditional-tenantid-injection.md`

## 🙏 Additional Context

The bug affected 7 of 12 Bicep templates (all services, UI, core) — not just auth-service and sleep-service as originally reported. Only the 5 API/MCP templates need `tenantId` for APIM named values / JWT configuration.