### PR TITLE
feat: upgrade Biotrackr.Activity.Svc to .NET 10

### DIFF
--- a/.github/workflows/deploy-activity-service.yml
+++ b/.github/workflows/deploy-activity-service.yml
@@ -15,7 +15,7 @@ permissions:
     checks: write  # Required for dorny/test-reporter@v2
 
 env:
-  DOTNET_VERSION: 9.0.x
+  DOTNET_VERSION: 10.0.x
   COVERAGE_PATH: ${{ github.workspace }}/coverage
 
 jobs:
@@ -41,6 +41,7 @@ jobs:
           working-directory: ./src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests
           coverage-threshold: 70
           fail-below-threshold: false
+          runsettings-path: ../coverage.runsettings
 
     run-contract-tests:
         name: Run Contract Tests

--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.IntegrationTests/Biotrackr.Activity.Svc.IntegrationTests.csproj
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.IntegrationTests/Biotrackr.Activity.Svc.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,19 +9,18 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.54.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/Biotrackr.Activity.Svc.UnitTests.csproj
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.UnitTests/Biotrackr.Activity.Svc.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,16 +11,16 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.4.0" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="ILogger.Moq" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.csproj
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Biotrackr.Activity.Svc-dc322568-94c5-4350-a329-8ff23306c3c2</UserSecretsId>
@@ -9,17 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
   </ItemGroup>
 </Project>

--- a/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Program.cs
+++ b/src/Biotrackr.Activity.Svc/Biotrackr.Activity.Svc/Program.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Security.KeyVault.Secrets;
@@ -14,20 +13,15 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
-[ExcludeFromCodeCoverage]
-internal class Program
+var resourceAttributes = new Dictionary<string, object>
 {
-    private static void Main(string[] args)
-    {
-        var resourceAttributes = new Dictionary<string, object>
-        {
-            { "service.name", "Biotrackr.Activity.Svc" },
-            { "service.version", "1.0.0" }
-        };
+    { "service.name", "Biotrackr.Activity.Svc" },
+    { "service.version", "1.0.0" }
+};
 
-        var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
 
-        IHost host = Host.CreateDefaultBuilder(args)
+IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureAppConfiguration(config =>
     {
         config.AddEnvironmentVariables();
@@ -62,8 +56,8 @@ internal class Program
             }
         };
 
-        services.AddSingleton(new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential(defaultCredentialOptions)));
-        services.AddSingleton(new CosmosClient(cosmosDbEndpoint, new DefaultAzureCredential(defaultCredentialOptions), cosmosClientOptions));
+        services.AddSingleton(new SecretClient(new Uri(keyVaultUrl!), new DefaultAzureCredential(defaultCredentialOptions)));
+        services.AddSingleton(new CosmosClient(cosmosDbEndpoint!, new DefaultAzureCredential(defaultCredentialOptions), cosmosClientOptions));
 
         services.AddScoped<ICosmosRepository, CosmosRepository>();
 
@@ -101,12 +95,9 @@ internal class Program
             {
                 options.ConnectionString = context.Configuration["applicationinsightsconnectionstring"];
             });
-
         });
     })
     .Build();
 
-        host.Run();
-    }
-}
+host.Run();
 

--- a/src/Biotrackr.Activity.Svc/Dockerfile
+++ b/src/Biotrackr.Activity.Svc/Dockerfile
@@ -1,13 +1,13 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS base
 USER $APP_UID
 WORKDIR /app
 
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Biotrackr.Activity.Svc/Biotrackr.Activity.Svc.csproj", "Biotrackr.Activity.Svc/"]

--- a/src/Biotrackr.Activity.Svc/coverage.runsettings
+++ b/src/Biotrackr.Activity.Svc/coverage.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Coverage exclusion settings for .NET 10 projects.
+  
+  Excludes code marked with [ExcludeFromCodeCoverage] from coverage instrumentation.
+  Place this file at the solution root and pass it via:
+    dotnet test - -settings ../coverage.runsettings
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
# 📝 Description

Upgrade `Biotrackr.Activity.Svc` solution from .NET 9 to .NET 10, following the same migration patterns established by the Activity API upgrade.

## 🔗 Related Issues

- Plan: `docs/plans/2026-03-07-activity-svc-dotnet10-upgrade.md`
- Reference: `docs/plans/2026-03-07-activity-api-dotnet10-upgrade.md`

## 🚀 Changes

**✨ feat(TFM & NuGet packages)**  
What: Updated TFM to `net10.0` across all three projects. Updated NuGet packages: Azure.Identity 1.18.0, Cosmos 3.57.1, Hosting 10.0.3, coverlet 8.0.0, FluentAssertions 8.8.0, Microsoft.NET.Test.Sdk 18.3.0, xunit.runner.visualstudio 3.1.5, Newtonsoft.Json 13.0.4, Containers.Tools 1.23.0, AppConfiguration 8.5.0.  
Why: .NET 10 upgrade  
📁 Files: `Biotrackr.Activity.Svc.csproj`, `Biotrackr.Activity.Svc.UnitTests.csproj`, `Biotrackr.Activity.Svc.IntegrationTests.csproj`

**🧹 refactor(Remove transitive packages)**  
What: Removed `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Options` (transitively included), and unused `Microsoft.AspNetCore.Mvc.Testing`.  
Why: Avoid NU1510 warnings; Mvc.Testing was unused in this worker service project.  
📁 Files: `Biotrackr.Activity.Svc.csproj`, `Biotrackr.Activity.Svc.IntegrationTests.csproj`

**🧹 refactor(Program.cs top-level statements)**  
What: Converted `Program.cs` from `[ExcludeFromCodeCoverage] internal class Program` wrapper to top-level statements. Fixed CosmosClient nullable overload resolution.  
Why: Matches .NET 10 conventions; removes unnecessary code coverage exclusion wrapper.  
📁 Files: `Program.cs`

**🔧 config(Dockerfile & CI)**  
What: Updated Dockerfile to `runtime:10.0`/`sdk:10.0`. Updated workflow to `DOTNET_VERSION: 10.0.x` with `runsettings-path`.  
Why: Target .NET 10 runtime and SDK for builds and deployments.  
📁 Files: `Dockerfile`, `deploy-activity-service.yml`

**🔧 config(coverage.runsettings)**  
What: Added `coverage.runsettings` at solution root for coverlet `ExcludeByAttribute` support.  
Why: Consistent coverage configuration across all upgraded projects.  
📁 Files: `coverage.runsettings` (new)

## 🙏 Additional Context

- All **72 unit tests** pass locally on .NET 10
- All **8 contract tests** pass locally (no Cosmos emulator required)
- E2E tests require Cosmos DB emulator (x64 only) — must be verified in CI
- `Microsoft.Extensions.Hosting` must remain explicit for Worker SDK (unlike Web SDK)