### PR TITLE
Upgrade remaining services (Food.Svc, Sleep.Svc, Weight.Svc, Auth.Svc) to .NET 10

### DIFF
--- a/.github/workflows/deploy-auth-service.yml
+++ b/.github/workflows/deploy-auth-service.yml
@@ -16,7 +16,7 @@ permissions:
     checks: write
 
 env:
-  DOTNET_VERSION: 9.0.x
+  DOTNET_VERSION: 10.0.x
 
 jobs:
   env-setup:
@@ -37,6 +37,7 @@ jobs:
       with:
         dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
         working-directory: ./src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.UnitTests
+        runsettings-path: ../coverage.runsettings
 
   run-contract-tests:
       name: Run Contract Tests

--- a/.github/workflows/deploy-food-service.yml
+++ b/.github/workflows/deploy-food-service.yml
@@ -15,7 +15,7 @@ permissions:
     checks: write  # Required for dorny/test-reporter@v2
 
 env:
-  DOTNET_VERSION: 9.0.x
+  DOTNET_VERSION: 10.0.x
   COVERAGE_PATH: ${{ github.workspace }}/coverage
 
 jobs:
@@ -41,6 +41,7 @@ jobs:
           working-directory: ./src/Biotrackr.Food.Svc/Biotrackr.Food.Svc.UnitTests
           coverage-threshold: 70
           fail-below-threshold: false
+          runsettings-path: ../coverage.runsettings
 
     run-contract-tests:
         name: Run Contract Tests

--- a/.github/workflows/deploy-sleep-service.yml
+++ b/.github/workflows/deploy-sleep-service.yml
@@ -16,7 +16,7 @@ permissions:
     checks: write  # Required for dorny/test-reporter@v2
 
 env:
-  DOTNET_VERSION: 9.0.x
+  DOTNET_VERSION: 10.0.x
 
 jobs:
     env-setup:
@@ -37,6 +37,7 @@ jobs:
         with:
           dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
           working-directory: ./src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests
+          runsettings-path: ../coverage.runsettings
 
     run-contract-tests:
         name: Run Contract Tests

--- a/.github/workflows/deploy-weight-service.yml
+++ b/.github/workflows/deploy-weight-service.yml
@@ -16,7 +16,7 @@ permissions:
     checks: write
 
 env:
-  DOTNET_VERSION: 9.0.x
+  DOTNET_VERSION: 10.0.x
 
 jobs:
     env-setup:
@@ -37,6 +37,7 @@ jobs:
         with:
           dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
           working-directory: ./src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.UnitTests
+          runsettings-path: ../coverage.runsettings
 
     run-contract-tests:
         name: Run Contract Tests

--- a/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.IntegrationTests/Biotrackr.Auth.Svc.IntegrationTests.csproj
+++ b/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.IntegrationTests/Biotrackr.Auth.Svc.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -10,17 +10,16 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Azure.Identity" Version="1.14.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.UnitTests/Biotrackr.Auth.Svc.UnitTests.csproj
+++ b/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.UnitTests/Biotrackr.Auth.Svc.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,18 +11,16 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.4.0" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="ILogger.Moq" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.csproj
+++ b/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Biotrackr.Auth.Svc-6c188595-c6ba-499b-a3d4-8d176d07aa25</UserSecretsId>
@@ -9,13 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
   </ItemGroup>
 </Project>

--- a/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc/Program.cs
+++ b/src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc/Program.cs
@@ -1,16 +1,10 @@
-using System.Diagnostics.CodeAnalysis;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using Biotrackr.Auth.Svc;
 using Biotrackr.Auth.Svc.Services;
 using Biotrackr.Auth.Svc.Services.Interfaces;
 
-[ExcludeFromCodeCoverage]
-internal class Program
-{
-    private static void Main(string[] args)
-    {
-        IHost host = Host.CreateDefaultBuilder(args)
+IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureAppConfiguration(config =>
     {
         config.AddEnvironmentVariables();
@@ -23,7 +17,7 @@ internal class Program
             ManagedIdentityClientId = context.Configuration["managedidentityclientid"]
         };
 
-        services.AddSingleton(new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential(defaultCredentialOptions)));
+        services.AddSingleton(new SecretClient(new Uri(keyVaultUrl!), new DefaultAzureCredential(defaultCredentialOptions)));
 
         services.AddHttpClient<IRefreshTokenService, RefreshTokenService>()
             .AddStandardResilienceHandler();
@@ -37,6 +31,4 @@ internal class Program
     })
     .Build();
 
-        host.Run();
-    }
-}
+host.Run();

--- a/src/Biotrackr.Auth.Svc/Dockerfile
+++ b/src/Biotrackr.Auth.Svc/Dockerfile
@@ -1,13 +1,13 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS base
 USER $APP_UID
 WORKDIR /app
 
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.csproj", "Biotrackr.Auth.Svc/"]

--- a/src/Biotrackr.Auth.Svc/coverage.runsettings
+++ b/src/Biotrackr.Auth.Svc/coverage.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Coverage exclusion settings for .NET 10 projects.
+  
+  Excludes code marked with [ExcludeFromCodeCoverage] from coverage instrumentation.
+  Place this file at the solution root and pass it via:
+    dotnet test - -settings ../coverage.runsettings
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/Biotrackr.Auth.Svc/coverage.runsettings
+++ b/src/Biotrackr.Auth.Svc/coverage.runsettings
@@ -12,6 +12,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+          <ExcludeByFile>**/Program.cs</ExcludeByFile>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/src/Biotrackr.Food.Svc/Biotrackr.Food.Svc.IntegrationTests/Biotrackr.Food.Svc.IntegrationTests.csproj
+++ b/src/Biotrackr.Food.Svc/Biotrackr.Food.Svc.IntegrationTests/Biotrackr.Food.Svc.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,15 +9,14 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Azure.Identity" Version="1.14.2" />
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="FluentAssertions" Version="8.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Biotrackr.Food.Svc/Biotrackr.Food.Svc.UnitTests/Biotrackr.Food.Svc.UnitTests.csproj
+++ b/src/Biotrackr.Food.Svc/Biotrackr.Food.Svc.UnitTests/Biotrackr.Food.Svc.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,25 +9,25 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Azure.Identity" Version="1.14.2" />
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="ILogger.Moq" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
     <PackageReference Include="OpenTelemetry" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Biotrackr.Food.Svc/Biotrackr.Food.Svc/Biotrackr.Food.Svc.csproj
+++ b/src/Biotrackr.Food.Svc/Biotrackr.Food.Svc/Biotrackr.Food.Svc.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>dotnet-Biotrackr.Food.Svc-962f5121-cddd-49ae-afbf-540af42178ae</UserSecretsId>
@@ -10,17 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.14.2" />
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.8" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
   </ItemGroup>
 

--- a/src/Biotrackr.Food.Svc/Biotrackr.Food.Svc/Program.cs
+++ b/src/Biotrackr.Food.Svc/Biotrackr.Food.Svc/Program.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Security.KeyVault.Secrets;
@@ -14,20 +13,15 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
-[ExcludeFromCodeCoverage]
-internal class Program
+var resourceAttributes = new Dictionary<string, object>
 {
-    private static void Main(string[] args)
-    {
-        var resourceAttributes = new Dictionary<string, object>
-        {
-            { "service.name", "Biotrackr.Food.Svc" },
-            { "service.version", "1.0.0" }
-        };
+    { "service.name", "Biotrackr.Food.Svc" },
+    { "service.version", "1.0.0" }
+};
 
-        var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
 
-        IHost host = Host.CreateDefaultBuilder(args)
+IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureAppConfiguration(config =>
     {
         config.AddEnvironmentVariables();
@@ -62,8 +56,8 @@ internal class Program
             }
         };
 
-        services.AddSingleton(new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential(defaultCredentialOptions)));
-        services.AddSingleton(new CosmosClient(cosmosDbEndpoint, new DefaultAzureCredential(defaultCredentialOptions), cosmosClientOptions));
+        services.AddSingleton(new SecretClient(new Uri(keyVaultUrl!), new DefaultAzureCredential(defaultCredentialOptions)));
+        services.AddSingleton(new CosmosClient(cosmosDbEndpoint!, new DefaultAzureCredential(defaultCredentialOptions), cosmosClientOptions));
 
         services.AddScoped<ICosmosRepository, CosmosRepository>();
 
@@ -101,11 +95,8 @@ internal class Program
             {
                 options.ConnectionString = context.Configuration["applicationinsightsconnectionstring"];
             });
-
         });
     })
     .Build();
 
-        host.Run();
-    }
-}
+host.Run();

--- a/src/Biotrackr.Food.Svc/Dockerfile
+++ b/src/Biotrackr.Food.Svc/Dockerfile
@@ -1,13 +1,13 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS base
 USER $APP_UID
 WORKDIR /app
 
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Biotrackr.Food.Svc/Biotrackr.Food.Svc.csproj", "Biotrackr.Food.Svc/"]

--- a/src/Biotrackr.Food.Svc/coverage.runsettings
+++ b/src/Biotrackr.Food.Svc/coverage.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Coverage exclusion settings for .NET 10 projects.
+  
+  Excludes code marked with [ExcludeFromCodeCoverage] from coverage instrumentation.
+  Place this file at the solution root and pass it via:
+    dotnet test - -settings ../coverage.runsettings
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/Biotrackr.Food.Svc/coverage.runsettings
+++ b/src/Biotrackr.Food.Svc/coverage.runsettings
@@ -12,6 +12,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+          <ExcludeByFile>**/Program.cs</ExcludeByFile>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.IntegrationTests/Biotrackr.Sleep.Svc.IntegrationTests.csproj
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.IntegrationTests/Biotrackr.Sleep.Svc.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -10,16 +10,15 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/Biotrackr.Sleep.Svc.UnitTests.csproj
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/Biotrackr.Sleep.Svc.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,16 +11,16 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.4.0" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="ILogger.Moq" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/WorkerTests/SleepWorkerShould.cs
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/WorkerTests/SleepWorkerShould.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.Reflection;
 
 namespace Biotrackr.Sleep.Svc.UnitTests.WorkerTests
 {
@@ -132,9 +133,12 @@ namespace Biotrackr.Sleep.Svc.UnitTests.WorkerTests
                 _mockLogger.Object,
                 _mockAppLifetime.Object);
 
-            // Act
-            await worker.StartAsync(cancellationTokenSource.Token);
-            await Task.Delay(100); // Give time for cleanup
+            // Act — invoke ExecuteAsync directly via reflection to bypass
+            // .NET 10 BackgroundService.StartAsync which skips ExecuteAsync
+            // when the token is already cancelled.
+            var executeMethod = typeof(SleepWorker).GetMethod("ExecuteAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            var task = (Task<int>)executeMethod!.Invoke(worker, new object[] { cancellationTokenSource.Token })!;
+            await task;
 
             // Assert - Should complete without throwing
             _mockAppLifetime.Verify(

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.csproj
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Biotrackr.Sleep.Svc-c15c52f5-97d8-45e7-b032-02ccd5fa7063</UserSecretsId>
@@ -9,18 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
   </ItemGroup>
 </Project>

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Program.cs
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Program.cs
@@ -1,5 +1,3 @@
-// Test coverage implementation complete - triggering CI/CD workflow
-using System.Diagnostics.CodeAnalysis;
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Security.KeyVault.Secrets;
@@ -15,20 +13,15 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
-[ExcludeFromCodeCoverage]
-internal class Program
+var resourceAttributes = new Dictionary<string, object>
 {
-    private static void Main(string[] args)
-    {
-        var resourceAttributes = new Dictionary<string, object>
-        {
-            { "service.name", "Biotrackr.Sleep.Svc" },
-            { "service.version", "1.0.0" }
-        };
+    { "service.name", "Biotrackr.Sleep.Svc" },
+    { "service.version", "1.0.0" }
+};
 
-        var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
 
-        IHost host = Host.CreateDefaultBuilder(args)
+IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureAppConfiguration(config =>
     {
         config.AddEnvironmentVariables();
@@ -63,8 +56,8 @@ internal class Program
             }
         };
 
-        services.AddSingleton(new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential(defaultCredentialOptions)));
-        services.AddSingleton(new CosmosClient(cosmosDbEndpoint, new DefaultAzureCredential(defaultCredentialOptions), cosmosClientOptions));
+        services.AddSingleton(new SecretClient(new Uri(keyVaultUrl!), new DefaultAzureCredential(defaultCredentialOptions)));
+        services.AddSingleton(new CosmosClient(cosmosDbEndpoint!, new DefaultAzureCredential(defaultCredentialOptions), cosmosClientOptions));
 
         services.AddScoped<ICosmosRepository, CosmosRepository>();
 
@@ -102,11 +95,8 @@ internal class Program
             {
                 options.ConnectionString = context.Configuration["applicationinsightsconnectionstring"];
             });
-
         });
     })
     .Build();
 
-        host.Run();
-    }
-}
+host.Run();

--- a/src/Biotrackr.Sleep.Svc/Dockerfile
+++ b/src/Biotrackr.Sleep.Svc/Dockerfile
@@ -1,13 +1,13 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS base
 USER $APP_UID
 WORKDIR /app
 
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.csproj", "Biotrackr.Sleep.Svc/"]

--- a/src/Biotrackr.Sleep.Svc/coverage.runsettings
+++ b/src/Biotrackr.Sleep.Svc/coverage.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Coverage exclusion settings for .NET 10 projects.
+  
+  Excludes code marked with [ExcludeFromCodeCoverage] from coverage instrumentation.
+  Place this file at the solution root and pass it via:
+    dotnet test - -settings ../coverage.runsettings
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/Biotrackr.Sleep.Svc/coverage.runsettings
+++ b/src/Biotrackr.Sleep.Svc/coverage.runsettings
@@ -12,6 +12,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+          <ExcludeByFile>**/Program.cs</ExcludeByFile>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.IntegrationTests/Biotrackr.Weight.Svc.IntegrationTests.csproj
+++ b/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.IntegrationTests/Biotrackr.Weight.Svc.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,18 +9,17 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Azure.Identity" Version="1.14.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.UnitTests/Biotrackr.Weight.Svc.UnitTests.csproj
+++ b/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.UnitTests/Biotrackr.Weight.Svc.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,16 +11,16 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.4.0" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="ILogger.Moq" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.csproj
+++ b/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Biotrackr.Weight.Svc-962f5121-cddd-49ae-afbf-540af42178ae</UserSecretsId>
@@ -9,18 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
   </ItemGroup>
 </Project>

--- a/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc/Program.cs
+++ b/src/Biotrackr.Weight.Svc/Biotrackr.Weight.Svc/Program.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Security.KeyVault.Secrets;
@@ -14,20 +13,15 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
-[ExcludeFromCodeCoverage]
-internal class Program
+var resourceAttributes = new Dictionary<string, object>
 {
-    private static void Main(string[] args)
-    {
-        var resourceAttributes = new Dictionary<string, object>
-        {
-            { "service.name", "Biotrackr.Weight.Svc" },
-            { "service.version", "1.0.0" }
-        };
+    { "service.name", "Biotrackr.Weight.Svc" },
+    { "service.version", "1.0.0" }
+};
 
-        var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
 
-        IHost host = Host.CreateDefaultBuilder(args)
+IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureAppConfiguration(config =>
     {
         config.AddEnvironmentVariables();
@@ -62,8 +56,8 @@ internal class Program
             }
         };
 
-        services.AddSingleton(new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential(defaultCredentialOptions)));
-        services.AddSingleton(new CosmosClient(cosmosDbEndpoint, new DefaultAzureCredential(defaultCredentialOptions), cosmosClientOptions));
+        services.AddSingleton(new SecretClient(new Uri(keyVaultUrl!), new DefaultAzureCredential(defaultCredentialOptions)));
+        services.AddSingleton(new CosmosClient(cosmosDbEndpoint!, new DefaultAzureCredential(defaultCredentialOptions), cosmosClientOptions));
 
         services.AddScoped<ICosmosRepository, CosmosRepository>();
         services.AddScoped<IWeightService, WeightService>();
@@ -100,11 +94,8 @@ internal class Program
             {
                 options.ConnectionString = context.Configuration["applicationinsightsconnectionstring"];
             });
-
         });
     })
     .Build();
 
-        host.Run();
-    }
-}
+host.Run();

--- a/src/Biotrackr.Weight.Svc/Dockerfile
+++ b/src/Biotrackr.Weight.Svc/Dockerfile
@@ -1,13 +1,13 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS base
 USER $APP_UID
 WORKDIR /app
 
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Biotrackr.Weight.Svc/Biotrackr.Weight.Svc.csproj", "Biotrackr.Weight.Svc/"]

--- a/src/Biotrackr.Weight.Svc/coverage.runsettings
+++ b/src/Biotrackr.Weight.Svc/coverage.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Coverage exclusion settings for .NET 10 projects.
+  
+  Excludes code marked with [ExcludeFromCodeCoverage] from coverage instrumentation.
+  Place this file at the solution root and pass it via:
+    dotnet test - -settings ../coverage.runsettings
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/Biotrackr.Weight.Svc/coverage.runsettings
+++ b/src/Biotrackr.Weight.Svc/coverage.runsettings
@@ -12,6 +12,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+          <ExcludeByFile>**/Program.cs</ExcludeByFile>
         </Configuration>
       </DataCollector>
     </DataCollectors>


### PR DESCRIPTION
# 📝 Description

Upgrade the four remaining worker services from .NET 9.0 to .NET 10.0, following the same migration pattern established by the Activity.Svc upgrade.

## 🔗 Related Issues

Reference: `docs/plans/2026-03-07-activity-svc-dotnet10-upgrade.md`

## 🚀 Changes

**🔧 config(Update TFMs and NuGet packages)**  
What: Updated all project files to target `net10.0` and bumped NuGet packages to latest compatible versions  
Why: .NET 10 upgrade  
📁 Files: `*.csproj` across all four services

**🧹 refactor(Convert Program.cs to top-level statements)**  
What: Removed `[ExcludeFromCodeCoverage] internal class Program` wrapper, converted to top-level statements, added null-forgiving operators for CosmosClient/SecretClient  
Why: .NET 10 pattern; source generator auto-generates partial Program class  
📁 Files: `Program.cs` in Food.Svc, Sleep.Svc, Weight.Svc, Auth.Svc

**🧹 refactor(Remove transitively-included packages)**  
What: Removed `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Http.Polly`, `Microsoft.AspNetCore.Mvc.Testing`, `System.Net.Http`, `System.Text.RegularExpressions`  
Why: Transitively included in .NET 10; produces NU1510 warnings. Http.Polly deprecated  
📁 Files: `*.csproj` across services and test projects

**🔧 config(Update Dockerfiles)**  
What: Updated base images from `dotnet/runtime:9.0` / `dotnet/sdk:9.0` to `10.0`  
Why: .NET 10 upgrade  
📁 Files: `Dockerfile` in all four services

**🔧 config(Add coverage.runsettings)**  
What: Created `coverage.runsettings` at each solution root to exclude `[ExcludeFromCodeCoverage]`-attributed code  
Why: Consistent coverage configuration across upgraded projects  
📁 Files: `coverage.runsettings` (new) in Food.Svc, Sleep.Svc, Weight.Svc, Auth.Svc

**🔧 config(Update GitHub Actions workflows)**  
What: Updated `DOTNET_VERSION` to `10.0.x`, added `runsettings-path: ../coverage.runsettings` to unit test jobs  
Why: CI must use .NET 10 SDK and coverage exclusion settings  
📁 Files: `deploy-food-service.yml`, `deploy-sleep-service.yml`, `deploy-weight-service.yml`, `deploy-auth-service.yml`

**🐛 fix(Sleep.Svc cancellation test)**  
What: Updated `ExecuteAsync_ShouldHandleCancellation_Gracefully` to invoke `ExecuteAsync` via reflection instead of `StartAsync`  
Why: .NET 10 `BackgroundService.StartAsync` skips `ExecuteAsync` when token is pre-cancelled  
📁 Files: `SleepWorkerShould.cs`

## ✅ Local Verification

| Service | Build | Unit Tests | Contract Tests |
|---------|-------|-----------|----------------|
| Food.Svc | ✅ 0 errors | ✅ 100 passed | ✅ 7 passed |
| Sleep.Svc | ✅ 0 errors | ✅ 13 passed | ✅ 5 passed |
| Weight.Svc | ✅ 0 errors | ✅ 16 passed | ✅ 6 passed |
| Auth.Svc | ✅ 0 errors | ✅ 19 passed | ✅ 7 passed |