### PR TITLE
docs: Update README to reflect current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # biotrackr
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![.NET](https://img.shields.io/badge/.NET-9.0-purple.svg)](https://dotnet.microsoft.com/)
+[![.NET](https://img.shields.io/badge/.NET-10.0-purple.svg)](https://dotnet.microsoft.com/)
 [![Azure](https://img.shields.io/badge/Azure-Cloud-0078D4.svg)](https://azure.microsoft.com/)
 
 **biotrackr** is a personal health platform that integrates with the Fitbit API to collect, analyze, and provide insights on health and fitness data. The application follows a microservices architecture deployed on Azure, with comprehensive CI/CD pipelines and infrastructure as code.
@@ -11,9 +11,7 @@
 - [Architecture](#-architecture)
 - [Features](#-features)
 - [Tech Stack](#-tech-stack)
-- [Getting Started](#-getting-started)
 - [Build Status](#-build-status)
-- [Documentation](#-documentation)
 - [License](#-license)
 
 ## 🏗️ Architecture
@@ -26,6 +24,7 @@ The application follows a **microservices architecture** with separate services 
 - **Food Service**: Tracks nutrition and food logging data from Fitbit
 - **Auth Service**: Manages authentication and authorization with Fitbit API
 - **MCP Server**: [Model Context Protocol](https://modelcontextprotocol.io/) server exposing all health data as MCP tools for AI assistants
+- **UI**: Blazor Server dashboard for visualizing activity, sleep, weight, and food data
 
 Each service consists of:
 - **API Layer**: RESTful endpoints for data access
@@ -41,13 +40,14 @@ Each service consists of:
 - 🔐 **Secure Authentication**: OAuth integration with Fitbit
 - 📊 **Data Insights**: Analysis and reporting on health metrics
 - 🤖 **MCP Integration**: AI-ready via Model Context Protocol server with 12 tools across all health domains
+- 🖥️ **Web Dashboard**: Blazor Server UI for browsing and visualizing health data
 - ☁️ **Cloud-Native**: Fully deployed on Azure with auto-scaling
 - 🚀 **CI/CD**: Automated testing, deployment, and infrastructure management
 
 ## 🛠️ Tech Stack
 
 ### Backend
-- **.NET 9.0 / 10.0**: Modern C# microservices
+- **.NET 10.0**: Modern C# microservices
 - **Azure Functions**: Serverless compute for background processing
 - **Azure Cosmos DB**: NoSQL database for scalable data storage
 - **Azure App Configuration**: Centralized configuration management
@@ -60,63 +60,17 @@ Each service consists of:
 - **Azure API Management**: API gateway with JWT validation for secure managed identity authentication
 - **ModelContextProtocol SDK**: MCP server with Streamable HTTP transport
 
+### Frontend
+- **Blazor Server**: Interactive server-rendered UI with .NET 10.0
+- **OpenTelemetry**: Distributed tracing and metrics
+
 ### Testing
 - **xUnit**: Unit and integration testing framework
 - **FluentAssertions**: Readable test assertions
 - **Moq**: Mocking framework for unit tests
 - **Cosmos DB Emulator**: Local database testing
 
-## 🚀 Getting Started
-
-### Prerequisites
-
-- [.NET 9.0 SDK](https://dotnet.microsoft.com/download)
-- [Docker Desktop](https://www.docker.com/products/docker-desktop)
-- [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (for deployment)
-- [PowerShell](https://docs.microsoft.com/powershell/scripting/install/installing-powershell) (Windows users)
-
-### Local Development Setup
-
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/willvelida/biotrackr.git
-   cd biotrackr
-   ```
-
-2. **Start Cosmos DB Emulator**
-   
-   **Windows (PowerShell)**:
-   ```powershell
-   .\cosmos-emulator.ps1 start
-   ```
-   
-   **macOS/Linux**:
-   ```bash
-   docker-compose -f docker-compose.cosmos.yml up -d
-   ```
-
-3. **Install SSL Certificate** (Required for local testing)
-   
-   Follow the [Cosmos DB Emulator Setup Guide](docs/cosmos-emulator-setup.md) for platform-specific instructions.
-
-4. **Build a service**
-   ```bash
-   cd src/Biotrackr.Activity.Api
-   dotnet build
-   ```
-
-5. **Run tests**
-   ```bash
-   # Unit tests only
-   dotnet test --filter "FullyQualifiedName~UnitTests"
-   
-   # All tests (requires Cosmos DB Emulator)
-   dotnet test
-   ```
-
-For more detailed setup instructions, see the [Cosmos DB Emulator Setup Guide](docs/cosmos-emulator-setup.md).
-
-## 📊 Build Status
+##  Build Status
 
 | Component | Deployment Status | Unit Test Coverage | Integration Test Coverage |
 | --------- | ----------------- | ------------------ | ------------------------- |
@@ -131,27 +85,9 @@ For more detailed setup instructions, see the [Cosmos DB Emulator Setup Guide](d
 | **Food API** | [![Deploy Food Api](https://github.com/willvelida/biotrackr/actions/workflows/deploy-food-api.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-food-api.yml) | ![Code Coverage](https://img.shields.io/badge/Code%20Coverage-70%25-yellow?style=flat) | ![Integration Tests](https://img.shields.io/badge/Tests-26%20Passing-brightgreen?style=flat) |
 | **Food Service** | [![Deploy Food Service](https://github.com/willvelida/biotrackr/actions/workflows/deploy-food-service.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-food-service.yml) | ![Code Coverage](https://img.shields.io/badge/Code%20Coverage-100%25-brightgreen?style=flat) | ![Integration Tests](https://img.shields.io/badge/Tests-14%20Passing-brightgreen?style=flat) |
 | **MCP Server** | [![Deploy MCP Server](https://github.com/willvelida/biotrackr/actions/workflows/deploy-mcp-server.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-mcp-server.yml) | ![Code Coverage](https://img.shields.io/badge/Code%20Coverage-106%20Tests-brightgreen?style=flat) | ![Integration Tests](https://img.shields.io/badge/Tests-13%20Passing-brightgreen?style=flat) |
+| **UI** | [![Deploy UI](https://github.com/willvelida/biotrackr/actions/workflows/deploy-ui.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-ui.yml) | N/A | N/A |
 
-## 📚 Documentation
-
-### Architecture & Design
-- [GitHub Actions Workflow Templates](docs/github-workflow-templates.md) - Reusable CI/CD workflow patterns
-- [Bicep Modules Structure](docs/bicep-modules-structure.md) - Infrastructure as Code organization
-- [Decision Records](docs/decision-records/) - Architectural Decision Records (ADRs)
-
-### Development Guides
-- [Cosmos DB Emulator Setup](docs/cosmos-emulator-setup.md) - Local database configuration
-- [Contract Test Architecture](docs/decision-records/2025-10-28-contract-test-architecture.md) - Testing strategy
-- [Service Lifetime Registration](docs/decision-records/2025-10-28-service-lifetime-registration.md) - Dependency injection patterns
-
-### Key Decision Records
-- [Backend API Route Structure](docs/decision-records/2025-10-28-backend-api-route-structure.md)
-- [.NET Configuration Format](docs/decision-records/2025-10-28-dotnet-configuration-format.md)
-- [Integration Test Project Structure](docs/decision-records/2025-10-28-integration-test-project-structure.md)
-- [Flaky Test Handling](docs/decision-records/2025-10-28-flaky-test-handling.md)
-- [APIM Managed Identity Authentication](docs/decision-records/2025-11-12-apim-managed-identity-auth.md)
-
-## 📄 License
+##  License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
 


### PR DESCRIPTION
## Summary

Updates the README to reflect the current state of the project.

## Changes

- Updated .NET badge from 9.0 to **10.0** (all services now target `net10.0`)
- Added **Blazor Server UI** to architecture, features, and tech stack sections
- Added new **Frontend** section to tech stack
- Added **UI** row to build status table
- Removed **Getting Started** section (not accepting external contributions)
- Removed **Documentation** section
- Removed **Upgrade Plans** (not committed to remote)