### PR TITLE
fix: Fix OIDC auth failure in purge old images workflow

### DIFF
--- a/.github/workflows/task-purge-old-images.yml
+++ b/.github/workflows/task-purge-old-images.yml
@@ -8,16 +8,13 @@ on:
 permissions:
     contents: read
     id-token: write
-    pull-requests: write
 
 jobs:
     purge:
         runs-on: ubuntu-latest
+        environment: dev
 
         steps:
-            - name: Checkout repository code
-              uses: actions/checkout@v5
-
             - name: Azure login
               uses: azure/login@v2
               with:


### PR DESCRIPTION
## Summary

Fixes the `Purge Old Container Images from ACR` workflow which fails with `Login failed ... Double check if the 'auth-type' is correct` on every scheduled run.

## Root Cause

The workflow uses OIDC federated credentials via `azure/login@v2`. When triggered by `schedule`, the OIDC token subject is `repo:willvelida/biotrackr:ref:refs/heads/main`, which doesn't match any configured federated credential on the Azure app registration. All deploy workflows succeed because they use `environment: dev`, producing the subject `repo:willvelida/biotrackr:environment:dev` which has a matching credential.

## Changes

- Added `environment: dev` to the `purge` job so the OIDC subject matches the existing federated credential
- Removed unused `pull-requests: write` permission (workflow doesn't interact with PRs)
- Removed unnecessary `checkout` step (workflow doesn't use any repo files)

## Related

- Failed run: https://github.com/willvelida/biotrackr/actions/runs/22787322425