### PR TITLE
core(infra): add conversations container and agent identity scripts

### DIFF
--- a/infra/modules/database/serverless-cosmos-db.bicep
+++ b/infra/modules/database/serverless-cosmos-db.bicep
@@ -35,10 +35,12 @@ param logAnalyticsName string
 
 var accountName = 'cosmos-${baseName}-${environment}'
 var databaseName = 'BiotrackrDB'
-var containerName = 'records'
+var recordsContainerName = 'records'
+var conversationsContainerName = 'conversations'
 var cosmosDbEndpointSettingName = 'Biotrackr:CosmosDbEndpoint'
 var cosmosDatabaseSettingName = 'Biotrackr:DatabaseName'
-var containerSettingName = 'Biotrackr:ContainerName'
+var recordsContainerSettingName = 'Biotrackr:ContainerName'
+var conversationsContainerSettingName = 'Biotrackr:ConversationsContainerName'
 var cosmosDbDataContributorRole = '00000000-0000-0000-0000-000000000002'
 
 resource uai 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
@@ -110,12 +112,12 @@ resource databaseConfigSetting 'Microsoft.AppConfiguration/configurationStores/k
   }
 }
 
-resource activityContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
-  name: containerName
+resource recordsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
+  name: recordsContainerName
   parent: database
   properties: {
     resource: {
-      id: containerName
+      id: recordsContainerName
       partitionKey: {
         paths: [
           '/documentType'
@@ -134,11 +136,43 @@ resource activityContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/c
   }
 }
 
-resource activityContainerSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2024-05-01' = {
-  name: containerSettingName
+resource recordsContainerSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2024-05-01' = {
+  name: recordsContainerSettingName
   parent: appConfig
   properties: {
-    value: containerName
+    value: recordsContainerName
+  }
+}
+
+resource conversationsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
+  name: conversationsContainerName
+  parent: database
+  properties: {
+    resource: {
+      id: conversationsContainerName
+      partitionKey: {
+        paths: [
+          '/sessionId'
+        ]
+        kind: 'Hash'
+      }
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        includedPaths: [
+          {
+            path: '/*'
+          }
+        ]
+      }
+    }
+  }
+}
+
+resource conversationsContainerSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2024-05-01' = {
+  name: conversationsContainerSettingName
+  parent: appConfig
+  properties: {
+    value: conversationsContainerName
   }
 }
 

--- a/scripts/ui-chat-api-identity/configure-agent-identity.ps1
+++ b/scripts/ui-chat-api-identity/configure-agent-identity.ps1
@@ -1,5 +1,3 @@
-#Requires -Modules Microsoft.Graph.Beta.Applications, Microsoft.Graph.Beta.Identity.SignIns
-
 <#
 .SYNOPSIS
     Configures the Agent Identity for Biotrackr Chat Agent after infrastructure provisioning.
@@ -199,7 +197,14 @@ Write-Host ""
 
 Write-Host "── Step 3: Cosmos DB Role Assignment ──"
 
-$agentSpObjectId = (az ad sp show --id $agentIdentityId --query id -o tsv 2>$null)
+# Wait for agent identity SP to propagate in Entra ID
+$agentSpObjectId = $null
+for ($i = 1; $i -le 6; $i++) {
+    $agentSpObjectId = (az ad sp show --id $agentIdentityId --query id -o tsv 2>$null)
+    if ($agentSpObjectId) { break }
+    Write-Host "  Waiting for agent identity SP to propagate (attempt $i/6)..."
+    Start-Sleep -Seconds 10
+}
 if (-not $agentSpObjectId) {
     Write-Error "Could not find service principal for agent identity $agentIdentityId."
     exit 1

--- a/scripts/ui-chat-api-identity/configure-agent-identity.ps1
+++ b/scripts/ui-chat-api-identity/configure-agent-identity.ps1
@@ -1,0 +1,233 @@
+#Requires -Modules Microsoft.Graph.Beta.Applications, Microsoft.Graph.Beta.Identity.SignIns
+
+<#
+.SYNOPSIS
+    Configures the Agent Identity for Biotrackr Chat Agent after infrastructure provisioning.
+
+.DESCRIPTION
+    Post-provision script that creates the Federated Identity Credential (FIC), agent identity,
+    and Cosmos DB RBAC assignment. Run this interactively after deploying infrastructure.
+
+    Requires outputs from setup-agent-identity.ps1 and values from provisioned infrastructure.
+
+.PARAMETER TenantId
+    The Entra ID tenant ID.
+
+.PARAMETER AgentBlueprintAppId
+    The appId of the agent identity blueprint (output from setup-agent-identity.ps1).
+
+.PARAMETER AgentBlueprintClientSecret
+    The client secret for the blueprint (output from setup-agent-identity.ps1).
+
+.PARAMETER SponsorUserId
+    The sponsor user's object ID (output from setup-agent-identity.ps1).
+
+.PARAMETER ManagedIdentityPrincipalId
+    The principal ID of the provisioned UAI (uai-biotrackr-dev).
+
+.PARAMETER CosmosDbAccountName
+    The name of the provisioned Cosmos DB account.
+
+.PARAMETER ResourceGroupName
+    The Azure resource group containing Cosmos DB.
+
+.PARAMETER SubscriptionId
+    The Azure subscription ID.
+
+.EXAMPLE
+    .\configure-agent-identity.ps1 `
+        -TenantId "00000000-..." `
+        -AgentBlueprintAppId "00000000-..." `
+        -AgentBlueprintClientSecret "secret" `
+        -SponsorUserId "00000000-..." `
+        -ManagedIdentityPrincipalId "00000000-..." `
+        -CosmosDbAccountName "cosmos-biotrackr-dev" `
+        -ResourceGroupName "rg-biotrackr-dev" `
+        -SubscriptionId "00000000-..."
+#>
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true)]
+    [string] $TenantId,
+
+    [Parameter(Mandatory = $true)]
+    [string] $AgentBlueprintAppId,
+
+    [Parameter(Mandatory = $true)]
+    [string] $AgentBlueprintClientSecret,
+
+    [Parameter(Mandatory = $true)]
+    [string] $SponsorUserId,
+
+    [Parameter(Mandatory = $true)]
+    [string] $ManagedIdentityPrincipalId,
+
+    [Parameter(Mandatory = $true)]
+    [string] $CosmosDbAccountName,
+
+    [Parameter(Mandatory = $true)]
+    [string] $ResourceGroupName,
+
+    [Parameter(Mandatory = $true)]
+    [string] $SubscriptionId
+)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "=== Configure Agent Identity ==="
+Write-Host ""
+
+# Install required modules if not already installed
+if (-not (Get-Module -ListAvailable -Name Microsoft.Graph.Beta.Applications)) {
+    Write-Host "Installing Microsoft.Graph.Beta.Applications module..."
+    Install-Module Microsoft.Graph.Beta.Applications -Scope CurrentUser -Force
+}
+if (-not (Get-Module -ListAvailable -Name Microsoft.Graph.Beta.Identity.SignIns)) {
+    Write-Host "Installing Microsoft.Graph.Beta.Identity.SignIns module..."
+    Install-Module Microsoft.Graph.Beta.Identity.SignIns -Scope CurrentUser -Force
+}
+
+# Connect to Microsoft Graph with required scopes
+Write-Host "Connecting to Microsoft Graph..."
+Connect-MgGraph -Scopes @(
+    "AgentIdentityBlueprint.AddRemoveCreds.All",
+    "Application.ReadWrite.All",
+    "DelegatedPermissionGrant.ReadWrite.All"
+) -TenantId $TenantId -NoWelcome
+
+$mgContext = Get-MgContext
+if (-not $mgContext) {
+    Write-Error "Failed to connect to Microsoft Graph."
+    exit 1
+}
+Write-Host "Connected to Microsoft Graph as $($mgContext.Account)"
+Write-Host ""
+
+# ── Step 1: Federated Identity Credential ────────────────────────────────────
+# Links the UAI (uai-biotrackr-dev) to the blueprint so the Chat Agent API
+# can authenticate as the blueprint using the managed identity's assertion.
+
+Write-Host "── Step 1: Federated Identity Credential ──"
+Write-Host "  Blueprint AppId: $AgentBlueprintAppId"
+Write-Host "  UAI Principal ID (Subject): $ManagedIdentityPrincipalId"
+
+$federatedCredential = @{
+    Name      = "biotrackr-uai"
+    Issuer    = "https://login.microsoftonline.com/$TenantId/v2.0"
+    Subject   = $ManagedIdentityPrincipalId
+    Audiences = @("api://AzureADTokenExchange")
+}
+
+$existing = Get-MgBetaApplicationFederatedIdentityCredential `
+    -ApplicationId $AgentBlueprintAppId `
+    -Filter "name eq 'biotrackr-uai'" `
+    -ErrorAction SilentlyContinue
+
+if ($existing) {
+    Write-Host "  Federated credential already exists, updating..."
+    Update-MgBetaApplicationFederatedIdentityCredential `
+        -ApplicationId $AgentBlueprintAppId `
+        -FederatedIdentityCredentialId $existing.Id `
+        -BodyParameter $federatedCredential
+} else {
+    New-MgBetaApplicationFederatedIdentityCredential `
+        -ApplicationId $AgentBlueprintAppId `
+        -BodyParameter $federatedCredential
+}
+
+Write-Host "  Federated identity credential configured successfully."
+Write-Host ""
+
+# ── Step 2: Create Agent Identity ────────────────────────────────────────────
+# Creates the agent identity using the blueprint's client credentials.
+# This identity will be used by the Chat Agent API to call Cosmos DB.
+
+Write-Host "── Step 2: Agent Identity ──"
+
+# Acquire an access token as the blueprint using client credentials grant
+$tokenBody = @{
+    client_id     = $AgentBlueprintAppId
+    scope         = "https://graph.microsoft.com/.default"
+    client_secret = $AgentBlueprintClientSecret
+    grant_type    = "client_credentials"
+}
+
+$tokenResponse = Invoke-RestMethod -Method POST `
+    -Uri "https://login.microsoftonline.com/$TenantId/oauth2/v2.0/token" `
+    -ContentType "application/x-www-form-urlencoded" `
+    -Body $tokenBody
+
+if (-not $tokenResponse.access_token) {
+    Write-Error "Failed to acquire blueprint access token."
+    exit 1
+}
+
+$blueprintToken = $tokenResponse.access_token
+Write-Host "  Acquired blueprint access token."
+
+$agentBody = @{
+    "@odata.type"             = "#Microsoft.Graph.AgentIdentity"
+    "displayName"             = "biotrackr-chat-agent"
+    "agentIdentityBlueprintId" = $AgentBlueprintAppId
+    "sponsors@odata.bind"     = @("https://graph.microsoft.com/v1.0/users/$SponsorUserId")
+} | ConvertTo-Json -Depth 5
+
+Write-Host "  Creating agent identity with sponsor: $SponsorUserId"
+
+$agentResponse = Invoke-RestMethod -Method POST `
+    -Uri "https://graph.microsoft.com/beta/serviceprincipals/Microsoft.Graph.AgentIdentity" `
+    -Headers @{
+        "Authorization" = "Bearer $blueprintToken"
+        "OData-Version" = "4.0"
+    } `
+    -Body $agentBody `
+    -ContentType "application/json"
+
+$agentIdentityId = $agentResponse.appId
+if (-not $agentIdentityId) {
+    Write-Error "Failed to create agent identity - no appId returned."
+    exit 1
+}
+
+Write-Host "  Agent identity created: $agentIdentityId"
+Write-Host ""
+
+# ── Step 3: Cosmos DB RBAC Role Assignment ───────────────────────────────────
+# Assigns the Cosmos DB Built-in Data Contributor role to the agent identity
+# at account scope (matching the existing sqlRoleAssignment pattern).
+
+Write-Host "── Step 3: Cosmos DB Role Assignment ──"
+
+$agentSpObjectId = (az ad sp show --id $agentIdentityId --query id -o tsv 2>$null)
+if (-not $agentSpObjectId) {
+    Write-Error "Could not find service principal for agent identity $agentIdentityId."
+    exit 1
+}
+
+$cosmosScope = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.DocumentDB/databaseAccounts/$CosmosDbAccountName"
+
+$existingAssignment = az cosmosdb sql role assignment list `
+    --account-name $CosmosDbAccountName `
+    --resource-group $ResourceGroupName `
+    --query "[?principalId=='$agentSpObjectId']" -o json 2>$null | ConvertFrom-Json
+
+if ($existingAssignment -and $existingAssignment.Count -gt 0) {
+    Write-Host "  Cosmos DB role already assigned to agent identity. Skipping."
+} else {
+    Write-Host "  Assigning Cosmos DB Built-in Data Contributor role to agent identity ($agentSpObjectId)..."
+    az cosmosdb sql role assignment create `
+        --account-name $CosmosDbAccountName `
+        --resource-group $ResourceGroupName `
+        --role-definition-id "00000000-0000-0000-0000-000000000002" `
+        --principal-id $agentSpObjectId `
+        --scope $cosmosScope 2>&1 | Out-Null
+    Write-Host "  Cosmos DB role assigned successfully."
+}
+
+Write-Host ""
+Write-Host "=== Configuration complete ==="
+Write-Host ""
+Write-Host "Agent Identity ID: $agentIdentityId"
+Write-Host ""
+Write-Host "Save this value - it will be needed when configuring the Chat Agent API."

--- a/scripts/ui-chat-api-identity/setup-agent-identity.ps1
+++ b/scripts/ui-chat-api-identity/setup-agent-identity.ps1
@@ -1,5 +1,3 @@
-#Requires -Modules Microsoft.Graph.Beta.Applications, Microsoft.Graph.Applications
-
 <#
 .SYNOPSIS
     Creates the Agent Identity Blueprint in Entra ID for Biotrackr Chat Agent.

--- a/scripts/ui-chat-api-identity/setup-agent-identity.ps1
+++ b/scripts/ui-chat-api-identity/setup-agent-identity.ps1
@@ -1,0 +1,136 @@
+#Requires -Modules Microsoft.Graph.Beta.Applications, Microsoft.Graph.Applications
+
+<#
+.SYNOPSIS
+    Creates the Agent Identity Blueprint in Entra ID for Biotrackr Chat Agent.
+
+.DESCRIPTION
+    Pre-provision script that creates an Agent Identity Blueprint via Microsoft Graph beta API.
+    Run this interactively before deploying infrastructure. Copy the output values
+    to pass as parameters to configure-agent-identity.ps1.
+
+.PARAMETER TenantId
+    The Entra ID tenant ID.
+
+.PARAMETER AgentBlueprintPrincipalName
+    Display name for the agent identity blueprint.
+
+.EXAMPLE
+    .\setup-agent-identity.ps1 -TenantId "00000000-0000-0000-0000-000000000000" -AgentBlueprintPrincipalName "Biotrackr Chat Agent"
+#>
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true)]
+    [string] $TenantId,
+
+    [Parameter(Mandatory = $true)]
+    [string] $AgentBlueprintPrincipalName
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Install required modules if not already installed
+if (-not (Get-Module -ListAvailable -Name Microsoft.Graph.Beta.Applications)) {
+    Write-Host "Installing Microsoft.Graph.Beta.Applications module..."
+    Install-Module Microsoft.Graph.Beta.Applications -Scope CurrentUser -Force
+}
+if (-not (Get-Module -ListAvailable -Name Microsoft.Graph.Applications)) {
+    Write-Host "Installing Microsoft.Graph.Applications module..."
+    Install-Module Microsoft.Graph.Applications -Scope CurrentUser -Force
+}
+
+# Connect to Microsoft Graph with required scopes
+$allScopes = @(
+    "AgentIdentityBlueprint.Create",
+    "AgentIdentityBlueprint.AddRemoveCreds.All",
+    "AgentIdentityBlueprint.ReadWrite.All",
+    "AgentIdentityBlueprintPrincipal.Create",
+    "User.Read"
+)
+Connect-MgGraph -Scopes $allScopes -TenantId $TenantId -NoWelcome
+
+# Get current signed-in user (sponsor)
+$user = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/v1.0/me" -OutputType PSObject
+Write-Host "Current user: $($user.displayName) ($($user.id))"
+
+# Step 1: Create the agent identity blueprint
+Write-Host "Creating agent identity blueprint..."
+$body = @{
+    "@odata.type"          = "Microsoft.Graph.AgentIdentityBlueprint"
+    "displayName"          = $AgentBlueprintPrincipalName
+    "sponsors@odata.bind"  = @("https://graph.microsoft.com/v1.0/users/$($user.id)")
+    "owners@odata.bind"    = @("https://graph.microsoft.com/v1.0/users/$($user.id)")
+} | ConvertTo-Json -Depth 5
+
+$response = Invoke-MgGraphRequest `
+    -Method POST `
+    -Uri "https://graph.microsoft.com/beta/applications/graph.agentIdentityBlueprint" `
+    -Body $body `
+    -ContentType "application/json"
+
+$applicationId = $response.appId
+if (-not $applicationId) {
+    Write-Error "Failed to create agent identity blueprint - no appId returned from Graph API."
+    exit 1
+}
+Write-Host "Blueprint appId: $applicationId"
+
+# Step 2: Configure identifier URI and OAuth2 scope (access_agent)
+Write-Host "Configuring identifier URI and access_agent scope..."
+$identifierUri = "api://$applicationId"
+$scopeId = [guid]::NewGuid()
+
+$scope = @{
+    adminConsentDescription = "Allow the application to access the agent on behalf of the signed-in user."
+    adminConsentDisplayName = "Access agent"
+    id                      = $scopeId
+    isEnabled               = $true
+    type                    = "User"
+    value                   = "access_agent"
+}
+
+Update-MgBetaApplication -ApplicationId $applicationId `
+    -IdentifierUris @($identifierUri) `
+    -Api @{ oauth2PermissionScopes = @($scope) }
+
+Write-Host "Configured identifier URI: $identifierUri"
+Write-Host "Created scope 'access_agent' with ID: $scopeId"
+
+# Step 3: Create the agent blueprint principal (service principal)
+Write-Host "Creating agent blueprint principal..."
+$spBody = @{
+    appId = $applicationId
+}
+
+$spResponse = Invoke-MgGraphRequest `
+    -Method POST `
+    -Uri "https://graph.microsoft.com/beta/serviceprincipals/graph.agentIdentityBlueprintPrincipal" `
+    -Headers @{ "OData-Version" = "4.0" } `
+    -Body ($spBody | ConvertTo-Json)
+
+Write-Host "Agent blueprint principal created for appId: $applicationId"
+
+# Step 4: Add a temporary client secret (6-month expiry) for post-provision use
+Write-Host "Creating client secret..."
+$secretResult = Add-MgApplicationPassword -ApplicationId $applicationId `
+    -PasswordCredential @{
+        displayName = "postprovision-setup"
+        endDateTime = (Get-Date).AddMonths(6).ToString("o")
+    }
+
+if (-not $secretResult.SecretText) {
+    Write-Error "Failed to create client secret for blueprint."
+    exit 1
+}
+
+Write-Host "Client secret created (shown only once - copy it now)."
+
+# Output values needed by configure-agent-identity.ps1
+Write-Host ""
+Write-Host "Setup complete. Save the following values for configure-agent-identity.ps1:"
+Write-Host "  -AgentBlueprintAppId       $applicationId"
+Write-Host "  -AgentBlueprintClientSecret $($secretResult.SecretText)"
+Write-Host "  -SponsorUserId             $($user.id)"
+Write-Host ""
+Write-Host "Next: Deploy infrastructure, then run configure-agent-identity.ps1 with the values above."


### PR DESCRIPTION
# 📝 Description

Adds shared infrastructure for the Chat Agent feature: a new Cosmos DB conversations container and local scripts for Entra ID agent identity provisioning.

## 🔗 Related Issues

Part of Chat Agent core infrastructure ([implementation plan](docs/plans/2026-03-08-chat-agent-core-infra-implementation.md))

## 🚀 Changes

**🔧 config(Cosmos DB conversations container)**  
What: Add `conversations` container to Cosmos DB module with `/sessionId` partition key  
Why: Chat Agent API needs a dedicated container for conversation storage  
📁 Files: `serverless-cosmos-db.bicep` (`conversationsContainer`, `conversationsContainerSetting`)

**🧹 refactor(Rename container resources)**  
What: Rename `activityContainer` → `recordsContainer` and `containerName` → `recordsContainerName`  
Why: Clearer naming now that there are multiple containers. No deploy impact — resource names unchanged  
📁 Files: `serverless-cosmos-db.bicep` (`recordsContainer`, `recordsContainerSetting`)

**✨ feat(Agent identity setup script)**  
What: Create `scripts/ui-chat-api-identity/setup-agent-identity.ps1`  
Why: Pre-provision script to create Agent Identity Blueprint in Entra ID via Microsoft Graph beta API  
📁 Files: `setup-agent-identity.ps1`

**✨ feat(Agent identity configure script)**  
What: Create `scripts/ui-chat-api-identity/configure-agent-identity.ps1`  
Why: Post-provision script to create FIC, agent identity, and Cosmos DB RBAC assignment  
📁 Files: `configure-agent-identity.ps1`

## 🙏 Additional Context

- Scripts are run locally (interactive browser auth), not in CI/CD
- Blueprint has been created in Entra ID tenant; configure script runs after infrastructure deploys