### PR TITLE
feat(chat-api): add Biotrackr.Chat.Api service

### DIFF
--- a/.github/workflows/deploy-chat-api.yml
+++ b/.github/workflows/deploy-chat-api.yml
@@ -1,0 +1,152 @@
+name: Deploy Chat Api
+
+on:
+    pull_request:
+        branches:
+            - main
+        paths:
+            - 'infra/apps/chat-api/**'
+            - 'src/Biotrackr.Chat.Api/**'
+
+permissions:
+    contents: read
+    id-token: write
+    pull-requests: write
+    checks: write
+
+env:
+  DOTNET_VERSION: 10.0.x
+
+jobs:
+    env-setup:
+        name: Setup Environment
+        runs-on: ubuntu-latest
+        outputs:
+          dotnet-version: ${{ steps.set-output-defaults.outputs.dotnet-version }}
+        steps:
+          - name: set outputs with default values
+            id: set-output-defaults
+            run: |
+              echo "dotnet-version=${{ env.DOTNET_VERSION }}" >> "$GITHUB_OUTPUT"
+
+    run-unit-tests:
+          name: Run Unit Tests with Coverage
+          needs: env-setup
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-unit-tests.yml@main
+          with:
+            dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
+            working-directory: ./src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests
+            coverage-threshold: 70
+            fail-below-threshold: true
+            runsettings-path: ../coverage.runsettings
+
+    run-contract-tests:
+          name: Run API Contract Tests
+          needs: env-setup
+          uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-contract-tests.yml@main
+          with:
+            dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
+            working-directory: ./src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.IntegrationTests
+            test-filter: 'FullyQualifiedName~Contract'
+
+    build-container-image-dev:
+          name: Build and Push Container Image
+          needs: [run-unit-tests, run-contract-tests]
+          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
+          with:
+            working-directory: ./src/Biotrackr.Chat.Api
+            app-name: biotrackr-chat-api
+          secrets:
+            client-id: ${{ secrets.AZURE_CLIENT_ID }}
+            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+            resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}
+
+    retrieve-container-image-dev:
+        name: Retrieve Container Image
+        needs: build-container-image-dev
+        runs-on: ubuntu-latest
+        outputs:
+          loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
+        steps:
+          - name: Azure login
+            uses: azure/login@v2
+            with:
+              client-id: ${{ secrets.AZURE_CLIENT_ID }}
+              tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+              subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+          - name: Get ACR server
+            id: get-acr-server
+            run: |
+              loginServer=$(az acr list --resource-group ${{ secrets.AZURE_RG_NAME_DEV }} --query "[0].loginServer" -o tsv)
+              echo "loginServer=$loginServer" > "$GITHUB_OUTPUT"
+
+    lint:
+        name: Run Bicep Linter
+        needs: retrieve-container-image-dev
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-linter.yml@main
+        with:
+            template-file: './infra/apps/chat-api/main.bicep'
+
+    validate:
+        name: Validate Template
+        needs: [lint, retrieve-container-image-dev]
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@main
+        with:
+          template-file: './infra/apps/chat-api/main.bicep'
+          parameters-file: ./infra/apps/chat-api/main.dev.bicepparam
+          parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-chat-api:${{ github.sha }}"}'
+          scope: resourceGroup
+          inject-tenant-id: true
+        secrets:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}
+
+    preview:
+        name: Preview Changes
+        needs: [validate, retrieve-container-image-dev]
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@main
+        with:
+          scope: resourceGroup
+          template-file: './infra/apps/chat-api/main.bicep'
+          parameters-file: ./infra/apps/chat-api/main.dev.bicepparam
+          parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-chat-api:${{ github.sha }}"}'
+          inject-tenant-id: true
+        secrets:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}
+
+    deploy-dev:
+        name: Deploy Template to Dev
+        needs: [preview, retrieve-container-image-dev]
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@main
+        with:
+          template-file: './infra/apps/chat-api/main.bicep'
+          parameters-file: ./infra/apps/chat-api/main.dev.bicepparam
+          parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-chat-api:${{ github.sha }}"}'
+          scope: resourceGroup
+          inject-tenant-id: true
+          environment: dev
+        secrets:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}
+
+    run-e2e-tests:
+        name: Run E2E Tests Against Dev
+        needs: [deploy-dev, env-setup]
+        uses: willvelida/biotrackr/.github/workflows/template-dotnet-run-e2e-tests.yml@main
+        with:
+          dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
+          working-directory: ./src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.IntegrationTests
+          test-filter: 'FullyQualifiedName~E2E'
+        secrets:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/infra/apps/chat-api/main.bicep
+++ b/infra/apps/chat-api/main.bicep
@@ -1,0 +1,280 @@
+@description('The name of the Chat Api application')
+param name string
+
+@description('The image that the Chat Api will use')
+param imageName string
+
+@description('The region where the Chat Api will be deployed')
+param location string
+
+@description('The tags that will be applied to the Chat Api')
+param tags object
+
+@description('The name of the Container App Environment that this Chat Api will be deployed to')
+param containerAppEnvironmentName string
+
+@description('The name of the Container Registry that this Chat Api will pull images from')
+param containerRegistryName string
+
+@description('The name of the user-assigned identity that the Chat Api will use')
+param uaiName string
+
+@description('The name of the App Config Store that the Chat Api uses')
+param appConfigName string
+
+@description('The name of the Cosmos DB account that this Chat Api uses')
+param cosmosDbAccountName string
+
+@description('The name of the API Management instance that this Api uses')
+param apimName string
+
+@description('The name of the Key Vault that stores secrets')
+param keyVaultName string
+
+@description('Enable JWT validation for managed identity authentication')
+param enableManagedIdentityAuth bool = true
+
+@description('Azure AD tenant ID for JWT issuer validation')
+param tenantId string
+
+@description('JWT audience to validate (uses default Azure Management API audience)')
+param jwtAudience string = environment().authentication.audiences[0]
+
+@description('The Claude model to use for the chat agent')
+param chatAgentModel string = 'claude-sonnet-4-6'
+
+resource uai 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: uaiName
+}
+
+resource appConfig 'Microsoft.AppConfiguration/configurationStores@2024-05-01' existing = {
+  name: appConfigName
+}
+
+resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' existing = {
+  name: cosmosDbAccountName
+}
+
+resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
+  name: apimName
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+var apiProductName = 'Chat'
+var chatApiEndpointConfigName = 'Biotrackr:ChatApiUrl'
+
+module chatApi '../../modules/host/container-app-http.bicep' = {
+  name: 'chat-api'
+  params: {
+    name: name
+    location: location
+    tags: tags
+    containerAppEnvironmentName: containerAppEnvironmentName
+    containerRegistryName: containerRegistryName
+    imageName: imageName
+    uaiName: uai.name
+    targetPort: 8080
+    healthProbes: [
+      {
+        type: 'Liveness'
+        httpGet: {
+          port: 8080
+          path: '/healthz/liveness'
+        }
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        failureThreshold: 3
+        timeoutSeconds: 1
+      }
+    ]
+    envVariables: [
+      {
+        name: 'azureappconfigendpoint'
+        value: appConfig.properties.endpoint
+      }
+      {
+        name: 'managedidentityclientid'
+        value: uai.properties.clientId
+      }
+      {
+        name: 'cosmosdbendpoint'
+        value: cosmosDbAccount.properties.documentEndpoint
+      }
+    ]
+  }
+}
+
+// APIM API definition
+resource chatApimApi 'Microsoft.ApiManagement/service/apis@2024-06-01-preview' = {
+  name: 'chat'
+  parent: apim
+  properties: {
+    path: 'chat'
+    displayName: 'Chat API'
+    description: 'Endpoints for Biotrackr Chat Agent API'
+    subscriptionRequired: true
+    protocols: [
+      'https'
+    ]
+    serviceUrl: 'https://${chatApi.outputs.fqdn}'
+  }
+}
+
+// APIM Named Values for JWT validation
+module chatApiNamedValues '../../modules/apim/apim-named-values.bicep' = {
+  name: 'chat-api-named-values'
+  params: {
+    apimName: apim.name
+    tenantId: tenantId
+    jwtAudience: jwtAudience
+    enableManagedIdentityAuth: enableManagedIdentityAuth
+  }
+}
+
+// APIM JWT auth policy
+resource chatApiPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-06-01-preview' = {
+  name: 'policy'
+  parent: chatApimApi
+  properties: {
+    value: enableManagedIdentityAuth
+      ? loadTextContent('policy-jwt-auth.xml')
+      : loadTextContent('policy-subscription-key.xml')
+    format: 'xml'
+  }
+  dependsOn: [
+    chatApiNamedValues
+  ]
+}
+
+// APIM Operations
+resource chatApiPost 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  name: 'chat-post'
+  parent: chatApimApi
+  properties: {
+    displayName: 'SendChatMessage'
+    method: 'POST'
+    urlTemplate: '/'
+    description: 'Send a chat message to the AI agent via AG-UI protocol (SSE streaming response)'
+  }
+}
+
+resource chatApiGetConversations 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  name: 'chat-getconversations'
+  parent: chatApimApi
+  properties: {
+    displayName: 'GetConversations'
+    method: 'GET'
+    urlTemplate: '/conversations'
+    description: 'Get all conversations with pagination'
+    request: {
+      queryParameters: [
+        {
+          name: 'pageNumber'
+          description: 'The page number to retrieve (default: 1)'
+          type: 'integer'
+          required: false
+          defaultValue: '1'
+          values: []
+        }
+        {
+          name: 'pageSize'
+          description: 'The number of items per page (default: 20, max: 100)'
+          type: 'integer'
+          required: false
+          defaultValue: '20'
+          values: []
+        }
+      ]
+    }
+  }
+}
+
+resource chatApiGetConversation 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  name: 'chat-getconversation'
+  parent: chatApimApi
+  properties: {
+    displayName: 'GetConversation'
+    method: 'GET'
+    urlTemplate: '/conversations/{sessionId}'
+    description: 'Get a specific conversation by session ID'
+    templateParameters: [
+      {
+        name: 'sessionId'
+        description: 'The session ID of the conversation'
+        type: 'string'
+        required: true
+      }
+    ]
+  }
+}
+
+resource chatApiDeleteConversation 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  name: 'chat-deleteconversation'
+  parent: chatApimApi
+  properties: {
+    displayName: 'DeleteConversation'
+    method: 'DELETE'
+    urlTemplate: '/conversations/{sessionId}'
+    description: 'Delete a conversation by session ID'
+    templateParameters: [
+      {
+        name: 'sessionId'
+        description: 'The session ID of the conversation to delete'
+        type: 'string'
+        required: true
+      }
+    ]
+  }
+}
+
+resource chatApiHealthCheck 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  name: 'chat-healthcheck'
+  parent: chatApimApi
+  properties: {
+    displayName: 'LivenessCheck'
+    method: 'GET'
+    urlTemplate: '/healthz/liveness'
+    description: 'Liveness Health Check Endpoint'
+  }
+}
+
+// APIM Product
+module chatApiProduct '../../modules/apim/apim-products.bicep' = {
+  name: 'chat-product'
+  params: {
+    apimName: apim.name
+    productName: apiProductName
+    apiName: chatApimApi.name
+  }
+}
+
+// App Configuration: Chat API endpoint URL
+resource chatApiEndpointSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2025-02-01-preview' = {
+  name: chatApiEndpointConfigName
+  parent: appConfig
+  properties: {
+    value: '${apim.properties.gatewayUrl}/chat'
+  }
+}
+
+// App Configuration: Chat Agent Model
+resource chatAgentModelSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2025-02-01-preview' = {
+  name: 'Biotrackr:ChatAgentModel'
+  parent: appConfig
+  properties: {
+    value: chatAgentModel
+  }
+}
+
+// App Configuration: Anthropic API Key (Key Vault reference)
+resource anthropicApiKeySetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2025-02-01-preview' = {
+  name: 'Biotrackr:AnthropicApiKey'
+  parent: appConfig
+  properties: {
+    contentType: 'application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8'
+    value: '{"uri":"${keyVault.properties.vaultUri}secrets/AnthropicApiKey"}'
+  }
+}

--- a/infra/apps/chat-api/main.dev.bicepparam
+++ b/infra/apps/chat-api/main.dev.bicepparam
@@ -1,0 +1,20 @@
+using 'main.bicep'
+
+param name = 'biotrackr-chat-api-dev'
+param imageName = 'mcr.microsoft.com/k8se/quickstart:latest'
+param location = 'australiaeast'
+param tags = {
+  ApplicationName: 'Biotrackr'
+  Component: 'Chat-Api'
+  Environment: 'Dev'
+}
+param containerAppEnvironmentName = 'env-biotrackr-dev'
+param containerRegistryName = 'acrbiotrackrdev'
+param uaiName = 'uai-biotrackr-dev'
+param appConfigName = 'config-biotrackr-dev'
+param cosmosDbAccountName = 'cosmos-biotrackr-dev'
+param apimName = 'api-biotrackr-dev'
+param keyVaultName = 'kv-biotrackr-dev'
+param enableManagedIdentityAuth = true
+param tenantId = ''
+param chatAgentModel = 'claude-sonnet-4-6'

--- a/infra/apps/chat-api/policy-jwt-auth.xml
+++ b/infra/apps/chat-api/policy-jwt-auth.xml
@@ -1,0 +1,30 @@
+<policies>
+  <inbound>
+    <base />
+    <choose>
+      <when condition="@(context.Request.Headers.GetValueOrDefault(&quot;Authorization&quot;,&quot;&quot;).StartsWith(&quot;Bearer &quot;))">
+        <validate-jwt header-name="Authorization" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized: Invalid or missing JWT token">
+          <openid-config url="{{openid-config-url}}" />
+          <audiences>
+            <audience>{{jwt-audience}}</audience>
+          </audiences>
+          <issuers>
+            <issuer>{{jwt-issuer}}</issuer>
+          </issuers>
+        </validate-jwt>
+      </when>
+      <otherwise>
+        <check-header name="Ocp-Apim-Subscription-Key" failed-check-httpcode="401" failed-check-error-message="Unauthorized: Missing or invalid subscription key" />
+      </otherwise>
+    </choose>
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/infra/apps/chat-api/policy-subscription-key.xml
+++ b/infra/apps/chat-api/policy-subscription-key.xml
@@ -1,0 +1,15 @@
+<policies>
+  <inbound>
+    <base />
+    <check-header name="Ocp-Apim-Subscription-Key" failed-check-httpcode="401" failed-check-error-message="Unauthorized: Missing or invalid subscription key" />
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.IntegrationTests/Biotrackr.Chat.Api.IntegrationTests.csproj
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.IntegrationTests/Biotrackr.Chat.Api.IntegrationTests.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Biotrackr.Chat.Api\Biotrackr.Chat.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.IntegrationTests/Contract/ApiSmokeTests.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.IntegrationTests/Contract/ApiSmokeTests.cs
@@ -1,0 +1,42 @@
+using Biotrackr.Chat.Api.IntegrationTests.Fixtures;
+using FluentAssertions;
+using System.Net;
+
+namespace Biotrackr.Chat.Api.IntegrationTests.Contract;
+
+/// <summary>
+/// Smoke tests that verify the API starts up correctly and endpoints are registered.
+/// These tests do NOT require a running Cosmos DB emulator — they only verify
+/// that the application builds, DI resolves, and routes are mapped.
+/// </summary>
+public class ApiSmokeTests : IClassFixture<ChatApiWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public ApiSmokeTests(ChatApiWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task HealthCheck_ShouldReturn200()
+    {
+        // Act
+        var response = await _client.GetAsync("/healthz/liveness");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task OpenApi_ShouldReturn200()
+    {
+        // Act
+        var response = await _client.GetAsync("/openapi/v1.json");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("GetConversations");
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.IntegrationTests/Fixtures/ChatApiWebApplicationFactory.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.IntegrationTests/Fixtures/ChatApiWebApplicationFactory.cs
@@ -1,0 +1,60 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Biotrackr.Chat.Api.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Custom WebApplicationFactory for integration testing.
+/// Overrides Cosmos DB with local emulator and sets empty config values
+/// so Program.cs skips Azure App Configuration.
+/// </summary>
+public class ChatApiWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // Set environment variables before host builds
+        Environment.SetEnvironmentVariable("cosmosdbendpoint", "https://localhost:8081");
+        Environment.SetEnvironmentVariable("Biotrackr:DatabaseName", "biotrackr-test");
+        Environment.SetEnvironmentVariable("Biotrackr:ConversationsContainerName", "conversations-test");
+        Environment.SetEnvironmentVariable("Biotrackr:ApiBaseUrl", "https://localhost:9999");
+        Environment.SetEnvironmentVariable("Biotrackr:AnthropicApiKey", "test-key");
+        Environment.SetEnvironmentVariable("Biotrackr:ChatAgentModel", "claude-haiku-4-5");
+        Environment.SetEnvironmentVariable("Biotrackr:ChatSystemPrompt", "You are a test assistant.");
+        Environment.SetEnvironmentVariable("azureappconfigendpoint", string.Empty);
+        Environment.SetEnvironmentVariable("managedidentityclientid", string.Empty);
+
+        builder.UseEnvironment("Test");
+
+        builder.ConfigureServices(services =>
+        {
+            // Remove existing Cosmos Client registration
+            var cosmosDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(CosmosClient));
+            if (cosmosDescriptor != null)
+            {
+                services.Remove(cosmosDescriptor);
+            }
+
+            // Register Cosmos Client with local emulator
+            services.AddSingleton<CosmosClient>(sp =>
+            {
+                return new CosmosClient(
+                    "https://localhost:8081",
+                    "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+                    new CosmosClientOptions
+                    {
+                        ConnectionMode = ConnectionMode.Gateway,
+                        SerializerOptions = new CosmosSerializationOptions
+                        {
+                            PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+                        },
+                        HttpClientFactory = () => new HttpClient(new HttpClientHandler
+                        {
+                            ServerCertificateCustomValidationCallback = (_, _, _, _) => true
+                        })
+                    });
+            });
+        });
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Biotrackr.Chat.Api.UnitTests.csproj
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Biotrackr.Chat.Api.UnitTests.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="ILogger.Moq" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Biotrackr.Chat.Api\Biotrackr.Chat.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Handlers/ChatHandlersShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Handlers/ChatHandlersShould.cs
@@ -1,0 +1,120 @@
+using AutoFixture;
+using Biotrackr.Chat.Api.Handlers;
+using Biotrackr.Chat.Api.Models;
+using Biotrackr.Chat.Api.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+
+namespace Biotrackr.Chat.Api.UnitTests.Handlers
+{
+    public class ChatHandlersShould
+    {
+        private readonly Mock<IChatHistoryRepository> _repositoryMock;
+
+        public ChatHandlersShould()
+        {
+            _repositoryMock = new Mock<IChatHistoryRepository>();
+        }
+
+        [Fact]
+        public async Task GetConversations_ShouldReturnPaginatedResult()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var summaries = fixture.CreateMany<ChatConversationSummary>(5).ToList();
+            var paginatedResponse = new PaginationResponse<ChatConversationSummary>
+            {
+                Items = summaries,
+                PageNumber = 1,
+                PageSize = 20,
+                TotalCount = 5
+            };
+
+            _repositoryMock.Setup(x => x.GetConversationsAsync(It.IsAny<PaginationRequest>()))
+                .ReturnsAsync(paginatedResponse);
+
+            // Act
+            var result = await ChatHandlers.GetConversations(_repositoryMock.Object, 1, 20);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<ChatConversationSummary>>>();
+            var okResult = result as Ok<PaginationResponse<ChatConversationSummary>>;
+            okResult!.Value!.Items.Should().HaveCount(5);
+        }
+
+        [Fact]
+        public async Task GetConversations_ShouldUseDefaults_WhenNoParametersProvided()
+        {
+            // Arrange
+            var paginatedResponse = new PaginationResponse<ChatConversationSummary>
+            {
+                Items = [],
+                PageNumber = 1,
+                PageSize = 20,
+                TotalCount = 0
+            };
+
+            _repositoryMock.Setup(x => x.GetConversationsAsync(
+                It.Is<PaginationRequest>(r => r.PageNumber == 1 && r.PageSize == 20)))
+                .ReturnsAsync(paginatedResponse);
+
+            // Act
+            var result = await ChatHandlers.GetConversations(_repositoryMock.Object, null, null);
+
+            // Assert
+            result.Should().BeOfType<Ok<PaginationResponse<ChatConversationSummary>>>();
+            _repositoryMock.Verify(x => x.GetConversationsAsync(
+                It.Is<PaginationRequest>(r => r.PageNumber == 1 && r.PageSize == 20)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetConversation_ShouldReturnOk_WhenConversationIsFound()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var conversation = fixture.Create<ChatConversationDocument>();
+            var sessionId = conversation.SessionId;
+
+            _repositoryMock.Setup(x => x.GetConversationAsync(sessionId))
+                .ReturnsAsync(conversation);
+
+            // Act
+            var result = await ChatHandlers.GetConversation(_repositoryMock.Object, sessionId);
+
+            // Assert
+            result.Result.Should().BeOfType<Ok<ChatConversationDocument>>();
+        }
+
+        [Fact]
+        public async Task GetConversation_ShouldReturnNotFound_WhenConversationDoesNotExist()
+        {
+            // Arrange
+            var sessionId = "nonexistent-session";
+            _repositoryMock.Setup(x => x.GetConversationAsync(sessionId))
+                .ReturnsAsync((ChatConversationDocument?)null);
+
+            // Act
+            var result = await ChatHandlers.GetConversation(_repositoryMock.Object, sessionId);
+
+            // Assert
+            result.Result.Should().BeOfType<NotFound>();
+        }
+
+        [Fact]
+        public async Task DeleteConversation_ShouldReturnNoContent()
+        {
+            // Arrange
+            var sessionId = "session-to-delete";
+            _repositoryMock.Setup(x => x.DeleteConversationAsync(sessionId))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await ChatHandlers.DeleteConversation(_repositoryMock.Object, sessionId);
+
+            // Assert
+            result.Should().BeOfType<NoContent>();
+            _repositoryMock.Verify(x => x.DeleteConversationAsync(sessionId), Times.Once);
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Services/ChatHistoryRepositoryShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Services/ChatHistoryRepositoryShould.cs
@@ -1,0 +1,256 @@
+using AutoFixture;
+using Biotrackr.Chat.Api.Configuration;
+using Biotrackr.Chat.Api.Models;
+using Biotrackr.Chat.Api.Services;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Net;
+
+namespace Biotrackr.Chat.Api.UnitTests.Services
+{
+    public class ChatHistoryRepositoryShould
+    {
+        private readonly Mock<CosmosClient> _cosmosClientMock;
+        private readonly Mock<Container> _containerMock;
+        private readonly Mock<ILogger<ChatHistoryRepository>> _loggerMock;
+        private readonly ChatHistoryRepository _sut;
+
+        public ChatHistoryRepositoryShould()
+        {
+            _cosmosClientMock = new Mock<CosmosClient>();
+            _containerMock = new Mock<Container>();
+            _loggerMock = new Mock<ILogger<ChatHistoryRepository>>();
+
+            var settings = new Settings
+            {
+                DatabaseName = "test-db",
+                ConversationsContainerName = "conversations"
+            };
+            var options = Options.Create(settings);
+
+            _cosmosClientMock.Setup(x => x.GetContainer("test-db", "conversations"))
+                .Returns(_containerMock.Object);
+
+            _sut = new ChatHistoryRepository(_cosmosClientMock.Object, options, _loggerMock.Object);
+        }
+
+        [Fact]
+        public async Task GetConversationAsync_ShouldReturnDocument_WhenFound()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var conversation = fixture.Create<ChatConversationDocument>();
+            var sessionId = conversation.SessionId;
+
+            var responseMock = new Mock<ItemResponse<ChatConversationDocument>>();
+            responseMock.Setup(x => x.Resource).Returns(conversation);
+
+            _containerMock.Setup(x => x.ReadItemAsync<ChatConversationDocument>(
+                sessionId, new PartitionKey(sessionId), null, default))
+                .ReturnsAsync(responseMock.Object);
+
+            // Act
+            var result = await _sut.GetConversationAsync(sessionId);
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.SessionId.Should().Be(sessionId);
+        }
+
+        [Fact]
+        public async Task GetConversationAsync_ShouldReturnNull_WhenNotFound()
+        {
+            // Arrange
+            var sessionId = "nonexistent";
+            _containerMock.Setup(x => x.ReadItemAsync<ChatConversationDocument>(
+                sessionId, new PartitionKey(sessionId), null, default))
+                .ThrowsAsync(new CosmosException("Not found", HttpStatusCode.NotFound, 0, "", 0));
+
+            // Act
+            var result = await _sut.GetConversationAsync(sessionId);
+
+            // Assert
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GetConversationsAsync_ShouldReturnPaginatedResults()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var summaries = fixture.CreateMany<ChatConversationSummary>(3).ToList();
+            var pagination = new PaginationRequest { PageNumber = 1, PageSize = 20 };
+
+            // Mock count query
+            var countFeedResponse = new Mock<FeedResponse<int>>();
+            countFeedResponse.Setup(x => x.GetEnumerator()).Returns(new List<int> { 3 }.GetEnumerator());
+
+            var countIterator = new Mock<FeedIterator<int>>();
+            countIterator.SetupSequence(x => x.HasMoreResults).Returns(true).Returns(false);
+            countIterator.Setup(x => x.ReadNextAsync(default)).ReturnsAsync(countFeedResponse.Object);
+
+            _containerMock.Setup(x => x.GetItemQueryIterator<int>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("COUNT")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Returns(countIterator.Object);
+
+            // Mock data query
+            var dataFeedResponse = new Mock<FeedResponse<ChatConversationSummary>>();
+            dataFeedResponse.Setup(x => x.GetEnumerator()).Returns(summaries.GetEnumerator());
+
+            var dataIterator = new Mock<FeedIterator<ChatConversationSummary>>();
+            dataIterator.SetupSequence(x => x.HasMoreResults).Returns(true).Returns(false);
+            dataIterator.Setup(x => x.ReadNextAsync(default)).ReturnsAsync(dataFeedResponse.Object);
+
+            _containerMock.Setup(x => x.GetItemQueryIterator<ChatConversationSummary>(
+                It.Is<QueryDefinition>(q => q.QueryText.Contains("OFFSET")),
+                It.IsAny<string>(),
+                It.IsAny<QueryRequestOptions>()))
+                .Returns(dataIterator.Object);
+
+            // Act
+            var result = await _sut.GetConversationsAsync(pagination);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Items.Should().HaveCount(3);
+            result.TotalCount.Should().Be(3);
+            result.PageNumber.Should().Be(1);
+            result.PageSize.Should().Be(20);
+        }
+
+        [Fact]
+        public async Task DeleteConversationAsync_ShouldCallDeleteItem()
+        {
+            // Arrange
+            var sessionId = "session-to-delete";
+            var responseMock = new Mock<ItemResponse<ChatConversationDocument>>();
+
+            _containerMock.Setup(x => x.DeleteItemAsync<ChatConversationDocument>(
+                sessionId, new PartitionKey(sessionId), null, default))
+                .ReturnsAsync(responseMock.Object);
+
+            // Act
+            await _sut.DeleteConversationAsync(sessionId);
+
+            // Assert
+            _containerMock.Verify(x => x.DeleteItemAsync<ChatConversationDocument>(
+                sessionId, new PartitionKey(sessionId), null, default), Times.Once);
+        }
+
+        [Fact]
+        public async Task SaveMessageAsync_ShouldCreateNewConversation_WhenNotFound()
+        {
+            // Arrange
+            var sessionId = "new-session";
+            _containerMock.Setup(x => x.ReadItemAsync<ChatConversationDocument>(
+                sessionId, new PartitionKey(sessionId), null, default))
+                .ThrowsAsync(new CosmosException("Not found", HttpStatusCode.NotFound, 0, "", 0));
+
+            var responseMock = new Mock<ItemResponse<ChatConversationDocument>>();
+            _containerMock.Setup(x => x.UpsertItemAsync(
+                It.IsAny<ChatConversationDocument>(),
+                It.IsAny<PartitionKey>(),
+                null, default))
+                .ReturnsAsync(responseMock.Object);
+
+            // Act
+            var result = await _sut.SaveMessageAsync(sessionId, "user", "Hello");
+
+            // Assert
+            result.Should().NotBeNull();
+            result.SessionId.Should().Be(sessionId);
+            result.Messages.Should().HaveCount(1);
+            result.Messages[0].Role.Should().Be("user");
+            result.Messages[0].Content.Should().Be("Hello");
+        }
+
+        [Fact]
+        public async Task SaveMessageAsync_ShouldAutoTitle_FromFirstUserMessage()
+        {
+            // Arrange
+            var sessionId = "new-session";
+            _containerMock.Setup(x => x.ReadItemAsync<ChatConversationDocument>(
+                sessionId, new PartitionKey(sessionId), null, default))
+                .ThrowsAsync(new CosmosException("Not found", HttpStatusCode.NotFound, 0, "", 0));
+
+            var responseMock = new Mock<ItemResponse<ChatConversationDocument>>();
+            _containerMock.Setup(x => x.UpsertItemAsync(
+                It.IsAny<ChatConversationDocument>(),
+                It.IsAny<PartitionKey>(),
+                null, default))
+                .ReturnsAsync(responseMock.Object);
+
+            // Act
+            var result = await _sut.SaveMessageAsync(sessionId, "user", "What were my steps yesterday?");
+
+            // Assert
+            result.Title.Should().Be("What were my steps yesterday?");
+        }
+
+        [Fact]
+        public async Task SaveMessageAsync_ShouldTruncateTitle_WhenMessageIsLong()
+        {
+            // Arrange
+            var sessionId = "new-session";
+            var longMessage = new string('a', 100);
+            _containerMock.Setup(x => x.ReadItemAsync<ChatConversationDocument>(
+                sessionId, new PartitionKey(sessionId), null, default))
+                .ThrowsAsync(new CosmosException("Not found", HttpStatusCode.NotFound, 0, "", 0));
+
+            var responseMock = new Mock<ItemResponse<ChatConversationDocument>>();
+            _containerMock.Setup(x => x.UpsertItemAsync(
+                It.IsAny<ChatConversationDocument>(),
+                It.IsAny<PartitionKey>(),
+                null, default))
+                .ReturnsAsync(responseMock.Object);
+
+            // Act
+            var result = await _sut.SaveMessageAsync(sessionId, "user", longMessage);
+
+            // Assert
+            result.Title.Should().HaveLength(53); // 50 chars + "..."
+            result.Title.Should().EndWith("...");
+        }
+
+        [Fact]
+        public async Task SaveMessageAsync_ShouldAppendToExisting_WhenConversationExists()
+        {
+            // Arrange
+            var sessionId = "existing-session";
+            var existingConversation = new ChatConversationDocument
+            {
+                Id = sessionId,
+                SessionId = sessionId,
+                Title = "Existing conversation",
+                Messages = [new ChatMessage { Role = "user", Content = "First message" }]
+            };
+
+            var readResponseMock = new Mock<ItemResponse<ChatConversationDocument>>();
+            readResponseMock.Setup(x => x.Resource).Returns(existingConversation);
+
+            _containerMock.Setup(x => x.ReadItemAsync<ChatConversationDocument>(
+                sessionId, new PartitionKey(sessionId), null, default))
+                .ReturnsAsync(readResponseMock.Object);
+
+            var upsertResponseMock = new Mock<ItemResponse<ChatConversationDocument>>();
+            _containerMock.Setup(x => x.UpsertItemAsync(
+                It.IsAny<ChatConversationDocument>(),
+                It.IsAny<PartitionKey>(),
+                null, default))
+                .ReturnsAsync(upsertResponseMock.Object);
+
+            // Act
+            var result = await _sut.SaveMessageAsync(sessionId, "assistant", "Here is your data.");
+
+            // Assert
+            result.Messages.Should().HaveCount(2);
+            result.Messages[1].Role.Should().Be("assistant");
+            result.Title.Should().Be("Existing conversation"); // Title should not change
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/ActivityToolsShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/ActivityToolsShould.cs
@@ -1,0 +1,190 @@
+using System.Net;
+using Biotrackr.Chat.Api.Tools;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using Moq.Protected;
+
+namespace Biotrackr.Chat.Api.UnitTests.Tools
+{
+    public class ActivityToolsShould
+    {
+        private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
+        private readonly IMemoryCache _cache;
+        private readonly ActivityTools _sut;
+
+        public ActivityToolsShould()
+        {
+            _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            _cache = new MemoryCache(new MemoryCacheOptions());
+            _sut = new ActivityTools(_httpClientFactoryMock.Object, _cache);
+        }
+
+        private void SetupHttpClient(HttpStatusCode statusCode, string content = "{}")
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = statusCode,
+                    Content = new StringContent(content)
+                });
+
+            var client = new HttpClient(handler.Object)
+            {
+                BaseAddress = new Uri("https://api.test.com")
+            };
+            _httpClientFactoryMock.Setup(x => x.CreateClient("BiotrackrApi")).Returns(client);
+        }
+
+        [Fact]
+        public async Task GetActivityByDate_ShouldReturnError_WhenDateFormatIsInvalid()
+        {
+            // Act
+            var result = await _sut.GetActivityByDate("not-a-date");
+
+            // Assert
+            result.Should().Contain("error");
+            result.Should().Contain("Invalid date format");
+        }
+
+        [Fact]
+        public async Task GetActivityByDate_ShouldReturnData_WhenDateIsValid()
+        {
+            // Arrange
+            var expectedJson = """{"steps": 10000}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            // Act
+            var result = await _sut.GetActivityByDate("2025-01-15");
+
+            // Assert
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetActivityByDate_ShouldReturnError_WhenApiReturnsNotFound()
+        {
+            // Arrange
+            SetupHttpClient(HttpStatusCode.NotFound);
+
+            // Act
+            var result = await _sut.GetActivityByDate("2025-01-15");
+
+            // Assert
+            result.Should().Contain("error");
+            result.Should().Contain("not found");
+        }
+
+        [Fact]
+        public async Task GetActivityByDate_ShouldReturnCachedResult_OnSecondCall()
+        {
+            // Arrange
+            var expectedJson = """{"steps": 10000}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            // Act
+            var result1 = await _sut.GetActivityByDate("2025-01-15");
+            var result2 = await _sut.GetActivityByDate("2025-01-15");
+
+            // Assert
+            result1.Should().Be(expectedJson);
+            result2.Should().Be(expectedJson);
+            _httpClientFactoryMock.Verify(x => x.CreateClient("BiotrackrApi"), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetActivityByDateRange_ShouldReturnError_WhenStartDateIsInvalid()
+        {
+            // Act
+            var result = await _sut.GetActivityByDateRange("bad-date", "2025-01-15");
+
+            // Assert
+            result.Should().Contain("error");
+            result.Should().Contain("Invalid date format");
+        }
+
+        [Fact]
+        public async Task GetActivityByDateRange_ShouldReturnError_WhenRangeExceeds365Days()
+        {
+            // Act
+            var result = await _sut.GetActivityByDateRange("2025-01-01", "2026-03-01");
+
+            // Assert
+            result.Should().Contain("error");
+            result.Should().Contain("365 days");
+        }
+
+        [Fact]
+        public async Task GetActivityByDateRange_ShouldReturnData_WhenRangeIsValid()
+        {
+            // Arrange
+            var expectedJson = """{"items": []}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            // Act
+            var result = await _sut.GetActivityByDateRange("2025-01-01", "2025-01-30");
+
+            // Assert
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetActivityRecords_ShouldReturnData()
+        {
+            // Arrange
+            var expectedJson = """{"items": [], "totalCount": 0}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            // Act
+            var result = await _sut.GetActivityRecords(1, 10);
+
+            // Assert
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetActivityRecords_ShouldCapPageSizeAt50()
+        {
+            // Arrange
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.Query.Contains("pageSize=50")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{}")
+                });
+
+            var client = new HttpClient(handler.Object)
+            {
+                BaseAddress = new Uri("https://api.test.com")
+            };
+            _httpClientFactoryMock.Setup(x => x.CreateClient("BiotrackrApi")).Returns(client);
+
+            // Act
+            var result = await _sut.GetActivityRecords(1, 200);
+
+            // Assert
+            result.Should().Be("{}");
+        }
+
+        [Fact]
+        public async Task GetActivityRecords_ShouldReturnError_WhenApiFails()
+        {
+            // Arrange
+            SetupHttpClient(HttpStatusCode.InternalServerError);
+
+            // Act
+            var result = await _sut.GetActivityRecords();
+
+            // Assert
+            result.Should().Contain("error");
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/FoodToolsShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/FoodToolsShould.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using Biotrackr.Chat.Api.Tools;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using Moq.Protected;
+
+namespace Biotrackr.Chat.Api.UnitTests.Tools
+{
+    public class FoodToolsShould
+    {
+        private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
+        private readonly IMemoryCache _cache;
+        private readonly FoodTools _sut;
+
+        public FoodToolsShould()
+        {
+            _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            _cache = new MemoryCache(new MemoryCacheOptions());
+            _sut = new FoodTools(_httpClientFactoryMock.Object, _cache);
+        }
+
+        private void SetupHttpClient(HttpStatusCode statusCode, string content = "{}")
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = statusCode,
+                    Content = new StringContent(content)
+                });
+
+            var client = new HttpClient(handler.Object)
+            {
+                BaseAddress = new Uri("https://api.test.com")
+            };
+            _httpClientFactoryMock.Setup(x => x.CreateClient("BiotrackrApi")).Returns(client);
+        }
+
+        [Fact]
+        public async Task GetFoodByDate_ShouldReturnError_WhenDateFormatIsInvalid()
+        {
+            var result = await _sut.GetFoodByDate("not-a-date");
+            result.Should().Contain("error");
+            result.Should().Contain("Invalid date format");
+        }
+
+        [Fact]
+        public async Task GetFoodByDate_ShouldReturnData_WhenDateIsValid()
+        {
+            var expectedJson = """{"calories": 2000}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            var result = await _sut.GetFoodByDate("2025-01-15");
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetFoodByDate_ShouldReturnCachedResult_OnSecondCall()
+        {
+            var expectedJson = """{"calories": 2000}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            await _sut.GetFoodByDate("2025-01-15");
+            await _sut.GetFoodByDate("2025-01-15");
+
+            _httpClientFactoryMock.Verify(x => x.CreateClient("BiotrackrApi"), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetFoodByDateRange_ShouldReturnError_WhenRangeExceeds365Days()
+        {
+            var result = await _sut.GetFoodByDateRange("2025-01-01", "2026-03-01");
+            result.Should().Contain("error");
+            result.Should().Contain("365 days");
+        }
+
+        [Fact]
+        public async Task GetFoodByDateRange_ShouldReturnData_WhenRangeIsValid()
+        {
+            var expectedJson = """{"items": []}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            var result = await _sut.GetFoodByDateRange("2025-01-01", "2025-01-30");
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetFoodRecords_ShouldReturnData()
+        {
+            var expectedJson = """{"items": [], "totalCount": 0}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            var result = await _sut.GetFoodRecords(1, 10);
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetFoodRecords_ShouldCapPageSizeAt50()
+        {
+            SetupHttpClient(HttpStatusCode.OK, "{}");
+
+            var result = await _sut.GetFoodRecords(1, 200);
+            result.Should().Be("{}");
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/SleepToolsShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/SleepToolsShould.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using Biotrackr.Chat.Api.Tools;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using Moq.Protected;
+
+namespace Biotrackr.Chat.Api.UnitTests.Tools
+{
+    public class SleepToolsShould
+    {
+        private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
+        private readonly IMemoryCache _cache;
+        private readonly SleepTools _sut;
+
+        public SleepToolsShould()
+        {
+            _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            _cache = new MemoryCache(new MemoryCacheOptions());
+            _sut = new SleepTools(_httpClientFactoryMock.Object, _cache);
+        }
+
+        private void SetupHttpClient(HttpStatusCode statusCode, string content = "{}")
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = statusCode,
+                    Content = new StringContent(content)
+                });
+
+            var client = new HttpClient(handler.Object)
+            {
+                BaseAddress = new Uri("https://api.test.com")
+            };
+            _httpClientFactoryMock.Setup(x => x.CreateClient("BiotrackrApi")).Returns(client);
+        }
+
+        [Fact]
+        public async Task GetSleepByDate_ShouldReturnError_WhenDateFormatIsInvalid()
+        {
+            var result = await _sut.GetSleepByDate("not-a-date");
+            result.Should().Contain("error");
+            result.Should().Contain("Invalid date format");
+        }
+
+        [Fact]
+        public async Task GetSleepByDate_ShouldReturnData_WhenDateIsValid()
+        {
+            var expectedJson = """{"duration": 28800}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            var result = await _sut.GetSleepByDate("2025-01-15");
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetSleepByDate_ShouldReturnCachedResult_OnSecondCall()
+        {
+            var expectedJson = """{"duration": 28800}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            await _sut.GetSleepByDate("2025-01-15");
+            await _sut.GetSleepByDate("2025-01-15");
+
+            _httpClientFactoryMock.Verify(x => x.CreateClient("BiotrackrApi"), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetSleepByDateRange_ShouldReturnError_WhenRangeExceeds365Days()
+        {
+            var result = await _sut.GetSleepByDateRange("2025-01-01", "2026-03-01");
+            result.Should().Contain("error");
+            result.Should().Contain("365 days");
+        }
+
+        [Fact]
+        public async Task GetSleepByDateRange_ShouldReturnData_WhenRangeIsValid()
+        {
+            var expectedJson = """{"items": []}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            var result = await _sut.GetSleepByDateRange("2025-01-01", "2025-01-30");
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetSleepRecords_ShouldReturnData()
+        {
+            var expectedJson = """{"items": [], "totalCount": 0}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            var result = await _sut.GetSleepRecords(1, 10);
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetSleepRecords_ShouldCapPageSizeAt50()
+        {
+            SetupHttpClient(HttpStatusCode.OK, "{}");
+
+            var result = await _sut.GetSleepRecords(1, 200);
+            result.Should().Be("{}");
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/WeightToolsShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/WeightToolsShould.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using Biotrackr.Chat.Api.Tools;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using Moq.Protected;
+
+namespace Biotrackr.Chat.Api.UnitTests.Tools
+{
+    public class WeightToolsShould
+    {
+        private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
+        private readonly IMemoryCache _cache;
+        private readonly WeightTools _sut;
+
+        public WeightToolsShould()
+        {
+            _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            _cache = new MemoryCache(new MemoryCacheOptions());
+            _sut = new WeightTools(_httpClientFactoryMock.Object, _cache);
+        }
+
+        private void SetupHttpClient(HttpStatusCode statusCode, string content = "{}")
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = statusCode,
+                    Content = new StringContent(content)
+                });
+
+            var client = new HttpClient(handler.Object)
+            {
+                BaseAddress = new Uri("https://api.test.com")
+            };
+            _httpClientFactoryMock.Setup(x => x.CreateClient("BiotrackrApi")).Returns(client);
+        }
+
+        [Fact]
+        public async Task GetWeightByDate_ShouldReturnError_WhenDateFormatIsInvalid()
+        {
+            var result = await _sut.GetWeightByDate("not-a-date");
+            result.Should().Contain("error");
+            result.Should().Contain("Invalid date format");
+        }
+
+        [Fact]
+        public async Task GetWeightByDate_ShouldReturnData_WhenDateIsValid()
+        {
+            var expectedJson = """{"weight": 75.5}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            var result = await _sut.GetWeightByDate("2025-01-15");
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetWeightByDate_ShouldReturnCachedResult_OnSecondCall()
+        {
+            var expectedJson = """{"weight": 75.5}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            await _sut.GetWeightByDate("2025-01-15");
+            await _sut.GetWeightByDate("2025-01-15");
+
+            _httpClientFactoryMock.Verify(x => x.CreateClient("BiotrackrApi"), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetWeightByDateRange_ShouldReturnError_WhenRangeExceeds365Days()
+        {
+            var result = await _sut.GetWeightByDateRange("2025-01-01", "2026-03-01");
+            result.Should().Contain("error");
+            result.Should().Contain("365 days");
+        }
+
+        [Fact]
+        public async Task GetWeightByDateRange_ShouldReturnData_WhenRangeIsValid()
+        {
+            var expectedJson = """{"items": []}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            var result = await _sut.GetWeightByDateRange("2025-01-01", "2025-01-30");
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetWeightRecords_ShouldReturnData()
+        {
+            var expectedJson = """{"items": [], "totalCount": 0}""";
+            SetupHttpClient(HttpStatusCode.OK, expectedJson);
+
+            var result = await _sut.GetWeightRecords(1, 10);
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task GetWeightRecords_ShouldCapPageSizeAt50()
+        {
+            SetupHttpClient(HttpStatusCode.OK, "{}");
+
+            var result = await _sut.GetWeightRecords(1, 200);
+            result.Should().Be("{}");
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.slnx
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.slnx
@@ -1,0 +1,5 @@
+<Solution>
+  <Project Path="Biotrackr.Chat.Api.IntegrationTests/Biotrackr.Chat.Api.IntegrationTests.csproj" />
+  <Project Path="Biotrackr.Chat.Api.UnitTests/Biotrackr.Chat.Api.UnitTests.csproj" />
+  <Project Path="Biotrackr.Chat.Api/Biotrackr.Chat.Api.csproj" />
+</Solution>

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Biotrackr.Chat.Api.csproj
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Biotrackr.Chat.Api.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.0.0-rc3" />
+    <PackageReference Include="Microsoft.Agents.AI.Anthropic" Version="1.0.0-rc3" />
+    <PackageReference Include="Microsoft.Agents.AI.Hosting" Version="1.0.0-preview.260304.1" />
+    <PackageReference Include="Microsoft.Agents.AI.Hosting.AGUI.AspNetCore" Version="1.0.0-preview.260304.1" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/Settings.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/Settings.cs
@@ -1,0 +1,12 @@
+namespace Biotrackr.Chat.Api.Configuration
+{
+    public class Settings
+    {
+        public string DatabaseName { get; set; }
+        public string ConversationsContainerName { get; set; }
+        public string ApiBaseUrl { get; set; }
+        public string AnthropicApiKey { get; set; }
+        public string ChatAgentModel { get; set; }
+        public string ChatSystemPrompt { get; set; }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Extensions/EndpointRouteBuilderExtensions.cs
@@ -1,0 +1,47 @@
+using Biotrackr.Chat.Api.Handlers;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Biotrackr.Chat.Api.Extensions
+{
+    public static class EndpointRouteBuilderExtensions
+    {
+        public static void RegisterChatEndpoints(this IEndpointRouteBuilder endpointRouteBuilder)
+        {
+            var conversationEndpoints = endpointRouteBuilder.MapGroup("/conversations");
+
+            conversationEndpoints.MapGet("/", ChatHandlers.GetConversations)
+                .WithName("GetConversations")
+                .WithOpenApi()
+                .WithSummary("Get all conversations")
+                .WithDescription("Returns a paginated list of chat conversations, ordered by most recent.");
+
+            conversationEndpoints.MapGet("/{sessionId}", ChatHandlers.GetConversation)
+                .WithName("GetConversation")
+                .WithOpenApi()
+                .WithSummary("Get a conversation by session ID")
+                .WithDescription("Returns the full conversation document including all messages.");
+
+            conversationEndpoints.MapDelete("/{sessionId}", ChatHandlers.DeleteConversation)
+                .WithName("DeleteConversation")
+                .WithOpenApi()
+                .WithSummary("Delete a conversation")
+                .WithDescription("Permanently deletes a conversation and all its messages.");
+        }
+
+        public static void RegisterHealthCheckEndpoints(this IEndpointRouteBuilder endpointRouteBuilder)
+        {
+            var healthEndpoints = endpointRouteBuilder.MapGroup("/healthz");
+
+            healthEndpoints.MapHealthChecks("/liveness", new HealthCheckOptions
+            {
+                ResultStatusCodes =
+                {
+                    [HealthStatus.Healthy] = StatusCodes.Status200OK,
+                    [HealthStatus.Degraded] = StatusCodes.Status200OK,
+                    [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+                }
+            });
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Handlers/ChatHandlers.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Handlers/ChatHandlers.cs
@@ -1,0 +1,44 @@
+using Biotrackr.Chat.Api.Models;
+using Biotrackr.Chat.Api.Services;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Biotrackr.Chat.Api.Handlers
+{
+    public static class ChatHandlers
+    {
+        public static async Task<Ok<PaginationResponse<ChatConversationSummary>>> GetConversations(
+            IChatHistoryRepository repository,
+            int? pageNumber = null,
+            int? pageSize = null)
+        {
+            var paginationRequest = new PaginationRequest
+            {
+                PageNumber = pageNumber ?? 1,
+                PageSize = pageSize ?? 20
+            };
+
+            var conversations = await repository.GetConversationsAsync(paginationRequest);
+            return TypedResults.Ok(conversations);
+        }
+
+        public static async Task<Results<NotFound, Ok<ChatConversationDocument>>> GetConversation(
+            IChatHistoryRepository repository,
+            string sessionId)
+        {
+            var conversation = await repository.GetConversationAsync(sessionId);
+            if (conversation is null)
+            {
+                return TypedResults.NotFound();
+            }
+            return TypedResults.Ok(conversation);
+        }
+
+        public static async Task<NoContent> DeleteConversation(
+            IChatHistoryRepository repository,
+            string sessionId)
+        {
+            await repository.DeleteConversationAsync(sessionId);
+            return TypedResults.NoContent();
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
@@ -1,0 +1,74 @@
+using Biotrackr.Chat.Api.Services;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using System.Runtime.CompilerServices;
+
+namespace Biotrackr.Chat.Api.Middleware
+{
+    /// <summary>
+    /// Agent middleware that persists conversation messages to Cosmos DB
+    /// after each agent streaming run completes.
+    /// </summary>
+    public class ConversationPersistenceMiddleware(
+        IChatHistoryRepository repository,
+        ILogger<ConversationPersistenceMiddleware> logger)
+    {
+        public async IAsyncEnumerable<AgentResponseUpdate> HandleAsync(
+            IEnumerable<ChatMessage> messages,
+            AgentSession? session,
+            AgentRunOptions? options,
+            AIAgent innerAgent,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            // Collect the user message (last message in the input)
+            var userMessage = messages.LastOrDefault(m => m.Role == ChatRole.User);
+            var sessionId = session?.GetHashCode().ToString("x8") ?? Guid.NewGuid().ToString();
+
+            // Save the user message to Cosmos before streaming
+            if (userMessage is not null)
+            {
+                var userContent = string.Join("", userMessage.Contents.OfType<TextContent>().Select(c => c.Text));
+                if (!string.IsNullOrWhiteSpace(userContent))
+                {
+                    await repository.SaveMessageAsync(sessionId, "user", userContent);
+                    logger.LogInformation("Persisted user message for session {SessionId}", sessionId);
+                }
+            }
+
+            // Stream the agent response, collecting the full text
+            var responseText = new System.Text.StringBuilder();
+            var toolCalls = new List<string>();
+
+            await foreach (var update in innerAgent.RunStreamingAsync(messages, session, options, cancellationToken))
+            {
+                // Collect response content for persistence
+                foreach (var content in update.Contents)
+                {
+                    if (content is TextContent textContent)
+                    {
+                        responseText.Append(textContent.Text);
+                    }
+                    else if (content is FunctionCallContent functionCall)
+                    {
+                        toolCalls.Add(functionCall.Name);
+                    }
+                }
+
+                yield return update;
+            }
+
+            // Save the assistant response to Cosmos after streaming completes
+            var assistantContent = responseText.ToString();
+            if (!string.IsNullOrWhiteSpace(assistantContent))
+            {
+                await repository.SaveMessageAsync(
+                    sessionId,
+                    "assistant",
+                    assistantContent,
+                    toolCalls.Count > 0 ? toolCalls : null);
+                logger.LogInformation("Persisted assistant response for session {SessionId} ({ToolCount} tool calls)",
+                    sessionId, toolCalls.Count);
+            }
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Models/ChatConversationDocument.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Models/ChatConversationDocument.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace Biotrackr.Chat.Api.Models
+{
+    public class ChatConversationDocument
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        [JsonPropertyName("sessionId")]
+        public string SessionId { get; set; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonPropertyName("lastUpdated")]
+        public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
+
+        [JsonPropertyName("messages")]
+        public List<ChatMessage> Messages { get; set; } = [];
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Models/ChatConversationSummary.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Models/ChatConversationSummary.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Biotrackr.Chat.Api.Models
+{
+    public class ChatConversationSummary
+    {
+        [JsonPropertyName("sessionId")]
+        public string SessionId { get; set; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonPropertyName("lastUpdated")]
+        public DateTime LastUpdated { get; set; }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Models/ChatMessage.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Models/ChatMessage.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Biotrackr.Chat.Api.Models
+{
+    public class ChatMessage
+    {
+        [JsonPropertyName("role")]
+        public string Role { get; set; } = string.Empty;
+
+        [JsonPropertyName("content")]
+        public string Content { get; set; } = string.Empty;
+
+        [JsonPropertyName("timestamp")]
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+
+        [JsonPropertyName("toolCalls")]
+        public List<string>? ToolCalls { get; set; }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Models/PaginationRequest.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Models/PaginationRequest.cs
@@ -1,0 +1,33 @@
+namespace Biotrackr.Chat.Api.Models
+{
+    public class PaginationRequest
+    {
+        private int _pageNumber = 1;
+        private int _pageSize = 20;
+
+        public int PageNumber
+        {
+            get => _pageNumber;
+            set => _pageNumber = value < 1 ? 1 : value;
+        }
+
+        public int PageSize
+        {
+            get => _pageSize;
+            set => _pageSize = value < 1 ? 20 : value > 100 ? 100 : value;
+        }
+
+        public int Skip => (PageNumber - 1) * PageSize;
+    }
+
+    public class PaginationResponse<T>
+    {
+        public List<T> Items { get; set; } = new List<T>();
+        public int TotalCount { get; set; }
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
+        public int TotalPages => (int)Math.Ceiling((double)TotalCount / PageSize);
+        public bool HasPreviousPage => PageNumber > 1;
+        public bool HasNextPage => PageNumber < TotalPages;
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
@@ -1,0 +1,140 @@
+using Anthropic;
+using Azure.Identity;
+using Biotrackr.Chat.Api.Configuration;
+using Biotrackr.Chat.Api.Extensions;
+using Biotrackr.Chat.Api.Middleware;
+using Biotrackr.Chat.Api.Services;
+using Biotrackr.Chat.Api.Tools;
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Configuration.AddEnvironmentVariables();
+var managedIdentityClientId = builder.Configuration.GetValue<string>("managedidentityclientid");
+var azureAppConfigEndpoint = builder.Configuration.GetValue<string>("azureappconfigendpoint");
+
+// Azure App Configuration (skipped in test environment)
+if (!string.IsNullOrWhiteSpace(azureAppConfigEndpoint))
+{
+    builder.Configuration.AddAzureAppConfiguration(config =>
+    {
+        config.Connect(new Uri(azureAppConfigEndpoint),
+            new ManagedIdentityCredential(managedIdentityClientId))
+        .Select(KeyFilter.Any, LabelFilter.Null);
+    });
+}
+
+var defaultCredentialOptions = new DefaultAzureCredentialOptions()
+{
+    ManagedIdentityClientId = managedIdentityClientId
+};
+
+builder.Services.Configure<Settings>(builder.Configuration.GetSection("Biotrackr"));
+
+// Cosmos DB
+var cosmosClientOptions = new CosmosClientOptions
+{
+    SerializerOptions = new CosmosSerializationOptions
+    {
+        PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+    }
+};
+var cosmosClient = new CosmosClient(
+    builder.Configuration.GetValue<string>("cosmosdbendpoint"),
+    new DefaultAzureCredential(defaultCredentialOptions),
+    cosmosClientOptions);
+builder.Services.AddSingleton(cosmosClient);
+
+// Services
+builder.Services.AddScoped<IChatHistoryRepository, ChatHistoryRepository>();
+builder.Services.AddMemoryCache();
+
+// HttpClient for calling Biotrackr APIs via APIM
+builder.Services.AddHttpClient("BiotrackrApi", client =>
+{
+    client.BaseAddress = new Uri(builder.Configuration.GetValue<string>("Biotrackr:ApiBaseUrl")!);
+}).AddStandardResilienceHandler();
+
+// OpenTelemetry
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddOtlpExporter())
+    .WithMetrics(metrics => metrics
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddOtlpExporter());
+
+// OpenAPI
+builder.Services.AddOpenApi();
+
+// Health checks
+builder.Services.AddHealthChecks();
+
+// AG-UI services
+builder.Services.AddAGUI();
+
+var app = builder.Build();
+
+// Resolve tool dependencies from DI
+var httpClientFactory = app.Services.GetRequiredService<IHttpClientFactory>();
+var memoryCache = app.Services.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>();
+var activityTools = new ActivityTools(httpClientFactory, memoryCache);
+var sleepTools = new SleepTools(httpClientFactory, memoryCache);
+var weightTools = new WeightTools(httpClientFactory, memoryCache);
+var foodTools = new FoodTools(httpClientFactory, memoryCache);
+
+// Build the Anthropic-backed AIAgent
+var anthropicApiKey = builder.Configuration.GetValue<string>("Biotrackr:AnthropicApiKey");
+var modelName = builder.Configuration.GetValue<string>("Biotrackr:ChatAgentModel");
+var systemPrompt = builder.Configuration.GetValue<string>("Biotrackr:ChatSystemPrompt")!;
+
+AnthropicClient anthropicClient = new() { ApiKey = anthropicApiKey };
+
+AIAgent chatAgent = anthropicClient.AsAIAgent(
+    model: modelName,
+    name: "BiotrackrChatAgent",
+    instructions: systemPrompt,
+    tools:
+    [
+        AIFunctionFactory.Create(activityTools.GetActivityByDate),
+        AIFunctionFactory.Create(activityTools.GetActivityByDateRange),
+        AIFunctionFactory.Create(activityTools.GetActivityRecords),
+        AIFunctionFactory.Create(sleepTools.GetSleepByDate),
+        AIFunctionFactory.Create(sleepTools.GetSleepByDateRange),
+        AIFunctionFactory.Create(sleepTools.GetSleepRecords),
+        AIFunctionFactory.Create(weightTools.GetWeightByDate),
+        AIFunctionFactory.Create(weightTools.GetWeightByDateRange),
+        AIFunctionFactory.Create(weightTools.GetWeightRecords),
+        AIFunctionFactory.Create(foodTools.GetFoodByDate),
+        AIFunctionFactory.Create(foodTools.GetFoodByDateRange),
+        AIFunctionFactory.Create(foodTools.GetFoodRecords),
+    ]);
+
+// Wrap agent with conversation persistence middleware
+var chatHistoryRepository = app.Services.GetRequiredService<IChatHistoryRepository>();
+var persistenceLogger = app.Services.GetRequiredService<ILogger<ConversationPersistenceMiddleware>>();
+var persistenceMiddleware = new ConversationPersistenceMiddleware(chatHistoryRepository, persistenceLogger);
+
+AIAgent persistentAgent = chatAgent
+    .AsBuilder()
+        .Use(runFunc: null, runStreamingFunc: persistenceMiddleware.HandleAsync)
+    .Build();
+
+app.MapOpenApi();
+
+// AG-UI endpoint — SSE streaming, session management, protocol events
+app.MapAGUI("/", persistentAgent);
+
+// Conversation history + health check endpoints
+app.RegisterChatEndpoints();
+app.RegisterHealthCheckEndpoints();
+
+app.Run();

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
@@ -24,9 +24,13 @@ if (!string.IsNullOrWhiteSpace(azureAppConfigEndpoint))
 {
     builder.Configuration.AddAzureAppConfiguration(config =>
     {
-        config.Connect(new Uri(azureAppConfigEndpoint),
-            new ManagedIdentityCredential(managedIdentityClientId))
-        .Select(KeyFilter.Any, LabelFilter.Null);
+        var credential = new ManagedIdentityCredential(managedIdentityClientId);
+        config.Connect(new Uri(azureAppConfigEndpoint), credential)
+        .Select(KeyFilter.Any, LabelFilter.Null)
+        .ConfigureKeyVault(kv =>
+        {
+            kv.SetCredential(credential);
+        });
     });
 }
 

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Properties/launchSettings.json
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5096",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7210;http://localhost:5096",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatHistoryRepository.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatHistoryRepository.cs
@@ -1,0 +1,140 @@
+using Biotrackr.Chat.Api.Configuration;
+using Biotrackr.Chat.Api.Models;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+
+namespace Biotrackr.Chat.Api.Services
+{
+    public class ChatHistoryRepository : IChatHistoryRepository
+    {
+        private readonly Container _container;
+        private readonly ILogger<ChatHistoryRepository> _logger;
+
+        public ChatHistoryRepository(
+            CosmosClient cosmosClient,
+            IOptions<Settings> options,
+            ILogger<ChatHistoryRepository> logger)
+        {
+            var settings = options.Value;
+            _container = cosmosClient.GetContainer(settings.DatabaseName, settings.ConversationsContainerName);
+            _logger = logger;
+        }
+
+        public async Task<ChatConversationDocument?> GetConversationAsync(string sessionId)
+        {
+            _logger.LogInformation("Getting conversation {SessionId}", sessionId);
+
+            try
+            {
+                var response = await _container.ReadItemAsync<ChatConversationDocument>(
+                    sessionId, new PartitionKey(sessionId));
+                return response.Resource;
+            }
+            catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                _logger.LogInformation("Conversation {SessionId} not found", sessionId);
+                return null;
+            }
+        }
+
+        public async Task<PaginationResponse<ChatConversationSummary>> GetConversationsAsync(
+            PaginationRequest pagination)
+        {
+            _logger.LogInformation("Fetching conversations: Page={PageNumber}, Size={PageSize}",
+                pagination.PageNumber, pagination.PageSize);
+
+            var totalCount = await GetTotalConversationCount();
+
+            var queryDefinition = new QueryDefinition(
+                "SELECT c.sessionId, c.title, c.lastUpdated FROM c ORDER BY c.lastUpdated DESC OFFSET @offset LIMIT @limit")
+                .WithParameter("@offset", pagination.Skip)
+                .WithParameter("@limit", pagination.PageSize);
+
+            var iterator = _container.GetItemQueryIterator<ChatConversationSummary>(queryDefinition);
+            var results = new List<ChatConversationSummary>();
+
+            while (iterator.HasMoreResults)
+            {
+                var response = await iterator.ReadNextAsync();
+                results.AddRange(response);
+            }
+
+            _logger.LogInformation("Found {Count} conversations (page {PageNumber})",
+                results.Count, pagination.PageNumber);
+
+            return new PaginationResponse<ChatConversationSummary>
+            {
+                Items = results,
+                TotalCount = totalCount,
+                PageNumber = pagination.PageNumber,
+                PageSize = pagination.PageSize
+            };
+        }
+
+        public async Task<ChatConversationDocument> SaveMessageAsync(
+            string sessionId, string role, string content, List<string>? toolCalls = null)
+        {
+            _logger.LogInformation("Saving {Role} message to conversation {SessionId}", role, sessionId);
+
+            ChatConversationDocument conversation;
+            try
+            {
+                var response = await _container.ReadItemAsync<ChatConversationDocument>(
+                    sessionId, new PartitionKey(sessionId));
+                conversation = response.Resource;
+            }
+            catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                conversation = new ChatConversationDocument
+                {
+                    Id = sessionId,
+                    SessionId = sessionId,
+                    Title = "New conversation"
+                };
+            }
+
+            conversation.Messages.Add(new ChatMessage
+            {
+                Role = role,
+                Content = content,
+                Timestamp = DateTime.UtcNow,
+                ToolCalls = toolCalls
+            });
+            conversation.LastUpdated = DateTime.UtcNow;
+
+            // Auto-title from first user message
+            if (conversation.Title == "New conversation" && role == "user")
+            {
+                conversation.Title = content.Length > 50 ? content[..50] + "..." : content;
+            }
+
+            await _container.UpsertItemAsync(conversation, new PartitionKey(sessionId));
+
+            _logger.LogInformation("Saved message to conversation {SessionId}, total messages: {Count}",
+                sessionId, conversation.Messages.Count);
+
+            return conversation;
+        }
+
+        public async Task DeleteConversationAsync(string sessionId)
+        {
+            _logger.LogInformation("Deleting conversation {SessionId}", sessionId);
+            await _container.DeleteItemAsync<ChatConversationDocument>(
+                sessionId, new PartitionKey(sessionId));
+        }
+
+        private async Task<int> GetTotalConversationCount()
+        {
+            var countQuery = new QueryDefinition("SELECT VALUE COUNT(1) FROM c");
+            var iterator = _container.GetItemQueryIterator<int>(countQuery);
+
+            while (iterator.HasMoreResults)
+            {
+                var response = await iterator.ReadNextAsync();
+                return response.FirstOrDefault();
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/IChatHistoryRepository.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/IChatHistoryRepository.cs
@@ -1,0 +1,12 @@
+using Biotrackr.Chat.Api.Models;
+
+namespace Biotrackr.Chat.Api.Services
+{
+    public interface IChatHistoryRepository
+    {
+        Task<ChatConversationDocument?> GetConversationAsync(string sessionId);
+        Task<PaginationResponse<ChatConversationSummary>> GetConversationsAsync(PaginationRequest pagination);
+        Task<ChatConversationDocument> SaveMessageAsync(string sessionId, string role, string content, List<string>? toolCalls = null);
+        Task DeleteConversationAsync(string sessionId);
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/ActivityTools.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/ActivityTools.cs
@@ -1,0 +1,82 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Biotrackr.Chat.Api.Tools
+{
+    public class ActivityTools(IHttpClientFactory httpClientFactory, IMemoryCache cache)
+    {
+        [Description("Get activity data (steps, calories, distance) for a specific date. Date format: YYYY-MM-DD.")]
+        public async Task<string> GetActivityByDate(
+            [Description("The date to get activity data for, in YYYY-MM-DD format")] string date)
+        {
+            if (!DateOnly.TryParse(date, out _))
+                return """{"error": "Invalid date format. Use YYYY-MM-DD."}""";
+
+            var cacheKey = $"activity:{date}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/activity/{date}");
+
+            if (!response.IsSuccessStatusCode)
+                return $"{{\"error\": \"Activity data not found for {date}.\"}}";
+
+            var result = await response.Content.ReadAsStringAsync();
+
+            var ttl = DateOnly.Parse(date) == DateOnly.FromDateTime(DateTime.UtcNow)
+                ? TimeSpan.FromMinutes(5)
+                : TimeSpan.FromHours(1);
+            cache.Set(cacheKey, result, ttl);
+
+            return result;
+        }
+
+        [Description("Get activity data for a date range. Maximum 365 days. Date format: YYYY-MM-DD.")]
+        public async Task<string> GetActivityByDateRange(
+            [Description("The start date, in YYYY-MM-DD format")] string startDate,
+            [Description("The end date, in YYYY-MM-DD format")] string endDate)
+        {
+            if (!DateOnly.TryParse(startDate, out var start) || !DateOnly.TryParse(endDate, out var end))
+                return """{"error": "Invalid date format. Use YYYY-MM-DD."}""";
+
+            if ((end.ToDateTime(TimeOnly.MinValue) - start.ToDateTime(TimeOnly.MinValue)).Days > 365)
+                return """{"error": "Date range cannot exceed 365 days."}""";
+
+            var cacheKey = $"activity-range:{startDate}:{endDate}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/activity/range/{startDate}/{endDate}");
+
+            if (!response.IsSuccessStatusCode)
+                return """{"error": "No activity data found for the specified range."}""";
+
+            var result = await response.Content.ReadAsStringAsync();
+            cache.Set(cacheKey, result, TimeSpan.FromMinutes(30));
+            return result;
+        }
+
+        [Description("Get paginated activity records. Returns the most recent records by default.")]
+        public async Task<string> GetActivityRecords(
+            [Description("Page number (default: 1)")] int pageNumber = 1,
+            [Description("Page size (default: 10, max: 50)")] int pageSize = 10)
+        {
+            pageSize = Math.Min(pageSize, 50);
+            var cacheKey = $"activity-records:{pageNumber}:{pageSize}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/activity?pageNumber={pageNumber}&pageSize={pageSize}");
+
+            if (!response.IsSuccessStatusCode)
+                return """{"error": "Failed to retrieve activity records."}""";
+
+            var result = await response.Content.ReadAsStringAsync();
+            cache.Set(cacheKey, result, TimeSpan.FromMinutes(15));
+            return result;
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/FoodTools.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/FoodTools.cs
@@ -1,0 +1,82 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Biotrackr.Chat.Api.Tools
+{
+    public class FoodTools(IHttpClientFactory httpClientFactory, IMemoryCache cache)
+    {
+        [Description("Get food data (calories, macronutrients, meals) for a specific date. Date format: YYYY-MM-DD.")]
+        public async Task<string> GetFoodByDate(
+            [Description("The date to get food data for, in YYYY-MM-DD format")] string date)
+        {
+            if (!DateOnly.TryParse(date, out _))
+                return """{"error": "Invalid date format. Use YYYY-MM-DD."}""";
+
+            var cacheKey = $"food:{date}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/food/{date}");
+
+            if (!response.IsSuccessStatusCode)
+                return $"{{\"error\": \"Food data not found for {date}.\"}}";
+
+            var result = await response.Content.ReadAsStringAsync();
+
+            var ttl = DateOnly.Parse(date) == DateOnly.FromDateTime(DateTime.UtcNow)
+                ? TimeSpan.FromMinutes(5)
+                : TimeSpan.FromHours(1);
+            cache.Set(cacheKey, result, ttl);
+
+            return result;
+        }
+
+        [Description("Get food data for a date range. Maximum 365 days. Date format: YYYY-MM-DD.")]
+        public async Task<string> GetFoodByDateRange(
+            [Description("The start date, in YYYY-MM-DD format")] string startDate,
+            [Description("The end date, in YYYY-MM-DD format")] string endDate)
+        {
+            if (!DateOnly.TryParse(startDate, out var start) || !DateOnly.TryParse(endDate, out var end))
+                return """{"error": "Invalid date format. Use YYYY-MM-DD."}""";
+
+            if ((end.ToDateTime(TimeOnly.MinValue) - start.ToDateTime(TimeOnly.MinValue)).Days > 365)
+                return """{"error": "Date range cannot exceed 365 days."}""";
+
+            var cacheKey = $"food-range:{startDate}:{endDate}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/food/range/{startDate}/{endDate}");
+
+            if (!response.IsSuccessStatusCode)
+                return """{"error": "No food data found for the specified range."}""";
+
+            var result = await response.Content.ReadAsStringAsync();
+            cache.Set(cacheKey, result, TimeSpan.FromMinutes(30));
+            return result;
+        }
+
+        [Description("Get paginated food records. Returns the most recent records by default.")]
+        public async Task<string> GetFoodRecords(
+            [Description("Page number (default: 1)")] int pageNumber = 1,
+            [Description("Page size (default: 10, max: 50)")] int pageSize = 10)
+        {
+            pageSize = Math.Min(pageSize, 50);
+            var cacheKey = $"food-records:{pageNumber}:{pageSize}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/food?pageNumber={pageNumber}&pageSize={pageSize}");
+
+            if (!response.IsSuccessStatusCode)
+                return """{"error": "Failed to retrieve food records."}""";
+
+            var result = await response.Content.ReadAsStringAsync();
+            cache.Set(cacheKey, result, TimeSpan.FromMinutes(15));
+            return result;
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/SleepTools.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/SleepTools.cs
@@ -1,0 +1,82 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Biotrackr.Chat.Api.Tools
+{
+    public class SleepTools(IHttpClientFactory httpClientFactory, IMemoryCache cache)
+    {
+        [Description("Get sleep data (duration, efficiency, stages, heart rate) for a specific date. Date format: YYYY-MM-DD.")]
+        public async Task<string> GetSleepByDate(
+            [Description("The date to get sleep data for, in YYYY-MM-DD format")] string date)
+        {
+            if (!DateOnly.TryParse(date, out _))
+                return """{"error": "Invalid date format. Use YYYY-MM-DD."}""";
+
+            var cacheKey = $"sleep:{date}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/sleep/{date}");
+
+            if (!response.IsSuccessStatusCode)
+                return $"{{\"error\": \"Sleep data not found for {date}.\"}}";
+
+            var result = await response.Content.ReadAsStringAsync();
+
+            var ttl = DateOnly.Parse(date) == DateOnly.FromDateTime(DateTime.UtcNow)
+                ? TimeSpan.FromMinutes(5)
+                : TimeSpan.FromHours(1);
+            cache.Set(cacheKey, result, ttl);
+
+            return result;
+        }
+
+        [Description("Get sleep data for a date range. Maximum 365 days. Date format: YYYY-MM-DD.")]
+        public async Task<string> GetSleepByDateRange(
+            [Description("The start date, in YYYY-MM-DD format")] string startDate,
+            [Description("The end date, in YYYY-MM-DD format")] string endDate)
+        {
+            if (!DateOnly.TryParse(startDate, out var start) || !DateOnly.TryParse(endDate, out var end))
+                return """{"error": "Invalid date format. Use YYYY-MM-DD."}""";
+
+            if ((end.ToDateTime(TimeOnly.MinValue) - start.ToDateTime(TimeOnly.MinValue)).Days > 365)
+                return """{"error": "Date range cannot exceed 365 days."}""";
+
+            var cacheKey = $"sleep-range:{startDate}:{endDate}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/sleep/range/{startDate}/{endDate}");
+
+            if (!response.IsSuccessStatusCode)
+                return """{"error": "No sleep data found for the specified range."}""";
+
+            var result = await response.Content.ReadAsStringAsync();
+            cache.Set(cacheKey, result, TimeSpan.FromMinutes(30));
+            return result;
+        }
+
+        [Description("Get paginated sleep records. Returns the most recent records by default.")]
+        public async Task<string> GetSleepRecords(
+            [Description("Page number (default: 1)")] int pageNumber = 1,
+            [Description("Page size (default: 10, max: 50)")] int pageSize = 10)
+        {
+            pageSize = Math.Min(pageSize, 50);
+            var cacheKey = $"sleep-records:{pageNumber}:{pageSize}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/sleep?pageNumber={pageNumber}&pageSize={pageSize}");
+
+            if (!response.IsSuccessStatusCode)
+                return """{"error": "Failed to retrieve sleep records."}""";
+
+            var result = await response.Content.ReadAsStringAsync();
+            cache.Set(cacheKey, result, TimeSpan.FromMinutes(15));
+            return result;
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/WeightTools.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/WeightTools.cs
@@ -1,0 +1,82 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Biotrackr.Chat.Api.Tools
+{
+    public class WeightTools(IHttpClientFactory httpClientFactory, IMemoryCache cache)
+    {
+        [Description("Get weight data (weight, BMI, body fat percentage) for a specific date. Date format: YYYY-MM-DD.")]
+        public async Task<string> GetWeightByDate(
+            [Description("The date to get weight data for, in YYYY-MM-DD format")] string date)
+        {
+            if (!DateOnly.TryParse(date, out _))
+                return """{"error": "Invalid date format. Use YYYY-MM-DD."}""";
+
+            var cacheKey = $"weight:{date}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/weight/{date}");
+
+            if (!response.IsSuccessStatusCode)
+                return $"{{\"error\": \"Weight data not found for {date}.\"}}";
+
+            var result = await response.Content.ReadAsStringAsync();
+
+            var ttl = DateOnly.Parse(date) == DateOnly.FromDateTime(DateTime.UtcNow)
+                ? TimeSpan.FromMinutes(5)
+                : TimeSpan.FromHours(1);
+            cache.Set(cacheKey, result, ttl);
+
+            return result;
+        }
+
+        [Description("Get weight data for a date range. Maximum 365 days. Date format: YYYY-MM-DD.")]
+        public async Task<string> GetWeightByDateRange(
+            [Description("The start date, in YYYY-MM-DD format")] string startDate,
+            [Description("The end date, in YYYY-MM-DD format")] string endDate)
+        {
+            if (!DateOnly.TryParse(startDate, out var start) || !DateOnly.TryParse(endDate, out var end))
+                return """{"error": "Invalid date format. Use YYYY-MM-DD."}""";
+
+            if ((end.ToDateTime(TimeOnly.MinValue) - start.ToDateTime(TimeOnly.MinValue)).Days > 365)
+                return """{"error": "Date range cannot exceed 365 days."}""";
+
+            var cacheKey = $"weight-range:{startDate}:{endDate}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/weight/range/{startDate}/{endDate}");
+
+            if (!response.IsSuccessStatusCode)
+                return """{"error": "No weight data found for the specified range."}""";
+
+            var result = await response.Content.ReadAsStringAsync();
+            cache.Set(cacheKey, result, TimeSpan.FromMinutes(30));
+            return result;
+        }
+
+        [Description("Get paginated weight records. Returns the most recent records by default.")]
+        public async Task<string> GetWeightRecords(
+            [Description("Page number (default: 1)")] int pageNumber = 1,
+            [Description("Page size (default: 10, max: 50)")] int pageSize = 10)
+        {
+            pageSize = Math.Min(pageSize, 50);
+            var cacheKey = $"weight-records:{pageNumber}:{pageSize}";
+            if (cache.TryGetValue(cacheKey, out string? cached))
+                return cached!;
+
+            var client = httpClientFactory.CreateClient("BiotrackrApi");
+            var response = await client.GetAsync($"/weight?pageNumber={pageNumber}&pageSize={pageSize}");
+
+            if (!response.IsSuccessStatusCode)
+                return """{"error": "Failed to retrieve weight records."}""";
+
+            var result = await response.Content.ReadAsStringAsync();
+            cache.Set(cacheKey, result, TimeSpan.FromMinutes(15));
+            return result;
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/appsettings.Development.json
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/appsettings.json
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Biotrackr.Chat.Api/Dockerfile
+++ b/src/Biotrackr.Chat.Api/Dockerfile
@@ -1,0 +1,30 @@
+# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+# This stage is used when running from VS in fast mode (Default for Debug configuration)
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+
+# This stage is used to build the service project
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["Biotrackr.Chat.Api/Biotrackr.Chat.Api.csproj", "Biotrackr.Chat.Api/"]
+RUN dotnet restore "./Biotrackr.Chat.Api/Biotrackr.Chat.Api.csproj"
+COPY . .
+WORKDIR "/src/Biotrackr.Chat.Api"
+RUN dotnet build "./Biotrackr.Chat.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+# This stage is used to publish the service project to be copied to the final stage
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./Biotrackr.Chat.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+# This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "Biotrackr.Chat.Api.dll"]

--- a/src/Biotrackr.Chat.Api/coverage.runsettings
+++ b/src/Biotrackr.Chat.Api/coverage.runsettings
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Coverage exclusion settings for .NET 10 projects.
+  
+  The Microsoft.AspNetCore.OpenApi source generator (used by AddOpenApi()) emits classes
+  under the Microsoft.AspNetCore.OpenApi.Generated namespace that coverlet instruments
+  but no unit tests exercise, dragging coverage down significantly.
+  
+  Place this file at the solution root and pass it via:
+    dotnet test - -settings coverage.runsettings
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+          <Exclude>
+            [*]Microsoft.AspNetCore.OpenApi.Generated.*,
+            [*]System.Runtime.CompilerServices.*OpenApiXmlCommentSupport_generated*,
+            [Biotrackr.Chat.Api]Biotrackr.Chat.Api.Middleware.*,
+            [Biotrackr.Chat.Api]Biotrackr.Chat.Api.Extensions.*,
+            [Biotrackr.Chat.Api]Program
+          </Exclude>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
# 📝 Description

New `Biotrackr.Chat.Api` service — a .NET 10 Minimal API that hosts the AI chat agent using Microsoft Agent Framework with Anthropic Claude (AG-UI protocol). Persists conversation history to Cosmos DB and exposes endpoints through APIM.

## 🔗 Related Issues

Reference: [Chat Agent API Plan](docs/plans/2026-03-07-chat-agent-api.md)
Prerequisites: [Core Infrastructure Plan](docs/plans/2026-03-07-chat-agent-core-infrastructure.md)

## 🚀 Changes

**✨ feat(API service with Agent Framework + AG-UI)**
What: New Chat API with Anthropic Claude provider, AG-UI SSE streaming, 12 function tools (activity, sleep, weight, food), conversation persistence middleware
Why: Enable AI chat agent for Biotrackr health data queries
📁 Files: `Program.cs`, `Tools/*.cs`, `Middleware/ConversationPersistenceMiddleware.cs`

**✨ feat(Conversation history with Cosmos DB)**
What: ChatHistoryRepository with SaveMessageAsync pattern (read-or-create + append + auto-title + upsert), GET/DELETE conversation endpoints
Why: Persist chat conversations across sessions with pagination support
📁 Files: `Services/ChatHistoryRepository.cs`, `Handlers/ChatHandlers.cs`, `Models/*.cs`

**🔧 config(Infrastructure — Bicep, APIM, CI/CD)**
What: Container App, APIM API with JWT auth, Key Vault reference for Anthropic API key, App Config entries, CI/CD workflow
Why: Deploy and expose the Chat API through the existing Biotrackr infrastructure
📁 Files: `infra/apps/chat-api/*`, `.github/workflows/deploy-chat-api.yml`

**🧪 test(43 unit + 2 integration tests)**
What: Full test coverage for handlers, tools (4 classes), repository, plus smoke tests
Why: Validate all business logic and API startup
📁 Files: `*Tests/**/*.cs`

## 🙏 Additional Context

- Anthropic API key uploaded to Key Vault manually
- System prompt uploaded to App Config manually (not in source — ASI01)
- Agent Framework packages: `Microsoft.Agents.AI.Anthropic` 1.0.0-rc3, `Microsoft.Agents.AI.Hosting.AGUI.AspNetCore` 1.0.0-preview.260304.1
- Requires core infra (Cosmos `conversations` container) to be deployed first