### PR TITLE
docs: update README with Chat API and fix MCP Server build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The application follows a **microservices architecture** with separate services 
 - **Weight Service**: Handles weight measurements and trends
 - **Food Service**: Tracks nutrition and food logging data from Fitbit
 - **Auth Service**: Manages authentication and authorization with Fitbit API
+- **Chat API**: AI-powered chat agent for querying and analysing health data via natural language
 - **MCP Server**: [Model Context Protocol](https://modelcontextprotocol.io/) server exposing all health data as MCP tools for AI assistants
 - **UI**: Blazor Server dashboard for visualizing activity, sleep, weight, and food data
 
@@ -39,6 +40,7 @@ Each service consists of:
 - 🍎 **Food Logging**: Nutrition tracking and food diary management
 - 🔐 **Secure Authentication**: OAuth integration with Fitbit
 - 📊 **Data Insights**: Analysis and reporting on health metrics
+- 💬 **AI Chat Agent**: Natural language chat interface powered by Claude for querying and analysing health data
 - 🤖 **MCP Integration**: AI-ready via Model Context Protocol server with 12 tools across all health domains
 - 🖥️ **Web Dashboard**: Blazor Server UI for browsing and visualizing health data
 - ☁️ **Cloud-Native**: Fully deployed on Azure with auto-scaling
@@ -52,6 +54,7 @@ Each service consists of:
 - **Azure Cosmos DB**: NoSQL database for scalable data storage
 - **Azure App Configuration**: Centralized configuration management
 - **Azure Key Vault**: Secure secrets management
+- **Microsoft Agent Framework**: AI agent orchestration with Claude (Anthropic) as the LLM backend
 
 ### Infrastructure
 - **Bicep**: Infrastructure as Code (IaC) for Azure resources
@@ -84,7 +87,8 @@ Each service consists of:
 | **Weight Service** | [![Deploy Weight Service](https://github.com/willvelida/biotrackr/actions/workflows/deploy-weight-service.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-weight-service.yml) | ![Code Coverage](https://img.shields.io/badge/Code%20Coverage-100%25-brightgreen?style=flat) | ![Integration Tests](https://img.shields.io/badge/Tests-4%20Passing-brightgreen?style=flat) |
 | **Food API** | [![Deploy Food Api](https://github.com/willvelida/biotrackr/actions/workflows/deploy-food-api.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-food-api.yml) | ![Code Coverage](https://img.shields.io/badge/Code%20Coverage-70%25-yellow?style=flat) | ![Integration Tests](https://img.shields.io/badge/Tests-26%20Passing-brightgreen?style=flat) |
 | **Food Service** | [![Deploy Food Service](https://github.com/willvelida/biotrackr/actions/workflows/deploy-food-service.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-food-service.yml) | ![Code Coverage](https://img.shields.io/badge/Code%20Coverage-100%25-brightgreen?style=flat) | ![Integration Tests](https://img.shields.io/badge/Tests-14%20Passing-brightgreen?style=flat) |
-| **MCP Server** | [![Deploy MCP Server](https://github.com/willvelida/biotrackr/actions/workflows/deploy-mcp-server.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-mcp-server.yml) | ![Code Coverage](https://img.shields.io/badge/Code%20Coverage-106%20Tests-brightgreen?style=flat) | ![Integration Tests](https://img.shields.io/badge/Tests-13%20Passing-brightgreen?style=flat) |
+| **Chat API** | [![Deploy Chat Api](https://github.com/willvelida/biotrackr/actions/workflows/deploy-chat-api.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-chat-api.yml) | ![Code Coverage](https://img.shields.io/badge/Code%20Coverage-86%25-brightgreen?style=flat) | ![Integration Tests](https://img.shields.io/badge/Tests-2%20Passing-brightgreen?style=flat) |
+| **MCP Server** | [![Deploy MCP Server](https://github.com/willvelida/biotrackr/actions/workflows/deploy-mcp-server.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-mcp-server.yml) | ![Code Coverage](https://img.shields.io/badge/Code%20Coverage-76%25-yellow?style=flat) | ![Integration Tests](https://img.shields.io/badge/Tests-13%20Passing-brightgreen?style=flat) |
 | **UI** | [![Deploy UI](https://github.com/willvelida/biotrackr/actions/workflows/deploy-ui.yml/badge.svg)](https://github.com/willvelida/biotrackr/actions/workflows/deploy-ui.yml) | N/A | N/A |
 
 ##  License


### PR DESCRIPTION
# 📝 Description

Updates the README to reflect the current state of the codebase, including the new Chat API service and corrected MCP Server build status.

## 🔗 Related Issues

N/A

## 🚀 Changes

**📚 docs(readme): add Chat API service to architecture, features, and tech stack**  
What: Added Chat API entry to architecture section, AI Chat Agent bullet to features, Microsoft Agent Framework to tech stack, and Chat API row to build status table (86% coverage, 2 integration tests from CI)  
Why: The Chat API was recently added but not reflected in the README  
📁 Files: `README.md`

**🐛 fix(readme): correct MCP Server unit test coverage badge**  
What: Changed MCP Server unit test badge from "106 Tests" to "76%" coverage  
Why: The badge format was inconsistent with all other services which show a percentage. 76% is the actual line coverage from CI (PR #156)  
📁 Files: `README.md`

## 🙏 Additional Context

Coverage and test counts sourced from CI/CD pipeline results:
- Chat API: 86% coverage (PR #170), 2 integration tests (PR #169)
- MCP Server: 76% coverage (PR #156), 13 integration tests