### PR TITLE
feat: add CodeQL SAST analysis workflow for C#

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL Analysis
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+    schedule:
+        - cron: '0 6 * * 1' # Weekly Monday 06:00 UTC
+
+permissions:
+    actions: read
+    contents: read
+    security-events: write
+
+jobs:
+    analyze:
+        name: Analyze C#
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v5
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                languages: csharp
+
+            - name: Autobuild
+              uses: github/codeql-action/autobuild@v3
+
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v3
+              with:
+                category: "/language:csharp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,11 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v5
 
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                dotnet-version: 10.0.x
+
             - name: Initialize CodeQL
               uses: github/codeql-action/init@v3
               with:


### PR DESCRIPTION
## Summary

Adds GitHub CodeQL static analysis (SAST) for C# to the CI/CD pipeline, addressing **ASI04 §4.5** (Supply Chain Vulnerabilities — Static Analysis) from the OWASP Agentic Top 10 implementation plan.

## Changes

- **New:** `.github/workflows/codeql.yml` — CodeQL analysis workflow

## Details

The workflow:
- **Triggers:** push to `main`, PRs to `main`, and weekly schedule (Monday 06:00 UTC)
- **Permissions:** minimal — `actions: read`, `contents: read`, `security-events: write`
- **Steps:** checkout → setup .NET 10 SDK → CodeQL init (C#) → autobuild → analyze
- Results appear in the GitHub **Security** tab

## References

- Implementation plan: `docs/plans/2026-03-13-asi04-codeql-sast.md`
- Parent plan: `docs/plans/2026-03-13-owasp-agentic-top10-implementation-plan.md` §4.5
- Blog post: `docs/blog-post-ideas/06-owasp-asi04-supply-chain-vulnerabilities.md`