### PR TITLE
feat(chat-api): log tool call arguments for audit

### DIFF
--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ConversationPersistenceMiddlewareShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ConversationPersistenceMiddlewareShould.cs
@@ -1,0 +1,151 @@
+using Biotrackr.Chat.Api.Middleware;
+using Biotrackr.Chat.Api.Services;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using ChatMessage = Microsoft.Extensions.AI.ChatMessage;
+using ChatConversationDocument = Biotrackr.Chat.Api.Models.ChatConversationDocument;
+
+namespace Biotrackr.Chat.Api.UnitTests.Middleware
+{
+    public class ConversationPersistenceMiddlewareShould
+    {
+        private readonly Mock<IChatHistoryRepository> _repositoryMock;
+        private readonly Mock<ILogger<ConversationPersistenceMiddleware>> _loggerMock;
+        private readonly ConversationPersistenceMiddleware _sut;
+
+        public ConversationPersistenceMiddlewareShould()
+        {
+            _repositoryMock = new Mock<IChatHistoryRepository>();
+            _loggerMock = new Mock<ILogger<ConversationPersistenceMiddleware>>();
+
+            _repositoryMock
+                .Setup(r => r.SaveMessageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>?>()))
+                .ReturnsAsync(new ChatConversationDocument());
+
+            _sut = new ConversationPersistenceMiddleware(_repositoryMock.Object, _loggerMock.Object);
+        }
+
+        private static IEnumerable<ChatMessage> CreateMessages(string userText)
+        {
+            return [new ChatMessage(ChatRole.User, userText)];
+        }
+
+        [Fact]
+        public async Task LogToolCallWithArguments_WhenFunctionCallContentIsYielded()
+        {
+            // Arrange
+            var arguments = new Dictionary<string, object?> { ["date"] = "2026-01-15", ["page"] = 1 };
+            var functionCall = new FunctionCallContent("call-1", "GetActivityByDate", arguments);
+            var agent = new FakeAgent(functionCall, new TextContent("Here is your data."));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+            {
+                // Drain the stream
+            }
+
+            // Assert
+            _loggerMock.VerifyLog(l => l.LogInformation(
+                It.Is<string>(s => s.Contains("GetActivityByDate") && s.Contains("2026-01-15"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task LogNullArguments_WhenFunctionCallHasNoArguments()
+        {
+            // Arrange
+            var functionCall = new FunctionCallContent("call-1", "GetActivityByDate");
+            var agent = new FakeAgent(functionCall, new TextContent("Here is your data."));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+            {
+                // Drain the stream
+            }
+
+            // Assert
+            _loggerMock.VerifyLog(l => l.LogInformation(
+                It.Is<string>(s => s.Contains("GetActivityByDate") && s.Contains("null"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task NotPersistArgumentsToCosmosDb_WhenToolCallIsLogged()
+        {
+            // Arrange
+            var arguments = new Dictionary<string, object?> { ["date"] = "2026-01-15" };
+            var functionCall = new FunctionCallContent("call-1", "GetActivityByDate", arguments);
+            var agent = new FakeAgent(functionCall, new TextContent("Here is your data."));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+            {
+                // Drain the stream
+            }
+
+            // Assert — only tool names are persisted, not arguments
+            _repositoryMock.Verify(r => r.SaveMessageAsync(
+                It.IsAny<string>(),
+                "assistant",
+                It.IsAny<string>(),
+                It.Is<List<string>?>(tc => tc != null && tc.Contains("GetActivityByDate") && tc.All(t => !t.Contains("2026-01-15")))),
+                Times.Once);
+        }
+
+        /// <summary>
+        /// Concrete AIAgent subclass for testing that yields preconfigured content.
+        /// </summary>
+        private sealed class FakeAgent(params AIContent[] contents) : AIAgent
+        {
+            protected override Task<AgentResponse> RunCoreAsync(
+                IEnumerable<ChatMessage> messages,
+                AgentSession session,
+                AgentRunOptions options,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, contents)));
+            }
+
+            protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+                IEnumerable<ChatMessage> messages,
+                AgentSession session,
+                AgentRunOptions options,
+                [EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                yield return new AgentResponseUpdate(ChatRole.Assistant, contents);
+                await Task.CompletedTask;
+            }
+
+            protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken)
+            {
+                return new ValueTask<AgentSession>(new FakeSession());
+            }
+
+            protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(
+                JsonElement sessionData,
+                JsonSerializerOptions? options,
+                CancellationToken cancellationToken)
+            {
+                return new ValueTask<AgentSession>(new FakeSession());
+            }
+
+            protected override ValueTask<JsonElement> SerializeSessionCoreAsync(
+                AgentSession session,
+                JsonSerializerOptions? options,
+                CancellationToken cancellationToken)
+            {
+                return new ValueTask<JsonElement>(JsonDocument.Parse("{}").RootElement);
+            }
+        }
+
+        private sealed class FakeSession : AgentSession;
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
@@ -2,6 +2,7 @@ using Biotrackr.Chat.Api.Services;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 
 namespace Biotrackr.Chat.Api.Middleware
 {
@@ -51,6 +52,11 @@ namespace Biotrackr.Chat.Api.Middleware
                     else if (content is FunctionCallContent functionCall)
                     {
                         toolCalls.Add(functionCall.Name);
+                        logger.LogInformation(
+                            "Tool call: {ToolName} with arguments: {Arguments} in session {SessionId}",
+                            functionCall.Name,
+                            functionCall.Arguments is not null ? JsonSerializer.Serialize(functionCall.Arguments) : "null",
+                            sessionId);
                     }
                 }
 


### PR DESCRIPTION
## Summary

Extends `ConversationPersistenceMiddleware` to log tool call arguments (with JSON serialization) for audit and anomaly detection, addressing **ASI02: Tool Misuse & Exploitation** — Control 3 (Audit Logging).

## Changes

### `ConversationPersistenceMiddleware.cs`
- Serialize `FunctionCallContent.Arguments` via `JsonSerializer.Serialize` and log at `Information` level
- Log entry includes `ToolName`, `Arguments`, and `SessionId` for structured querying in Log Analytics
- Arguments are **not** persisted to Cosmos DB — only in the transient log stream (PII safety)

### `ConversationPersistenceMiddlewareShould.cs` *(new)*
- `LogToolCallWithArguments_WhenFunctionCallContentIsYielded` — verifies arguments appear in logs
- `LogNullArguments_WhenFunctionCallHasNoArguments` — verifies null arguments handled gracefully
- `NotPersistArgumentsToCosmosDb_WhenToolCallIsLogged` — verifies only tool names (not arguments) are saved to Cosmos

## Testing

All 52 unit tests pass (3 new + 49 existing).

## References

- Plan: `docs/plans/2026-03-13-asi02-log-tool-arguments.md`
- OWASP reference: `docs/blog-post-ideas/04-owasp-asi02-tool-misuse-exploitation.md`