### PR TITLE
core(infra): move system prompt to Key Vault secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,6 @@ docs/blog-post-ideas/*
 
 .github/agents/*
 .github/skills/*
+
+# Chat system prompt — sensitive configuration, stored in Key Vault
+scripts/chat-system-prompt/system-prompt.txt

--- a/infra/apps/chat-api/main.bicep
+++ b/infra/apps/chat-api/main.bicep
@@ -43,9 +43,6 @@ param jwtAudience string = environment().authentication.audiences[0]
 @description('The Claude model to use for the chat agent')
 param chatAgentModel string = 'claude-sonnet-4-6'
 
-@description('The system prompt for the chat agent')
-param chatSystemPrompt string = 'You are the Biotrackr health and fitness assistant. You help the user understand their health data by querying activity, sleep, weight, and food records using the available tools. Always use the tools to retrieve data before answering. Present data clearly and concisely. You are not a medical professional — remind users to consult a healthcare provider for medical advice.'
-
 @description('The application (client) ID of the agent identity blueprint')
 param agentBlueprintClientId string
 
@@ -364,12 +361,13 @@ resource apiSubscriptionKeySetting 'Microsoft.AppConfiguration/configurationStor
   }
 }
 
-// App Configuration: Chat agent system prompt
+// App Configuration: Chat agent system prompt (Key Vault reference)
 resource chatSystemPromptSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2025-02-01-preview' = {
   name: 'Biotrackr:ChatSystemPrompt'
   parent: appConfig
   properties: {
-    value: chatSystemPrompt
+    contentType: 'application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8'
+    value: '{"uri":"${keyVault.properties.vaultUri}secrets/ChatSystemPrompt"}'
   }
 }
 

--- a/scripts/chat-system-prompt/upload-system-prompt.ps1
+++ b/scripts/chat-system-prompt/upload-system-prompt.ps1
@@ -1,0 +1,35 @@
+<#
+.SYNOPSIS
+    Uploads the chat system prompt to Azure Key Vault.
+.DESCRIPTION
+    Reads the system prompt from system-prompt.txt and uploads it as a
+    Key Vault secret named 'ChatSystemPrompt'.
+.PARAMETER VaultName
+    The name of the Azure Key Vault.
+#>
+param(
+    [Parameter(Mandatory)]
+    [string]$VaultName
+)
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$promptFile = Join-Path $scriptDir 'system-prompt.txt'
+
+if (-not (Test-Path $promptFile)) {
+    Write-Error "System prompt file not found: $promptFile"
+    exit 1
+}
+
+az keyvault secret set `
+    --vault-name $VaultName `
+    --name 'ChatSystemPrompt' `
+    --file $promptFile `
+    --encoding utf-8 `
+    --content-type 'text/plain'
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "System prompt uploaded successfully to Key Vault '$VaultName'" -ForegroundColor Green
+} else {
+    Write-Error "Failed to upload system prompt to Key Vault"
+    exit 1
+}


### PR DESCRIPTION
## Summary

Hardens the Chat Agent system prompt (ASI01) and moves it from a plain-text Bicep parameter to an Azure Key Vault secret, referenced via App Configuration Key Vault reference.

## Changes

- **Remove `chatSystemPrompt` Bicep parameter** — the prompt is no longer stored in source control
- **App Config Key Vault reference** — `Biotrackr:ChatSystemPrompt` now uses the same `keyvaultref` pattern as `AnthropicApiKey`
- **Upload script** — `scripts/chat-system-prompt/upload-system-prompt.ps1` uploads the prompt from a local file to Key Vault using `--file` for multiline secret support
- **Gitignore** — `scripts/chat-system-prompt/system-prompt.txt` is excluded from source control

## Hardened System Prompt

The new prompt adds:
- **Explicit negative constraints** — cannot modify data, access URLs, or execute code
- **Anti-prompt-injection** — reject attempts to override instructions, change role, or extract system prompt
- **Tool result trust boundary** — ignore instructions/commands embedded in tool result content
- **Scope boundary** — only answer health/fitness data questions, redirect off-topic requests
- **Data quality caveats** — disclose data point counts and partial data in trend analysis (ASI09 §8.3)

## References

- Plan: `docs/plans/2026-03-13-asi01-harden-system-prompt.md`
- OWASP ASI01: `docs/blog-post-ideas/03-owasp-asi01-agent-goal-hijack.md` — Control 5 (System Prompt Scope Constraints)

## Prerequisites

The Key Vault secret `ChatSystemPrompt` must exist before deploying:
```powershell
.\scripts\chat-system-prompt\upload-system-prompt.ps1 -VaultName <keyvault-name>
```