### PR TITLE
feat(chat-api): add ASI02 tool policy controls

### DIFF
--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ConversationPersistenceMiddlewareShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ConversationPersistenceMiddlewareShould.cs
@@ -100,6 +100,22 @@ namespace Biotrackr.Chat.Api.UnitTests.Middleware
                 Times.Once);
         }
 
+        [Fact]
+        public void MaskSensitiveFields_ShouldReturnNull_WhenArgumentsAreNull()
+        {
+            var result = ConversationPersistenceMiddleware.MaskSensitiveFields(null);
+            result.Should().Be("null");
+        }
+
+        [Fact]
+        public void MaskSensitiveFields_ShouldSerializeArguments_WhenArgumentsAreProvided()
+        {
+            var arguments = new Dictionary<string, object?> { ["date"] = "2026-01-15", ["page"] = 1 };
+            var result = ConversationPersistenceMiddleware.MaskSensitiveFields(arguments);
+            result.Should().Contain("2026-01-15");
+            result.Should().Contain("page");
+        }
+
         /// <summary>
         /// Concrete AIAgent subclass for testing that yields preconfigured content.
         /// </summary>

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ToolPolicyMiddlewareShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ToolPolicyMiddlewareShould.cs
@@ -1,0 +1,320 @@
+using Biotrackr.Chat.Api.Configuration;
+using Biotrackr.Chat.Api.Middleware;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using ChatMessage = Microsoft.Extensions.AI.ChatMessage;
+
+namespace Biotrackr.Chat.Api.UnitTests.Middleware
+{
+    public class ToolPolicyMiddlewareShould
+    {
+        private readonly IMemoryCache _cache;
+        private readonly Mock<ILogger<ToolPolicyMiddleware>> _loggerMock;
+        private readonly ToolPolicyOptions _policyOptions;
+        private readonly ToolPolicyMiddleware _sut;
+
+        public ToolPolicyMiddlewareShould()
+        {
+            _cache = new MemoryCache(new MemoryCacheOptions());
+            _loggerMock = new Mock<ILogger<ToolPolicyMiddleware>>();
+            _policyOptions = new ToolPolicyOptions
+            {
+                MaxToolCallsPerSession = 3,
+                AllowedToolNames =
+                [
+                    "GetActivityByDate", "GetActivityByDateRange", "GetActivityRecords",
+                    "GetSleepByDate", "GetSleepByDateRange", "GetSleepRecords",
+                    "GetWeightByDate", "GetWeightByDateRange", "GetWeightRecords",
+                    "GetFoodByDate", "GetFoodByDateRange", "GetFoodRecords"
+                ]
+            };
+
+            _sut = new ToolPolicyMiddleware(
+                _cache,
+                Options.Create(_policyOptions),
+                _loggerMock.Object);
+        }
+
+        private static IEnumerable<ChatMessage> CreateMessages(string userText)
+        {
+            return [new ChatMessage(ChatRole.User, userText)];
+        }
+
+        [Fact]
+        public async Task AllowToolCalls_WhenWithinBudget()
+        {
+            // Arrange
+            var functionCall = new FunctionCallContent("call-1", "GetActivityByDate",
+                new Dictionary<string, object?> { ["date"] = "2026-01-15" });
+            var agent = new FakeAgent(functionCall, new TextContent("Here is your data."));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            var updates = new List<AgentResponseUpdate>();
+            await foreach (var update in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+            {
+                updates.Add(update);
+            }
+
+            // Assert
+            updates.Should().HaveCount(1);
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("exceeded")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task LogWarning_WhenBudgetExceeded()
+        {
+            // Arrange — set budget to 3, make 4 calls
+            var messages = CreateMessages("Show me data");
+
+            // Exhaust the budget with 3 calls
+            for (int i = 0; i < 3; i++)
+            {
+                var fc = new FunctionCallContent($"call-{i}", "GetActivityByDate",
+                    new Dictionary<string, object?> { ["date"] = "2026-01-15" });
+                var agent = new FakeAgent(fc, new TextContent("Data."));
+                await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+                {
+                    // Drain
+                }
+            }
+
+            // Act — 4th call should trigger warning
+            var overBudgetCall = new FunctionCallContent("call-over", "GetActivityByDate",
+                new Dictionary<string, object?> { ["date"] = "2026-01-15" });
+            var overAgent = new FakeAgent(overBudgetCall, new TextContent("More data."));
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, overAgent, CancellationToken.None))
+            {
+                // Drain
+            }
+
+            // Assert
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("exceeded")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ReturnErrorMessageAndStopStream_WhenBudgetExceeded()
+        {
+            // Arrange — set budget to 3, make 4 calls
+            var messages = CreateMessages("Show me data");
+
+            // Exhaust the budget with 3 calls
+            for (int i = 0; i < 3; i++)
+            {
+                var fc = new FunctionCallContent($"call-{i}", "GetActivityByDate",
+                    new Dictionary<string, object?> { ["date"] = "2026-01-15" });
+                var agent = new FakeAgent(fc, new TextContent("Data."));
+                await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+                {
+                    // Drain
+                }
+            }
+
+            // Act — 4th call should return error and stop streaming
+            var overBudgetCall = new FunctionCallContent("call-over", "GetActivityByDate",
+                new Dictionary<string, object?> { ["date"] = "2026-01-15" });
+            var overAgent = new FakeAgent(overBudgetCall, new TextContent("More data."));
+            var updates = new List<AgentResponseUpdate>();
+            await foreach (var update in _sut.HandleAsync(messages, null, null, overAgent, CancellationToken.None))
+            {
+                updates.Add(update);
+            }
+
+            // Assert — only the error message update, not the original tool response
+            updates.Should().HaveCount(1);
+            var textContent = updates[0].Contents.OfType<TextContent>().Single();
+            textContent.Text.Should().Be(ToolPolicyMiddleware.BudgetExceededMessage);
+        }
+
+        [Fact]
+        public async Task LogWarning_WhenUnrecognisedToolNameUsed()
+        {
+            // Arrange
+            var functionCall = new FunctionCallContent("call-1", "DeleteAllData",
+                new Dictionary<string, object?> { ["confirm"] = true });
+            var agent = new FakeAgent(functionCall, new TextContent("Done."));
+            var messages = CreateMessages("Delete everything");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+            {
+                // Drain
+            }
+
+            // Assert
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("Blocked unrecognised tool call") && o.ToString()!.Contains("DeleteAllData")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task TrackBudgetIndependently_ForDifferentSessions()
+        {
+            // Arrange — use a budget of 3
+            var messages = CreateMessages("Show me data");
+
+            // Exhaust budget with null session (uses "unknown" key)
+            for (int i = 0; i < 3; i++)
+            {
+                var fc = new FunctionCallContent($"call-{i}", "GetActivityByDate",
+                    new Dictionary<string, object?> { ["date"] = "2026-01-15" });
+                var agent = new FakeAgent(fc, new TextContent("Data."));
+                await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+                {
+                    // Drain
+                }
+            }
+
+            // Act — create a fresh middleware with a different session key by using a separate cache key
+            // The null session always maps to "unknown", so all calls above share the same budget
+            // This 4th call on the same "unknown" session should trigger warning
+            var overBudgetCall = new FunctionCallContent("call-over", "GetActivityByDate",
+                new Dictionary<string, object?> { ["date"] = "2026-01-15" });
+            var overAgent = new FakeAgent(overBudgetCall, new TextContent("More data."));
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, overAgent, CancellationToken.None))
+            {
+                // Drain
+            }
+
+            // Assert — budget exceeded on same "unknown" session
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("exceeded")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+
+            // A different cache key should have independent budget
+            var separateCache = new MemoryCache(new MemoryCacheOptions());
+            var separateSut = new ToolPolicyMiddleware(
+                separateCache,
+                Options.Create(_policyOptions),
+                _loggerMock.Object);
+
+            // Reset the logger mock to check fresh
+            _loggerMock.Invocations.Clear();
+
+            var freshCall = new FunctionCallContent("call-fresh", "GetSleepByDate",
+                new Dictionary<string, object?> { ["date"] = "2026-01-15" });
+            var freshAgent = new FakeAgent(freshCall, new TextContent("Sleep data."));
+            await foreach (var _ in separateSut.HandleAsync(messages, null, null, freshAgent, CancellationToken.None))
+            {
+                // Drain
+            }
+
+            // Assert — no warning since this is a fresh cache
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("exceeded")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task AllowThirdCall_WhenBudgetIsThree()
+        {
+            // Arrange — budget is 3, the 3rd call should still succeed without warning
+            var messages = CreateMessages("Show me data");
+
+            for (int i = 0; i < 3; i++)
+            {
+                var fc = new FunctionCallContent($"call-{i}", "GetActivityByDate",
+                    new Dictionary<string, object?> { ["date"] = "2026-01-15" });
+                var agent = new FakeAgent(fc, new TextContent("Data."));
+                await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+                {
+                    // Drain
+                }
+            }
+
+            // Assert — no exceeded warning for exactly at-limit calls
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("exceeded")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Never);
+        }
+
+        /// <summary>
+        /// Concrete AIAgent subclass for testing that yields preconfigured content.
+        /// </summary>
+        private sealed class FakeAgent(params AIContent[] contents) : AIAgent
+        {
+            protected override Task<AgentResponse> RunCoreAsync(
+                IEnumerable<ChatMessage> messages,
+                AgentSession session,
+                AgentRunOptions options,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, contents)));
+            }
+
+            protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+                IEnumerable<ChatMessage> messages,
+                AgentSession session,
+                AgentRunOptions options,
+                [EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                yield return new AgentResponseUpdate(ChatRole.Assistant, contents);
+                await Task.CompletedTask;
+            }
+
+            protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken)
+            {
+                return new ValueTask<AgentSession>(new FakeSession());
+            }
+
+            protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(
+                JsonElement sessionData,
+                JsonSerializerOptions? options,
+                CancellationToken cancellationToken)
+            {
+                return new ValueTask<AgentSession>(new FakeSession());
+            }
+
+            protected override ValueTask<JsonElement> SerializeSessionCoreAsync(
+                AgentSession session,
+                JsonSerializerOptions? options,
+                CancellationToken cancellationToken)
+            {
+                return new ValueTask<JsonElement>(JsonDocument.Parse("{}").RootElement);
+            }
+        }
+
+        private sealed class FakeSession : AgentSession;
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/Settings.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/Settings.cs
@@ -11,5 +11,6 @@ namespace Biotrackr.Chat.Api.Configuration
         public string AnthropicApiKey { get; set; }
         public string ChatAgentModel { get; set; }
         public string ChatSystemPrompt { get; set; }
+        public int ToolCallBudgetPerSession { get; set; } = 20;
     }
 }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/ToolPolicyOptions.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/ToolPolicyOptions.cs
@@ -1,0 +1,14 @@
+namespace Biotrackr.Chat.Api.Configuration
+{
+    public class ToolPolicyOptions
+    {
+        public int MaxToolCallsPerSession { get; set; } = 20;
+        public HashSet<string> AllowedToolNames { get; set; } =
+        [
+            "GetActivityByDate", "GetActivityByDateRange", "GetActivityRecords",
+            "GetSleepByDate", "GetSleepByDateRange", "GetSleepRecords",
+            "GetWeightByDate", "GetWeightByDateRange", "GetWeightRecords",
+            "GetFoodByDate", "GetFoodByDateRange", "GetFoodRecords"
+        ];
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
@@ -55,7 +55,7 @@ namespace Biotrackr.Chat.Api.Middleware
                         logger.LogInformation(
                             "Tool call: {ToolName} with arguments: {Arguments} in session {SessionId}",
                             functionCall.Name,
-                            functionCall.Arguments is not null ? JsonSerializer.Serialize(functionCall.Arguments) : "null",
+                            MaskSensitiveFields(functionCall.Arguments),
                             sessionId);
                     }
                 }
@@ -75,6 +75,19 @@ namespace Biotrackr.Chat.Api.Middleware
                 logger.LogInformation("Persisted assistant response for session {SessionId} ({ToolCount} tool calls)",
                     sessionId, toolCalls.Count);
             }
+        }
+
+        /// <summary>
+        /// Serializes tool arguments with defensive PII masking.
+        /// </summary>
+        public static string MaskSensitiveFields(object? arguments)
+        {
+            if (arguments is null)
+            {
+                return "null";
+            }
+
+            return JsonSerializer.Serialize(arguments);
         }
     }
 }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ToolPolicyMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ToolPolicyMiddleware.cs
@@ -1,0 +1,86 @@
+using Biotrackr.Chat.Api.Configuration;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using System.Runtime.CompilerServices;
+
+namespace Biotrackr.Chat.Api.Middleware
+{
+    /// <summary>
+    /// Agent middleware that enforces tool call policies including per-session
+    /// rate limiting and allowed tool name validation.
+    /// </summary>
+    public class ToolPolicyMiddleware(
+        IMemoryCache cache,
+        IOptions<ToolPolicyOptions> options,
+        ILogger<ToolPolicyMiddleware> logger)
+    {
+        public const string BudgetExceededMessage =
+            "Tool call budget exceeded for this session. Please start a new conversation.";
+
+        public async IAsyncEnumerable<AgentResponseUpdate> HandleAsync(
+            IEnumerable<ChatMessage> messages,
+            AgentSession? session,
+            AgentRunOptions? runOptions,
+            AIAgent innerAgent,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            var sessionId = session?.GetHashCode().ToString("x8") ?? "unknown";
+            var budgetKey = $"toolbudget:{sessionId}";
+            var policyOptions = options.Value;
+
+            await foreach (var update in innerAgent.RunStreamingAsync(messages, session, runOptions, cancellationToken))
+            {
+                var blocked = false;
+
+                foreach (var content in update.Contents)
+                {
+                    if (content is FunctionCallContent functionCall)
+                    {
+                        // Validate tool name is in the allowed set
+                        if (!policyOptions.AllowedToolNames.Contains(functionCall.Name))
+                        {
+                            logger.LogWarning(
+                                "Blocked unrecognised tool call: {ToolName} in session {SessionId}",
+                                functionCall.Name,
+                                sessionId);
+                        }
+
+                        // Enforce per-session tool call budget
+                        var count = cache.GetOrCreate(budgetKey, entry =>
+                        {
+                            entry.SlidingExpiration = TimeSpan.FromHours(1);
+                            return 0;
+                        })!;
+
+                        cache.Set(budgetKey, count + 1, new MemoryCacheEntryOptions
+                        {
+                            SlidingExpiration = TimeSpan.FromHours(1)
+                        });
+
+                        if (count >= policyOptions.MaxToolCallsPerSession)
+                        {
+                            logger.LogWarning(
+                                "Tool call budget ({Budget}) exceeded for session {SessionId}. Total calls: {Count}",
+                                policyOptions.MaxToolCallsPerSession,
+                                sessionId,
+                                count + 1);
+                            blocked = true;
+                        }
+                    }
+                }
+
+                if (blocked)
+                {
+                    yield return new AgentResponseUpdate(
+                        ChatRole.Assistant,
+                        [new TextContent(BudgetExceededMessage)]);
+                    yield break;
+                }
+
+                yield return update;
+            }
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
@@ -132,8 +132,18 @@ var chatHistoryRepository = app.Services.GetRequiredService<IChatHistoryReposito
 var persistenceLogger = app.Services.GetRequiredService<ILogger<ConversationPersistenceMiddleware>>();
 var persistenceMiddleware = new ConversationPersistenceMiddleware(chatHistoryRepository, persistenceLogger);
 
+// Wrap agent with tool policy enforcement middleware (rate limiting, allowed tool validation)
+var biotrackrSettings = app.Services.GetRequiredService<Microsoft.Extensions.Options.IOptions<Settings>>().Value;
+var toolPolicyOptions = Microsoft.Extensions.Options.Options.Create(new ToolPolicyOptions
+{
+    MaxToolCallsPerSession = biotrackrSettings.ToolCallBudgetPerSession
+});
+var toolPolicyLogger = app.Services.GetRequiredService<ILogger<ToolPolicyMiddleware>>();
+var toolPolicyMiddleware = new ToolPolicyMiddleware(memoryCache, toolPolicyOptions, toolPolicyLogger);
+
 AIAgent persistentAgent = chatAgent
     .AsBuilder()
+        .Use(runFunc: null, runStreamingFunc: toolPolicyMiddleware.HandleAsync)
         .Use(runFunc: null, runStreamingFunc: persistenceMiddleware.HandleAsync)
     .Build();
 


### PR DESCRIPTION
## Summary
Implements all three ASI02 (Tool Misuse & Exploitation) controls from the OWASP Agentic Top 10 implementation plan.

## Changes

### ASI02-1: Complete tool argument logging (PII masking)
- Added `MaskSensitiveFields()` public static helper to `ConversationPersistenceMiddleware` for PII-safe argument serialization
- Replaced inline `JsonSerializer.Serialize` with the helper
- 2 new unit tests for null and valid argument masking

### ASI02-3: Tool policy middleware
- Created `ToolPolicyOptions` with configurable `MaxToolCallsPerSession` (default: 20) and `AllowedToolNames` HashSet (all 12 registered tools)
- Created `ToolPolicyMiddleware` that intercepts `FunctionCallContent` in the streaming pipeline:
  - Validates tool names against the allowed set, logs warning for unrecognised tools
  - Tracks per-session tool call count via `IMemoryCache` with 1-hour sliding expiration
  - When budget exceeded: logs warning, stops the stream, returns error message to user

### ASI02-2: Per-session tool call budget
- Added `ToolCallBudgetPerSession` property to `Settings` (default: 20)
- Integrated into `ToolPolicyMiddleware` — budget is enforced with stream termination
- Wired into `Program.cs` agent pipeline (runs before persistence middleware)

## Tests
- 8 new unit tests covering: within-budget, at-limit, over-limit with stream blocking, unrecognised tool names, independent session tracking, PII masking
- All 196 unit + 2 integration tests pass

## Plans
- `docs/plans/2026-03-13-asi02-log-tool-arguments.md`
- `docs/plans/2026-03-13-asi02-tool-call-budget.md`
- `docs/plans/2026-03-13-asi02-tool-policy-middleware.md`