### PR TITLE
feat: Add OpenTelemetry instrumentation to Activity API

### DIFF
--- a/infra/apps/activity-api/main.bicep
+++ b/infra/apps/activity-api/main.bicep
@@ -25,6 +25,9 @@ param appConfigName string
 @description('The name of the Cosmos DB account that this Activity Api uses')
 param cosmosDbAccountName string
 
+@description('The name of the Application Insights instance')
+param appInsightsName string
+
 @description('The name of the API Management instance that this Api uses')
 param apimName string
 
@@ -47,6 +50,10 @@ resource appConfig 'Microsoft.AppConfiguration/configurationStores@2024-05-01' e
 
 resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' existing = {
   name: cosmosDbAccountName
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: appInsightsName
 }
 
 resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
@@ -92,6 +99,10 @@ module activityApi '../../modules/host/container-app-http.bicep' = {
       {
         name: 'cosmosdbendpoint'
         value: cosmosDbAccount.properties.documentEndpoint
+      }
+      {
+        name: 'applicationinsightsconnectionstring'
+        value: appInsights.properties.ConnectionString
       }
     ]
   }

--- a/infra/apps/activity-api/main.dev.bicepparam
+++ b/infra/apps/activity-api/main.dev.bicepparam
@@ -13,6 +13,7 @@ param containerRegistryName = 'acrbiotrackrdev'
 param uaiName = 'uai-biotrackr-dev'
 param appConfigName = 'config-biotrackr-dev'
 param cosmosDbAccountName = 'cosmos-biotrackr-dev'
+param appInsightsName = 'appins-biotrackr-dev'
 param apimName = 'api-biotrackr-dev'
 param enableManagedIdentityAuth = true
 param tenantId = ''

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/Fixtures/ActivityApiWebApplicationFactory.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api.IntegrationTests/Fixtures/ActivityApiWebApplicationFactory.cs
@@ -25,6 +25,7 @@ public class ActivityApiWebApplicationFactory : WebApplicationFactory<Program>
         Environment.SetEnvironmentVariable("Biotrackr:ContainerName", "activity-test");
         Environment.SetEnvironmentVariable("azureappconfigendpoint", string.Empty);
         Environment.SetEnvironmentVariable("managedidentityclientid", string.Empty);
+        Environment.SetEnvironmentVariable("applicationinsightsconnectionstring", "InstrumentationKey=00000000-0000-0000-0000-000000000000");
         
         // Set environment to Test
         builder.UseEnvironment("Test");

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Biotrackr.Activity.Api.csproj
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Biotrackr.Activity.Api.csproj
@@ -10,11 +10,15 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.18.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Program.cs
+++ b/src/Biotrackr.Activity.Api/Biotrackr.Activity.Api/Program.cs
@@ -1,10 +1,21 @@
 using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.Exporter;
 using Biotrackr.Activity.Api.Configuration;
 using Biotrackr.Activity.Api.Extensions;
 using Biotrackr.Activity.Api.Repositories;
 using Biotrackr.Activity.Api.Repositories.Interfaces;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+var resourceAttributes = new Dictionary<string, object>
+{
+    { "service.name", "Biotrackr.Activity.Api" },
+    { "service.version", "1.0.0" }
+};
+var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -51,6 +62,39 @@ builder.Services.AddScoped<ICosmosRepository, CosmosRepository>();
 builder.Services.AddOpenApi();
 
 builder.Services.AddHealthChecks();
+
+var appInsightsConnectionString = builder.Configuration["applicationinsightsconnectionstring"];
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing =>
+    {
+        tracing.SetResourceBuilder(resourceBuilder)
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddAzureMonitorTraceExporter(options =>
+            {
+                options.ConnectionString = appInsightsConnectionString;
+            });
+    })
+    .WithMetrics(metrics =>
+    {
+        metrics.SetResourceBuilder(resourceBuilder)
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddAzureMonitorMetricExporter(options =>
+            {
+                options.ConnectionString = appInsightsConnectionString;
+            });
+    });
+
+builder.Logging.AddOpenTelemetry(log =>
+{
+    log.SetResourceBuilder(resourceBuilder);
+    log.AddAzureMonitorLogExporter(options =>
+    {
+        options.ConnectionString = appInsightsConnectionString;
+    });
+});
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary

Adds OpenTelemetry tracing, metrics, and logging with Azure Monitor exporter to `Biotrackr.Activity.Api`. This service previously had zero OTel instrumentation — no `AppRequests`, traces, metrics, or logs were emitted to Application Insights.

## Changes

### Application Code
- **Biotrackr.Activity.Api.csproj** — Added NuGet packages:
  - `Azure.Monitor.OpenTelemetry.Exporter` 1.4.0
  - `OpenTelemetry.Extensions.Hosting` 1.12.0
  - `OpenTelemetry.Instrumentation.AspNetCore` 1.12.0
  - `OpenTelemetry.Instrumentation.Http` 1.12.0
- **Program.cs** — Configured OpenTelemetry with:
  - Tracing (ASP.NET Core + HTTP client instrumentation)
  - Metrics (ASP.NET Core + HTTP client instrumentation)
  - Logging via Azure Monitor log exporter
  - Resource attributes (`service.name`, `service.version`)

### Infrastructure
- **infra/apps/activity-api/main.bicep** — Added `appInsightsName` parameter, `appInsights` existing resource reference, and `applicationinsightsconnectionstring` environment variable
- **infra/apps/activity-api/main.dev.bicepparam** — Added `appInsightsName = 'appins-biotrackr-dev'`

## Related Plan

[`docs/plans/2026-03-15-asi03-activity-api-telemetry.md`](docs/plans/2026-03-15-asi03-activity-api-telemetry.md)

## Acceptance Criteria

- [x] `Biotrackr.Activity.Api` compiles with new OTel packages
- [ ] `applicationinsightsconnectionstring` env var added to infra
- [ ] Application visible in Application Insights Application Map after deployment
- [ ] `AppRequests` table shows Activity API requests