### PR TITLE
feat: Add OpenTelemetry instrumentation to Biotrackr.Food.Api

### DIFF
--- a/infra/apps/food-api/main.bicep
+++ b/infra/apps/food-api/main.bicep
@@ -25,6 +25,9 @@ param appConfigName string
 @description('The name of the Cosmos DB account that this Food Api uses')
 param cosmosDbAccountName string
 
+@description('The name of the Application Insights instance')
+param appInsightsName string
+
 @description('The name of the API Management instance that this Api uses')
 param apimName string
 
@@ -47,6 +50,10 @@ resource appConfig 'Microsoft.AppConfiguration/configurationStores@2024-05-01' e
 
 resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' existing = {
   name: cosmosDbAccountName
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: appInsightsName
 }
 
 resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
@@ -92,6 +99,10 @@ module foodApi '../../modules/host/container-app-http.bicep' = {
       {
         name: 'cosmosdbendpoint'
         value: cosmosDbAccount.properties.documentEndpoint
+      }
+      {
+        name: 'applicationinsightsconnectionstring'
+        value: appInsights.properties.ConnectionString
       }
     ]
   }

--- a/infra/apps/food-api/main.dev.bicepparam
+++ b/infra/apps/food-api/main.dev.bicepparam
@@ -13,6 +13,7 @@ param containerRegistryName = 'acrbiotrackrdev'
 param uaiName = 'uai-biotrackr-dev'
 param appConfigName = 'config-biotrackr-dev'
 param cosmosDbAccountName = 'cosmos-biotrackr-dev'
+param appInsightsName = 'appins-biotrackr-dev'
 param apimName = 'api-biotrackr-dev'
 param enableManagedIdentityAuth = true
 param tenantId = ''

--- a/src/Biotrackr.Food.Api/Biotrackr.Food.Api.IntegrationTests/Fixtures/FoodApiWebApplicationFactory.cs
+++ b/src/Biotrackr.Food.Api/Biotrackr.Food.Api.IntegrationTests/Fixtures/FoodApiWebApplicationFactory.cs
@@ -25,6 +25,7 @@ public class FoodApiWebApplicationFactory : WebApplicationFactory<Program>
         Environment.SetEnvironmentVariable("Biotrackr:ContainerName", "food-test");
         Environment.SetEnvironmentVariable("azureappconfigendpoint", string.Empty);
         Environment.SetEnvironmentVariable("managedidentityclientid", string.Empty);
+        Environment.SetEnvironmentVariable("applicationinsightsconnectionstring", "InstrumentationKey=00000000-0000-0000-0000-000000000000");
         
         // Set environment to Test
         builder.UseEnvironment("Test");

--- a/src/Biotrackr.Food.Api/Biotrackr.Food.Api/Biotrackr.Food.Api.csproj
+++ b/src/Biotrackr.Food.Api/Biotrackr.Food.Api/Biotrackr.Food.Api.csproj
@@ -8,10 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.18.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Biotrackr.Food.Api/Biotrackr.Food.Api/Program.cs
+++ b/src/Biotrackr.Food.Api/Biotrackr.Food.Api/Program.cs
@@ -1,6 +1,18 @@
 using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.Exporter;
 using Biotrackr.Food.Api.Extensions;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using System.Diagnostics.CodeAnalysis;
+
+var resourceAttributes = new Dictionary<string, object>
+{
+    { "service.name", "Biotrackr.Food.Api" },
+    { "service.version", "1.0.0" }
+};
+var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -31,6 +43,39 @@ builder.Services.AddOpenApi();
 // Add health checks
 builder.Services.AddHealthChecks();
 
+var appInsightsConnectionString = builder.Configuration["applicationinsightsconnectionstring"];
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing =>
+    {
+        tracing.SetResourceBuilder(resourceBuilder)
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddAzureMonitorTraceExporter(options =>
+            {
+                options.ConnectionString = appInsightsConnectionString;
+            });
+    })
+    .WithMetrics(metrics =>
+    {
+        metrics.SetResourceBuilder(resourceBuilder)
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddAzureMonitorMetricExporter(options =>
+            {
+                options.ConnectionString = appInsightsConnectionString;
+            });
+    });
+
+builder.Logging.AddOpenTelemetry(log =>
+{
+    log.SetResourceBuilder(resourceBuilder);
+    log.AddAzureMonitorLogExporter(options =>
+    {
+        options.ConnectionString = appInsightsConnectionString;
+    });
+});
+
 var app = builder.Build();
 
 app.MapOpenApi();
@@ -40,3 +85,6 @@ app.RegisterFoodEndpoints();
 app.RegisterHealthCheckEndpoints();
 
 app.Run();
+
+[ExcludeFromCodeCoverage]
+public partial class Program { }


### PR DESCRIPTION
# Add OpenTelemetry to Biotrackr.Food.Api

## Summary

Adds OpenTelemetry tracing, metrics, and logging with Azure Monitor exporter to `Biotrackr.Food.Api`, matching the pattern already in place for `Biotrackr.Activity.Api`.

## Changes

### Application Code
- **Biotrackr.Food.Api.csproj** — Added NuGet packages: `Azure.Monitor.OpenTelemetry.Exporter`, `OpenTelemetry.Extensions.Hosting`, `OpenTelemetry.Instrumentation.AspNetCore`, `OpenTelemetry.Instrumentation.Http`
- **Program.cs** — Configured OpenTelemetry tracing, metrics, and logging with Azure Monitor exporters using the `applicationinsightsconnectionstring` configuration value

### Infrastructure
- **infra/apps/food-api/main.bicep** — Added `appInsightsName` parameter, `appInsights` existing resource reference, and `applicationinsightsconnectionstring` environment variable to the container app
- **infra/apps/food-api/main.dev.bicepparam** — Added `appInsightsName = 'appins-biotrackr-dev'`

### Tests
- **FoodApiWebApplicationFactory.cs** — Added dummy App Insights connection string (`InstrumentationKey=00000000-0000-0000-0000-000000000000`) for integration tests, matching the Activity API test pattern

## Plan Reference

Implements [`docs/plans/2026-03-15-asi03-food-api-telemetry.md`](docs/plans/2026-03-15-asi03-food-api-telemetry.md)

## Testing

- ✅ Build succeeds
- ✅ 31/31 unit tests pass
- ✅ 18/18 contract/smoke integration tests pass
- ⏭️ E2E tests require Cosmos DB emulator (not related to this change)