### PR TITLE
feat: Switch MCP Server from OTLP to Azure Monitor telemetry exporter

### DIFF
--- a/infra/apps/mcp-server/main.bicep
+++ b/infra/apps/mcp-server/main.bicep
@@ -22,6 +22,9 @@ param uaiName string
 @description('The name of the App Config Store that the MCP Server uses')
 param appConfigName string
 
+@description('The name of the Application Insights instance')
+param appInsightsName string
+
 @description('The name of the API Management instance that this MCP Server uses')
 param apimName string
 
@@ -40,6 +43,10 @@ resource uai 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' exist
 
 resource appConfig 'Microsoft.AppConfiguration/configurationStores@2024-05-01' existing = {
   name: appConfigName
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: appInsightsName
 }
 
 resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
@@ -83,6 +90,10 @@ module mcpServer '../../modules/host/container-app-http.bicep' = {
       {
         name: 'managedidentityclientid'
         value: uai.properties.clientId
+      }
+      {
+        name: 'applicationinsightsconnectionstring'
+        value: appInsights.properties.ConnectionString
       }
     ]
   }

--- a/infra/apps/mcp-server/main.dev.bicepparam
+++ b/infra/apps/mcp-server/main.dev.bicepparam
@@ -12,6 +12,7 @@ param containerAppEnvironmentName = 'env-biotrackr-dev'
 param containerRegistryName = 'acrbiotrackrdev'
 param uaiName = 'uai-biotrackr-dev'
 param appConfigName = 'config-biotrackr-dev'
+param appInsightsName = 'appins-biotrackr-dev'
 param apimName = 'api-biotrackr-dev'
 param enableManagedIdentityAuth = true
 param tenantId = ''

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server.IntegrationTests/Fixtures/McpServerWebApplicationFactory.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server.IntegrationTests/Fixtures/McpServerWebApplicationFactory.cs
@@ -58,6 +58,7 @@ namespace Biotrackr.Mcp.Server.IntegrationTests.Fixtures
             // Override config values via environment variables
             builder.UseSetting("biotrackrapiendpoint", "https://mock-api.test.com");
             builder.UseSetting("biotrackrapisubscriptionkey", "test-sub-key");
+            builder.UseSetting("applicationinsightsconnectionstring", "InstrumentationKey=00000000-0000-0000-0000-000000000000");
         }
     }
 }

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server.csproj
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.2.0" />
     <PackageReference Include="ModelContextProtocol" Version="0.8.0-preview.1" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Program.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Program.cs
@@ -1,6 +1,5 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Threading.RateLimiting;
 using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.Exporter;
 using Biotrackr.Mcp.Server.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -9,9 +8,18 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.RateLimiting;
+
+var resourceAttributes = new Dictionary<string, object>
+{
+    { "service.name", "Biotrackr.Mcp.Server" },
+    { "service.version", "1.0.0" }
+};
+var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -45,8 +53,11 @@ builder.Services
     .WithHttpTransport(o => o.Stateless = true)
     .WithToolsFromAssembly();
 
+var appInsightsConnectionString = builder.Configuration["applicationinsightsconnectionstring"];
+
 builder.Services.AddOpenTelemetry()
-    .WithTracing(b => b.AddSource("Biotrackr.Mcp.Server")
+    .WithTracing(b => b.SetResourceBuilder(resourceBuilder)
+        .AddSource("Biotrackr.Mcp.Server")
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation(o =>
         {
@@ -56,12 +67,28 @@ builder.Services.AddOpenTelemetry()
                 // Ensure subscription key header is never captured in traces
                 activity.SetTag("http.request.header.ocp_apim_subscription_key", "[REDACTED]");
             };
+        })
+        .AddAzureMonitorTraceExporter(options =>
+        {
+            options.ConnectionString = appInsightsConnectionString;
         }))
-    .WithMetrics(b => b.AddMeter("Biotrackr.Mcp.Server")
+    .WithMetrics(b => b.SetResourceBuilder(resourceBuilder)
+        .AddMeter("Biotrackr.Mcp.Server")
         .AddAspNetCoreInstrumentation()
-        .AddHttpClientInstrumentation())
-    .WithLogging()
-    .UseOtlpExporter();
+        .AddHttpClientInstrumentation()
+        .AddAzureMonitorMetricExporter(options =>
+        {
+            options.ConnectionString = appInsightsConnectionString;
+        }));
+
+builder.Logging.AddOpenTelemetry(log =>
+{
+    log.SetResourceBuilder(resourceBuilder);
+    log.AddAzureMonitorLogExporter(options =>
+    {
+        options.ConnectionString = appInsightsConnectionString;
+    });
+});
 
 builder.Services.AddTransient<ApiKeyDelegatingHandler>();
 


### PR DESCRIPTION
# Switch MCP Server from OTLP to Azure Monitor Telemetry Exporter

## Summary

Replaces the silently-dropped OTLP exporter (targeting `localhost:4317` with no collector configured) with Azure Monitor exporters, ensuring telemetry actually reaches Application Insights in production.

## Changes

### Application Code
- **Biotrackr.Mcp.Server.csproj** — Replaced `OpenTelemetry.Exporter.OpenTelemetryProtocol` with `Azure.Monitor.OpenTelemetry.Exporter`
- **Program.cs** — Swapped `.UseOtlpExporter()` for individual Azure Monitor trace, metric, and log exporters with a `ResourceBuilder`; preserved custom `AddSource("Biotrackr.Mcp.Server")`, `AddMeter`, and HTTP instrumentation enrichment (subscription key redaction)

### Infrastructure
- **infra/apps/mcp-server/main.bicep** — Added `appInsightsName` parameter, `appInsights` existing resource reference, and `applicationinsightsconnectionstring` environment variable
- **infra/apps/mcp-server/main.dev.bicepparam** — Added `appInsightsName = 'appins-biotrackr-dev'`

### Tests
- **McpServerWebApplicationFactory.cs** — Added dummy App Insights connection string for integration tests

## Plan Reference

Implements [`docs/plans/2026-03-15-asi03-mcp-server-telemetry.md`](docs/plans/2026-03-15-asi03-mcp-server-telemetry.md)

## Testing

- ✅ Build succeeds
- ✅ 106/106 unit tests pass
- ✅ 13/13 integration tests pass