### PR TITLE
feat: Switch Chat API from OTLP to Azure Monitor telemetry exporter

### DIFF
--- a/infra/apps/chat-api/main.bicep
+++ b/infra/apps/chat-api/main.bicep
@@ -25,6 +25,9 @@ param appConfigName string
 @description('The name of the Cosmos DB account that this Chat Api uses')
 param cosmosDbAccountName string
 
+@description('The name of the Application Insights instance')
+param appInsightsName string
+
 @description('The name of the API Management instance that this Api uses')
 param apimName string
 
@@ -59,6 +62,10 @@ resource appConfig 'Microsoft.AppConfiguration/configurationStores@2024-05-01' e
 
 resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' existing = {
   name: cosmosDbAccountName
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: appInsightsName
 }
 
 resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
@@ -104,6 +111,10 @@ module chatApi '../../modules/host/container-app-http.bicep' = {
       {
         name: 'managedidentityclientid'
         value: uai.properties.clientId
+      }
+      {
+        name: 'applicationinsightsconnectionstring'
+        value: appInsights.properties.ConnectionString
       }
     ]
   }

--- a/infra/apps/chat-api/main.dev.bicepparam
+++ b/infra/apps/chat-api/main.dev.bicepparam
@@ -13,6 +13,7 @@ param containerRegistryName = 'acrbiotrackrdev'
 param uaiName = 'uai-biotrackr-dev'
 param appConfigName = 'config-biotrackr-dev'
 param cosmosDbAccountName = 'cosmos-biotrackr-dev'
+param appInsightsName = 'appins-biotrackr-dev'
 param apimName = 'api-biotrackr-dev'
 param keyVaultName = 'kv-biotrackr-dev'
 param enableManagedIdentityAuth = true

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.IntegrationTests/Fixtures/ChatApiWebApplicationFactory.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.IntegrationTests/Fixtures/ChatApiWebApplicationFactory.cs
@@ -27,6 +27,7 @@ public class ChatApiWebApplicationFactory : WebApplicationFactory<Program>
         Environment.SetEnvironmentVariable("Biotrackr:ChatSystemPrompt", "You are a test assistant.");
         Environment.SetEnvironmentVariable("azureappconfigendpoint", string.Empty);
         Environment.SetEnvironmentVariable("managedidentityclientid", string.Empty);
+        Environment.SetEnvironmentVariable("applicationinsightsconnectionstring", "InstrumentationKey=00000000-0000-0000-0000-000000000000");
         Environment.SetEnvironmentVariable("AzureAd:TenantId", "test-tenant");
         Environment.SetEnvironmentVariable("AzureAd:ClientId", "test-client");
 

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Biotrackr.Chat.Api.csproj
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Biotrackr.Chat.Api.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="Microsoft.Identity.Web.AgentIdentities" Version="4.5.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
   </ItemGroup>

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
@@ -1,5 +1,6 @@
 using Anthropic;
 using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.Exporter;
 using Biotrackr.Chat.Api.Configuration;
 using Biotrackr.Chat.Api.Configuration;
 using Biotrackr.Chat.Api.Extensions;
@@ -13,7 +14,16 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Identity.Web;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using System.Diagnostics.CodeAnalysis;
+
+var resourceAttributes = new Dictionary<string, object>
+{
+    { "service.name", "Biotrackr.Chat.Api" },
+    { "service.version", "1.0.0" }
+};
+var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -71,15 +81,38 @@ builder.Services.AddHttpClient("BiotrackrApi", (sp, client) =>
 .AddStandardResilienceHandler();
 
 // OpenTelemetry
+var appInsightsConnectionString = builder.Configuration["applicationinsightsconnectionstring"];
+
 builder.Services.AddOpenTelemetry()
-    .WithTracing(tracing => tracing
-        .AddAspNetCoreInstrumentation()
-        .AddHttpClientInstrumentation()
-        .AddOtlpExporter())
-    .WithMetrics(metrics => metrics
-        .AddAspNetCoreInstrumentation()
-        .AddHttpClientInstrumentation()
-        .AddOtlpExporter());
+    .WithTracing(tracing =>
+    {
+        tracing.SetResourceBuilder(resourceBuilder)
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddAzureMonitorTraceExporter(options =>
+            {
+                options.ConnectionString = appInsightsConnectionString;
+            });
+    })
+    .WithMetrics(metrics =>
+    {
+        metrics.SetResourceBuilder(resourceBuilder)
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddAzureMonitorMetricExporter(options =>
+            {
+                options.ConnectionString = appInsightsConnectionString;
+            });
+    });
+
+builder.Logging.AddOpenTelemetry(log =>
+{
+    log.SetResourceBuilder(resourceBuilder);
+    log.AddAzureMonitorLogExporter(options =>
+    {
+        options.ConnectionString = appInsightsConnectionString;
+    });
+});
 
 // OpenAPI
 builder.Services.AddOpenApi();
@@ -157,3 +190,6 @@ app.RegisterChatEndpoints();
 app.RegisterHealthCheckEndpoints();
 
 app.Run();
+
+[ExcludeFromCodeCoverage]
+public partial class Program { }


### PR DESCRIPTION
# Switch Chat API from OTLP to Azure Monitor Telemetry Exporter

## Summary

Replaces the silently-dropped OTLP exporter (targeting `localhost:4317` with no collector configured) with Azure Monitor exporters, and adds the previously missing logging exporter.

## Changes

### Application Code
- **Biotrackr.Chat.Api.csproj** — Replaced `OpenTelemetry.Exporter.OpenTelemetryProtocol` with `Azure.Monitor.OpenTelemetry.Exporter`; bumped `OpenTelemetry.Extensions.Hosting` from 1.11.2 to 1.12.0
- **Program.cs** — Swapped `.AddOtlpExporter()` for individual Azure Monitor trace, metric, and log exporters with a `ResourceBuilder`; added `[ExcludeFromCodeCoverage]` on `Program` class; added logging exporter (was previously missing)

### Infrastructure
- **infra/apps/chat-api/main.bicep** — Added `appInsightsName` parameter, `appInsights` existing resource reference, and `applicationinsightsconnectionstring` environment variable
- **infra/apps/chat-api/main.dev.bicepparam** — Added `appInsightsName = 'appins-biotrackr-dev'`

### Tests
- **ChatApiWebApplicationFactory.cs** — Added dummy App Insights connection string for integration tests

## Plan Reference

Implements [`docs/plans/2026-03-15-asi03-chat-api-telemetry.md`](docs/plans/2026-03-15-asi03-chat-api-telemetry.md)

## Testing

- ✅ Build succeeds
- ✅ 196/196 unit tests pass
- ✅ 2/2 integration tests pass