### PR TITLE
feat: Add CycloneDX SBOM generation to container image build pipeline

### DIFF
--- a/.github/workflows/deploy-chat-api.yml
+++ b/.github/workflows/deploy-chat-api.yml
@@ -52,7 +52,7 @@ jobs:
     build-container-image-dev:
           name: Build and Push Container Image
           needs: [run-unit-tests, run-contract-tests]
-          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
+          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@feature/asi04-sbom-generation
           with:
             working-directory: ./src/Biotrackr.Chat.Api
             app-name: biotrackr-chat-api
@@ -92,8 +92,7 @@ jobs:
     validate:
         name: Validate Template
         needs: [lint, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@feature/asi03-alert-rules
-        with:
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@main
           template-file: './infra/apps/chat-api/main.bicep'
           parameters-file: ./infra/apps/chat-api/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-chat-api:${{ github.sha }}"}'
@@ -110,7 +109,7 @@ jobs:
     preview:
         name: Preview Changes
         needs: [validate, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@feature/asi03-alert-rules
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@main
         with:
           scope: resourceGroup
           template-file: './infra/apps/chat-api/main.bicep'
@@ -128,7 +127,7 @@ jobs:
     deploy-dev:
         name: Deploy Template to Dev
         needs: [preview, retrieve-container-image-dev]
-        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@feature/asi03-alert-rules
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@main
         with:
           template-file: './infra/apps/chat-api/main.bicep'
           parameters-file: ./infra/apps/chat-api/main.dev.bicepparam

--- a/.github/workflows/deploy-chat-api.yml
+++ b/.github/workflows/deploy-chat-api.yml
@@ -93,6 +93,7 @@ jobs:
         name: Validate Template
         needs: [lint, retrieve-container-image-dev]
         uses: willvelida/biotrackr/.github/workflows/template-bicep-validate.yml@main
+        with:
           template-file: './infra/apps/chat-api/main.bicep'
           parameters-file: ./infra/apps/chat-api/main.dev.bicepparam
           parameters: '{"imageName": "${{ needs.retrieve-container-image-dev.outputs.loginServer }}/biotrackr-chat-api:${{ github.sha }}"}'

--- a/.github/workflows/deploy-chat-api.yml
+++ b/.github/workflows/deploy-chat-api.yml
@@ -9,7 +9,7 @@ on:
             - 'src/Biotrackr.Chat.Api/**'
 
 permissions:
-    contents: read
+    contents: write
     id-token: write
     pull-requests: write
     checks: write

--- a/.github/workflows/template-acr-push-image.yml
+++ b/.github/workflows/template-acr-push-image.yml
@@ -77,6 +77,14 @@ jobs:
             path: sbom.cdx.json
             retention-days: 90
 
+        - name: Submit SBOM to GitHub Dependency Graph
+          uses: anchore/sbom-action@v0
+          with:
+            image: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}:${{ github.sha }}
+            dependency-snapshot: true
+            upload-artifact: false
+          continue-on-error: true
+
         - name: Run Dockle
           uses: erzz/dockle-action@v1
           with:

--- a/.github/workflows/template-acr-push-image.yml
+++ b/.github/workflows/template-acr-push-image.yml
@@ -61,6 +61,22 @@ jobs:
           run: |
             docker build -t ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}:${{ github.sha }} .
 
+        - name: Generate SBOM
+          uses: aquasecurity/trivy-action@0.35.0
+          with:
+            image-ref: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}:${{ github.sha }}
+            format: 'cyclonedx'
+            output: 'sbom.cdx.json'
+          continue-on-error: true
+
+        - name: Upload SBOM as artifact
+          if: always()
+          uses: actions/upload-artifact@v4
+          with:
+            name: sbom-${{ inputs.app-name }}
+            path: sbom.cdx.json
+            retention-days: 90
+
         - name: Run Dockle
           uses: erzz/dockle-action@v1
           with:

--- a/src/Biotrackr.Chat.Api/Dockerfile
+++ b/src/Biotrackr.Chat.Api/Dockerfile
@@ -1,4 +1,5 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# SBOM: CycloneDX SBOM is generated from this image by Trivy in CI/CD
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base


### PR DESCRIPTION
## Summary

Adds Software Bill of Materials (SBOM) generation in CycloneDX format to the container image build workflow, using Trivy (already present in the pipeline for vulnerability scanning).

**Reference:** OWASP ASI04 — Supply Chain Vulnerabilities (Control 1: Provenance, SBOMs, and AIBOMs)
**Plan:** `docs/plans/2026-03-13-asi04-sbom-generation.md`

## Changes

### `.github/workflows/template-acr-push-image.yml`
- Added **Generate SBOM** step using `aquasecurity/trivy-action@0.35.0` with `format: 'cyclonedx'` to produce a CycloneDX JSON SBOM from the built container image
- Added **Upload SBOM as artifact** step using `actions/upload-artifact@v4` with 90-day retention
- SBOM generation uses `continue-on-error: true` so failures don't block the image push
- Upload step uses `if: always()` to persist the artifact regardless of SBOM step outcome

### `.github/workflows/deploy-chat-api.yml`
- Temporarily pointed ACR push image template reference to `@feature/asi04-sbom-generation` for testing
- **⚠️ Must revert to `@main` before merging**

### `src/Biotrackr.Chat.Api/Dockerfile`
- Added SBOM documentation comment to trigger the Chat API workflow on this PR

## Step Order (after change)

1. Checkout
2. Azure login
3. Setup Docker Buildx
4. Get ACR name / server
5. Login to ACR
6. Build Docker image
7. **Generate SBOM (Trivy CycloneDX)** ← NEW
8. **Upload SBOM artifact** ← NEW
9. Run Dockle
10. Run Trivy (vulnerability scan)
11. Push Docker image

## Testing

- [ ] Chat API pipeline runs successfully on this PR
- [ ] SBOM artifact is downloadable from the workflow run
- [ ] SBOM contains `bomFormat: "CycloneDX"` with NuGet + OS dependencies
- [ ] Dockle, Trivy vuln scan, and Docker push still succeed
- [ ] Revert `deploy-chat-api.yml` template ref back to `@main` before merge