### PR TITLE
feat(chat-api): add ASI08 cascading failure mitigations

### DIFF
--- a/.github/workflows/deploy-chat-api.yml
+++ b/.github/workflows/deploy-chat-api.yml
@@ -52,7 +52,7 @@ jobs:
     build-container-image-dev:
           name: Build and Push Container Image
           needs: [run-unit-tests, run-contract-tests]
-          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@feature/asi04-sbom-generation
+          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
           with:
             working-directory: ./src/Biotrackr.Chat.Api
             app-name: biotrackr-chat-api

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ConversationPersistenceMiddlewareShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ConversationPersistenceMiddlewareShould.cs
@@ -116,6 +116,92 @@ namespace Biotrackr.Chat.Api.UnitTests.Middleware
             result.Should().Contain("page");
         }
 
+        [Fact]
+        public async Task HandleAsync_ShouldContinueStreaming_WhenUserMessagePersistenceFails()
+        {
+            // Arrange
+            _repositoryMock.Setup(r => r.SaveMessageAsync(
+                It.IsAny<string>(), "user", It.IsAny<string>(), null))
+                .ThrowsAsync(new InvalidOperationException("Cosmos DB unavailable"));
+
+            var agent = new FakeAgent(new TextContent("Here is your data."));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act — should not throw
+            var updates = new List<AgentResponseUpdate>();
+            await foreach (var update in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+            {
+                updates.Add(update);
+            }
+
+            // Assert — streaming continued despite persistence failure
+            updates.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldContinueStreaming_WhenAssistantPersistenceFails()
+        {
+            // Arrange — user persistence succeeds, assistant persistence fails
+            _repositoryMock.Setup(r => r.SaveMessageAsync(
+                It.IsAny<string>(), "assistant", It.IsAny<string>(), It.IsAny<List<string>?>()))
+                .ThrowsAsync(new InvalidOperationException("Cosmos DB throttled"));
+
+            var agent = new FakeAgent(new TextContent("Here is your data."));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act — should not throw
+            var updates = new List<AgentResponseUpdate>();
+            await foreach (var update in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+            {
+                updates.Add(update);
+            }
+
+            // Assert — all agent updates were yielded before persistence was attempted
+            updates.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldLogError_WhenUserMessagePersistenceFails()
+        {
+            // Arrange
+            _repositoryMock.Setup(r => r.SaveMessageAsync(
+                It.IsAny<string>(), "user", It.IsAny<string>(), null))
+                .ThrowsAsync(new InvalidOperationException("Cosmos DB unavailable"));
+
+            var agent = new FakeAgent(new TextContent("Here is your data."));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert
+            _loggerMock.VerifyLog(l => l.LogError(
+                It.IsAny<InvalidOperationException>(),
+                It.Is<string>(s => s.Contains("Failed to persist user message"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldLogError_WhenAssistantPersistenceFails()
+        {
+            // Arrange
+            _repositoryMock.Setup(r => r.SaveMessageAsync(
+                It.IsAny<string>(), "assistant", It.IsAny<string>(), It.IsAny<List<string>?>()))
+                .ThrowsAsync(new InvalidOperationException("Cosmos DB throttled"));
+
+            var agent = new FakeAgent(new TextContent("Here is your data."));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert
+            _loggerMock.VerifyLog(l => l.LogError(
+                It.IsAny<InvalidOperationException>(),
+                It.Is<string>(s => s.Contains("Failed to persist assistant response"))),
+                Times.Once);
+        }
+
         /// <summary>
         /// Concrete AIAgent subclass for testing that yields preconfigured content.
         /// </summary>

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/GracefulDegradationMiddlewareShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/GracefulDegradationMiddlewareShould.cs
@@ -1,0 +1,260 @@
+using Biotrackr.Chat.Api.Middleware;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using ChatMessage = Microsoft.Extensions.AI.ChatMessage;
+
+namespace Biotrackr.Chat.Api.UnitTests.Middleware
+{
+    public class GracefulDegradationMiddlewareShould
+    {
+        private readonly Mock<ILogger<GracefulDegradationMiddleware>> _loggerMock;
+        private readonly GracefulDegradationMiddleware _sut;
+
+        public GracefulDegradationMiddlewareShould()
+        {
+            _loggerMock = new Mock<ILogger<GracefulDegradationMiddleware>>();
+            _sut = new GracefulDegradationMiddleware(_loggerMock.Object);
+        }
+
+        private static IEnumerable<ChatMessage> CreateMessages(string userText)
+        {
+            return [new ChatMessage(ChatRole.User, userText)];
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldPassThroughNormally_WhenNoExceptionOccurs()
+        {
+            // Arrange
+            var agent = new FakeAgent(new TextContent("Here is your data."));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            var updates = new List<AgentResponseUpdate>();
+            await foreach (var update in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+            {
+                updates.Add(update);
+            }
+
+            // Assert
+            updates.Should().ContainSingle();
+            updates[0].Contents.OfType<TextContent>().First().Text.Should().Be("Here is your data.");
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.ServiceUnavailable)]
+        [InlineData(HttpStatusCode.TooManyRequests)]
+        [InlineData(HttpStatusCode.BadGateway)]
+        [InlineData(HttpStatusCode.GatewayTimeout)]
+        public async Task HandleAsync_ShouldReturnFriendlyMessage_WhenClaudeApiReturnsErrorStatusCode(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var agent = new ThrowingAgent(new HttpRequestException("API error", null, statusCode));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            var updates = new List<AgentResponseUpdate>();
+            await foreach (var update in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+            {
+                updates.Add(update);
+            }
+
+            // Assert
+            updates.Should().ContainSingle();
+            updates[0].Contents.OfType<TextContent>().First().Text
+                .Should().Be(GracefulDegradationMiddleware.ServiceUnavailableMessage);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldReturnTimeoutMessage_WhenClaudeApiTimesOut()
+        {
+            // Arrange
+            var agent = new ThrowingAgent(
+                new TaskCanceledException("Timeout", new TimeoutException("The operation timed out")));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            var updates = new List<AgentResponseUpdate>();
+            await foreach (var update in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+            {
+                updates.Add(update);
+            }
+
+            // Assert
+            updates.Should().ContainSingle();
+            updates[0].Contents.OfType<TextContent>().First().Text
+                .Should().Be(GracefulDegradationMiddleware.TimeoutMessage);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldLogWarning_WhenClaudeApiIsUnavailable()
+        {
+            // Arrange
+            var agent = new ThrowingAgent(
+                new HttpRequestException("Service Unavailable", null, HttpStatusCode.ServiceUnavailable));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert
+            _loggerMock.VerifyLog(l => l.LogWarning(
+                It.IsAny<HttpRequestException>(),
+                It.Is<string>(s => s.Contains("Claude API unavailable"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldLogWarning_WhenClaudeApiTimesOut()
+        {
+            // Arrange
+            var agent = new ThrowingAgent(
+                new TaskCanceledException("Timeout", new TimeoutException("The operation timed out")));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert
+            _loggerMock.VerifyLog(l => l.LogWarning(
+                It.IsAny<TaskCanceledException>(),
+                It.Is<string>(s => s.Contains("Claude API timed out"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldNotCatch_WhenHttpExceptionHasNonRetryableStatusCode()
+        {
+            // Arrange — 400 Bad Request should not be caught
+            var agent = new ThrowingAgent(
+                new HttpRequestException("Bad Request", null, HttpStatusCode.BadRequest));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act & Assert
+            var act = async () =>
+            {
+                await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+            };
+
+            await act.Should().ThrowAsync<HttpRequestException>();
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldNotCatch_WhenTaskCancelledWithoutTimeoutInner()
+        {
+            // Arrange — plain cancellation (not timeout) should propagate
+            var agent = new ThrowingAgent(new TaskCanceledException("Cancelled"));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act & Assert
+            var act = async () =>
+            {
+                await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+            };
+
+            await act.Should().ThrowAsync<TaskCanceledException>();
+        }
+
+        /// <summary>
+        /// Fake agent that yields content normally (no exceptions).
+        /// </summary>
+        private sealed class FakeAgent(params AIContent[] contents) : AIAgent
+        {
+            protected override Task<AgentResponse> RunCoreAsync(
+                IEnumerable<ChatMessage> messages,
+                AgentSession session,
+                AgentRunOptions options,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, contents)));
+            }
+
+            protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+                IEnumerable<ChatMessage> messages,
+                AgentSession session,
+                AgentRunOptions options,
+                [EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                yield return new AgentResponseUpdate(ChatRole.Assistant, contents);
+                await Task.CompletedTask;
+            }
+
+            protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken)
+            {
+                return new ValueTask<AgentSession>(new FakeSession());
+            }
+
+            protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(
+                JsonElement sessionData,
+                JsonSerializerOptions? options,
+                CancellationToken cancellationToken)
+            {
+                return new ValueTask<AgentSession>(new FakeSession());
+            }
+
+            protected override ValueTask<JsonElement> SerializeSessionCoreAsync(
+                AgentSession session,
+                JsonSerializerOptions? options,
+                CancellationToken cancellationToken)
+            {
+                return new ValueTask<JsonElement>(JsonDocument.Parse("{}").RootElement);
+            }
+        }
+
+        /// <summary>
+        /// Fake agent that throws an exception during streaming.
+        /// </summary>
+        private sealed class ThrowingAgent(Exception exception) : AIAgent
+        {
+            protected override Task<AgentResponse> RunCoreAsync(
+                IEnumerable<ChatMessage> messages,
+                AgentSession session,
+                AgentRunOptions options,
+                CancellationToken cancellationToken)
+            {
+                throw exception;
+            }
+
+            protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+                IEnumerable<ChatMessage> messages,
+                AgentSession session,
+                AgentRunOptions options,
+                [EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                await Task.CompletedTask;
+                throw exception;
+#pragma warning disable CS0162 // Unreachable code detected
+                yield break;
+#pragma warning restore CS0162
+            }
+
+            protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken)
+            {
+                return new ValueTask<AgentSession>(new FakeSession());
+            }
+
+            protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(
+                JsonElement sessionData,
+                JsonSerializerOptions? options,
+                CancellationToken cancellationToken)
+            {
+                return new ValueTask<AgentSession>(new FakeSession());
+            }
+
+            protected override ValueTask<JsonElement> SerializeSessionCoreAsync(
+                AgentSession session,
+                JsonSerializerOptions? options,
+                CancellationToken cancellationToken)
+            {
+                return new ValueTask<JsonElement>(JsonDocument.Parse("{}").RootElement);
+            }
+        }
+
+        private sealed class FakeSession : AgentSession;
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
@@ -31,8 +31,17 @@ namespace Biotrackr.Chat.Api.Middleware
                 var userContent = string.Join("", userMessage.Contents.OfType<TextContent>().Select(c => c.Text));
                 if (!string.IsNullOrWhiteSpace(userContent))
                 {
-                    await repository.SaveMessageAsync(sessionId, "user", userContent);
-                    logger.LogInformation("Persisted user message for session {SessionId}", sessionId);
+                    try
+                    {
+                        await repository.SaveMessageAsync(sessionId, "user", userContent);
+                        logger.LogInformation("Persisted user message for session {SessionId}", sessionId);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex,
+                            "Failed to persist user message for session {SessionId}. Continuing without persistence.",
+                            sessionId);
+                    }
                 }
             }
 
@@ -67,13 +76,23 @@ namespace Biotrackr.Chat.Api.Middleware
             var assistantContent = responseText.ToString();
             if (!string.IsNullOrWhiteSpace(assistantContent))
             {
-                await repository.SaveMessageAsync(
-                    sessionId,
-                    "assistant",
-                    assistantContent,
-                    toolCalls.Count > 0 ? toolCalls : null);
-                logger.LogInformation("Persisted assistant response for session {SessionId} ({ToolCount} tool calls)",
-                    sessionId, toolCalls.Count);
+                try
+                {
+                    await repository.SaveMessageAsync(
+                        sessionId,
+                        "assistant",
+                        assistantContent,
+                        toolCalls.Count > 0 ? toolCalls : null);
+                    logger.LogInformation("Persisted assistant response for session {SessionId} ({ToolCount} tool calls)",
+                        sessionId, toolCalls.Count);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex,
+                        "Failed to persist assistant response for session {SessionId}. " +
+                        "The response was delivered to the user but will not appear in conversation history.",
+                        sessionId);
+                }
             }
         }
 

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/GracefulDegradationMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/GracefulDegradationMiddleware.cs
@@ -1,0 +1,82 @@
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using System.Net;
+using System.Runtime.CompilerServices;
+
+namespace Biotrackr.Chat.Api.Middleware
+{
+    /// <summary>
+    /// Agent middleware that catches Claude API failures during streaming
+    /// and returns a user-friendly error message instead of crashing the SSE connection.
+    /// </summary>
+    public class GracefulDegradationMiddleware(
+        ILogger<GracefulDegradationMiddleware> logger)
+    {
+        public const string ServiceUnavailableMessage =
+            "I'm sorry, I'm temporarily unable to process your request. The AI service is currently unavailable. Please try again in a few moments.";
+
+        public const string TimeoutMessage =
+            "I'm sorry, the request timed out. Please try again.";
+
+        public async IAsyncEnumerable<AgentResponseUpdate> HandleAsync(
+            IEnumerable<ChatMessage> messages,
+            AgentSession? session,
+            AgentRunOptions? options,
+            AIAgent innerAgent,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            var sessionId = session?.GetHashCode().ToString("x8") ?? "unknown";
+
+            IAsyncEnumerator<AgentResponseUpdate>? enumerator = null;
+            try
+            {
+                enumerator = innerAgent.RunStreamingAsync(messages, session, options, cancellationToken)
+                    .GetAsyncEnumerator(cancellationToken);
+
+                while (true)
+                {
+                    AgentResponseUpdate current;
+                    string? errorMessage = null;
+                    try
+                    {
+                        if (!await enumerator.MoveNextAsync())
+                            break;
+                        current = enumerator.Current;
+                    }
+                    catch (HttpRequestException ex) when (
+                        ex.StatusCode is HttpStatusCode.ServiceUnavailable
+                            or HttpStatusCode.TooManyRequests
+                            or HttpStatusCode.BadGateway
+                            or HttpStatusCode.GatewayTimeout)
+                    {
+                        logger.LogWarning(ex, "Claude API unavailable ({StatusCode}) for session {SessionId}",
+                            ex.StatusCode, sessionId);
+                        errorMessage = ServiceUnavailableMessage;
+                        current = default!;
+                    }
+                    catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+                    {
+                        logger.LogWarning(ex, "Claude API timed out for session {SessionId}", sessionId);
+                        errorMessage = TimeoutMessage;
+                        current = default!;
+                    }
+
+                    if (errorMessage is not null)
+                    {
+                        yield return new AgentResponseUpdate(
+                            ChatRole.Assistant,
+                            [new TextContent(errorMessage)]);
+                        yield break;
+                    }
+
+                    yield return current;
+                }
+            }
+            finally
+            {
+                if (enumerator is not null)
+                    await enumerator.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
@@ -174,10 +174,15 @@ var toolPolicyOptions = Microsoft.Extensions.Options.Options.Create(new ToolPoli
 var toolPolicyLogger = app.Services.GetRequiredService<ILogger<ToolPolicyMiddleware>>();
 var toolPolicyMiddleware = new ToolPolicyMiddleware(memoryCache, toolPolicyOptions, toolPolicyLogger);
 
+// Wrap agent with graceful degradation middleware (catches Claude API failures)
+var degradationLogger = app.Services.GetRequiredService<ILogger<GracefulDegradationMiddleware>>();
+var degradationMiddleware = new GracefulDegradationMiddleware(degradationLogger);
+
 AIAgent persistentAgent = chatAgent
     .AsBuilder()
         .Use(runFunc: null, runStreamingFunc: toolPolicyMiddleware.HandleAsync)
         .Use(runFunc: null, runStreamingFunc: persistenceMiddleware.HandleAsync)
+        .Use(runFunc: null, runStreamingFunc: degradationMiddleware.HandleAsync)
     .Build();
 
 app.MapOpenApi();


### PR DESCRIPTION
## Summary

Implements ASI08 (Cascading Failures) controls 7.1 and 7.2 from the [OWASP Agentic Top 10 implementation plan](docs/plans/2026-03-13-owasp-agentic-top10-implementation-plan.md).

## Changes

### 7.1 — Error Handling in ConversationPersistenceMiddleware

Wraps both `SaveMessageAsync` calls (user message + assistant response) in try-catch blocks so that Cosmos DB failures are logged at `Error` level but **do not crash the SSE streaming response**. Previously, a Cosmos DB outage (429/503/timeout) would propagate through the AG-UI streaming pipeline and kill the entire response — even though the agent had already generated the answer.

**Files modified:**
- `src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs`
- `src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ConversationPersistenceMiddlewareShould.cs` (+4 tests)

### 7.2 — Claude API Graceful Degradation

Adds a new `GracefulDegradationMiddleware` that catches Claude API failures during streaming and returns user-friendly error messages via SSE instead of crashing the connection:

- **503 / 429 / 502 / 504** → `\"I'm sorry, I'm temporarily unable to process your request. The AI service is currently unavailable. Please try again in a few moments.\"`
- **Timeout** (`TaskCanceledException` wrapping `TimeoutException`) → `\"I'm sorry, the request timed out. Please try again.\"`
- Non-retryable errors (e.g., 400) and plain cancellations still propagate normally.

Wired as the **outermost middleware** in the agent pipeline (degradation → persistence → tool policy → agent).

**Files created/modified:**
- `src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/GracefulDegradationMiddleware.cs` (new)
- `src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/GracefulDegradationMiddlewareShould.cs` (new, 7 tests)
- `src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs`

## Testing

All 211 unit tests pass, 0 failures. New tests cover:

| Test | Validates |
|------|-----------|
| Streaming continues when user message persistence fails | 7.1 |
| Streaming continues when assistant persistence fails | 7.1 |
| Error logged when user persistence fails | 7.1 |
| Error logged when assistant persistence fails | 7.1 |
| Normal streaming passes through unmodified | 7.2 |
| Friendly message for 503/429/502/504 | 7.2 |
| Timeout message for API timeout | 7.2 |
| Warning logged for API unavailable | 7.2 |
| Warning logged for timeout | 7.2 |
| Non-retryable status codes propagate | 7.2 |
| Plain cancellation propagates | 7.2 |

## References

- Plan: `docs/plans/2026-03-13-asi08-middleware-error-handling.md`
- Plan: `docs/plans/2026-03-13-asi08-claude-api-degradation.md`
- Parent: `docs/plans/2026-03-13-owasp-agentic-top10-implementation-plan.md` §7