### PR TITLE
fix: hydrate conversation history and enforce ASI06 safety limits

### DIFF
--- a/infra/modules/database/serverless-cosmos-db.bicep
+++ b/infra/modules/database/serverless-cosmos-db.bicep
@@ -156,6 +156,7 @@ resource conversationsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDataba
         ]
         kind: 'Hash'
       }
+      defaultTtl: 7776000
       indexingPolicy: {
         indexingMode: 'consistent'
         includedPaths: [

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/AgentSessionExtensionsShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/AgentSessionExtensionsShould.cs
@@ -1,0 +1,75 @@
+using Biotrackr.Chat.Api.Middleware;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using System.Reflection;
+
+namespace Biotrackr.Chat.Api.UnitTests.Middleware
+{
+    public class AgentSessionExtensionsShould
+    {
+        /// <summary>
+        /// Creates a <see cref="ChatClientAgentSession"/> via reflection because
+        /// its constructors are internal to the Microsoft.Agents.AI package.
+        /// </summary>
+        private static ChatClientAgentSession CreateChatSession(string conversationId)
+        {
+            var ctor = typeof(ChatClientAgentSession).GetConstructor(
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                [typeof(string), typeof(AgentSessionStateBag)]);
+
+            return (ChatClientAgentSession)ctor!.Invoke([conversationId, new AgentSessionStateBag()]);
+        }
+
+        [Fact]
+        public void ReturnConversationId_WhenSessionIsChatClientAgentSession()
+        {
+            var session = CreateChatSession("thread-abc-123");
+
+            var result = session.GetConversationId();
+
+            result.Should().Be("thread-abc-123");
+        }
+
+        [Fact]
+        public void ReturnFallback_WhenSessionIsNull()
+        {
+            AgentSession? session = null;
+
+            var result = session.GetConversationId("my-fallback");
+
+            result.Should().Be("my-fallback");
+        }
+
+        [Fact]
+        public void ReturnDefaultFallback_WhenSessionIsNull()
+        {
+            AgentSession? session = null;
+
+            var result = session.GetConversationId();
+
+            result.Should().Be("unknown");
+        }
+
+        [Fact]
+        public void ReturnFallback_WhenSessionIsNotChatClientAgentSession()
+        {
+            var session = new FakeSession();
+
+            var result = session.GetConversationId("fallback-id");
+
+            result.Should().Be("fallback-id");
+        }
+
+        [Fact]
+        public void ReturnFallback_WhenConversationIdIsEmpty()
+        {
+            var session = CreateChatSession("");
+
+            var result = session.GetConversationId("fallback-id");
+
+            result.Should().Be("fallback-id");
+        }
+
+        private sealed class FakeSession : AgentSession;
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/AgentSessionExtensionsShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/AgentSessionExtensionsShould.cs
@@ -1,75 +1,94 @@
 using Biotrackr.Chat.Api.Middleware;
 using FluentAssertions;
 using Microsoft.Agents.AI;
-using System.Reflection;
+using Microsoft.Extensions.AI;
 
 namespace Biotrackr.Chat.Api.UnitTests.Middleware
 {
     public class AgentSessionExtensionsShould
     {
-        /// <summary>
-        /// Creates a <see cref="ChatClientAgentSession"/> via reflection because
-        /// its constructors are internal to the Microsoft.Agents.AI package.
-        /// </summary>
-        private static ChatClientAgentSession CreateChatSession(string conversationId)
+        private static ChatClientAgentRunOptions CreateRunOptions(string? threadId)
         {
-            var ctor = typeof(ChatClientAgentSession).GetConstructor(
-                BindingFlags.NonPublic | BindingFlags.Instance,
-                [typeof(string), typeof(AgentSessionStateBag)]);
-
-            return (ChatClientAgentSession)ctor!.Invoke([conversationId, new AgentSessionStateBag()]);
+            return new ChatClientAgentRunOptions
+            {
+                ChatOptions = new ChatOptions
+                {
+                    AdditionalProperties = new AdditionalPropertiesDictionary
+                    {
+                        ["ag_ui_thread_id"] = threadId
+                    }
+                }
+            };
         }
 
         [Fact]
-        public void ReturnConversationId_WhenSessionIsChatClientAgentSession()
+        public void ReturnThreadId_WhenPresentInRunOptions()
         {
-            var session = CreateChatSession("thread-abc-123");
+            var options = CreateRunOptions("thread-abc-123");
 
-            var result = session.GetConversationId();
+            var result = options.GetConversationId();
 
             result.Should().Be("thread-abc-123");
         }
 
         [Fact]
-        public void ReturnFallback_WhenSessionIsNull()
+        public void ReturnFallback_WhenOptionsAreNull()
         {
-            AgentSession? session = null;
+            AgentRunOptions? options = null;
 
-            var result = session.GetConversationId("my-fallback");
+            var result = options.GetConversationId("my-fallback");
 
             result.Should().Be("my-fallback");
         }
 
         [Fact]
-        public void ReturnDefaultFallback_WhenSessionIsNull()
+        public void ReturnDefaultFallback_WhenOptionsAreNull()
         {
-            AgentSession? session = null;
+            AgentRunOptions? options = null;
 
-            var result = session.GetConversationId();
+            var result = options.GetConversationId();
 
             result.Should().Be("unknown");
         }
 
         [Fact]
-        public void ReturnFallback_WhenSessionIsNotChatClientAgentSession()
+        public void ReturnFallback_WhenOptionsAreNotChatClientAgentRunOptions()
         {
-            var session = new FakeSession();
+            var options = new AgentRunOptions();
 
-            var result = session.GetConversationId("fallback-id");
+            var result = options.GetConversationId("fallback-id");
 
             result.Should().Be("fallback-id");
         }
 
         [Fact]
-        public void ReturnFallback_WhenConversationIdIsEmpty()
+        public void ReturnFallback_WhenThreadIdIsEmpty()
         {
-            var session = CreateChatSession("");
+            var options = CreateRunOptions("");
 
-            var result = session.GetConversationId("fallback-id");
+            var result = options.GetConversationId("fallback-id");
 
             result.Should().Be("fallback-id");
         }
 
-        private sealed class FakeSession : AgentSession;
+        [Fact]
+        public void ReturnFallback_WhenThreadIdIsNull()
+        {
+            var options = CreateRunOptions(null);
+
+            var result = options.GetConversationId("fallback-id");
+
+            result.Should().Be("fallback-id");
+        }
+
+        [Fact]
+        public void ReturnFallback_WhenChatOptionsIsNull()
+        {
+            var options = new ChatClientAgentRunOptions { ChatOptions = null };
+
+            var result = options.GetConversationId("fallback-id");
+
+            result.Should().Be("fallback-id");
+        }
     }
 }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ConversationPersistenceMiddlewareShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ConversationPersistenceMiddlewareShould.cs
@@ -1,9 +1,11 @@
+using Biotrackr.Chat.Api.Configuration;
 using Biotrackr.Chat.Api.Middleware;
 using Biotrackr.Chat.Api.Services;
 using FluentAssertions;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -27,7 +29,13 @@ namespace Biotrackr.Chat.Api.UnitTests.Middleware
                 .Setup(r => r.SaveMessageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>?>()))
                 .ReturnsAsync(new ChatConversationDocument());
 
-            _sut = new ConversationPersistenceMiddleware(_repositoryMock.Object, _loggerMock.Object);
+            _sut = CreateSut();
+        }
+
+        private ConversationPersistenceMiddleware CreateSut(ConversationPolicyOptions? options = null)
+        {
+            var policyOptions = Options.Create(options ?? new ConversationPolicyOptions());
+            return new ConversationPersistenceMiddleware(_repositoryMock.Object, policyOptions, _loggerMock.Object);
         }
 
         private static IEnumerable<ChatMessage> CreateMessages(string userText)
@@ -202,6 +210,430 @@ namespace Biotrackr.Chat.Api.UnitTests.Middleware
                 Times.Once);
         }
 
+        [Fact]
+        public async Task HandleAsync_ShouldHydrateConversationHistory_WhenPriorMessagesExist()
+        {
+            // Arrange — Cosmos has two prior messages (user + assistant) plus the newly saved user message
+            var existingConversation = new ChatConversationDocument
+            {
+                SessionId = "test-session",
+                Messages =
+                [
+                    new Biotrackr.Chat.Api.Models.ChatMessage { Role = "user", Content = "How many steps on March 14th?" },
+                    new Biotrackr.Chat.Api.Models.ChatMessage { Role = "assistant", Content = "You took 15,244 steps." },
+                    new Biotrackr.Chat.Api.Models.ChatMessage { Role = "user", Content = "How many calories?" }
+                ]
+            };
+
+            _repositoryMock
+                .Setup(r => r.GetConversationAsync(It.IsAny<string>()))
+                .ReturnsAsync(existingConversation);
+
+            var capturingAgent = new MessageCapturingAgent(new TextContent("491 calories."));
+            var messages = CreateMessages("How many calories?");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, capturingAgent, CancellationToken.None))
+            {
+                // Drain
+            }
+
+            // Assert — agent should have received history + current message
+            var receivedMessages = capturingAgent.CapturedMessages!.ToList();
+            receivedMessages.Should().HaveCount(3);
+            receivedMessages[0].Role.Should().Be(ChatRole.User);
+            receivedMessages[0].Text.Should().Contain("How many steps on March 14th?");
+            receivedMessages[1].Role.Should().Be(ChatRole.Assistant);
+            receivedMessages[1].Text.Should().Contain("You took 15,244 steps.");
+            receivedMessages[2].Role.Should().Be(ChatRole.User);
+            receivedMessages[2].Text.Should().Contain("How many calories?");
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldNotHydrateHistory_WhenNoConversationExists()
+        {
+            // Arrange — Cosmos returns null (first message in a new conversation)
+            _repositoryMock
+                .Setup(r => r.GetConversationAsync(It.IsAny<string>()))
+                .ReturnsAsync((ChatConversationDocument?)null);
+
+            var capturingAgent = new MessageCapturingAgent(new TextContent("Hello!"));
+            var messages = CreateMessages("Hi there");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, capturingAgent, CancellationToken.None))
+            {
+                // Drain
+            }
+
+            // Assert — agent should only receive the current message
+            var receivedMessages = capturingAgent.CapturedMessages!.ToList();
+            receivedMessages.Should().HaveCount(1);
+            receivedMessages[0].Text.Should().Contain("Hi there");
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldContinueWithoutHistory_WhenHydrationFails()
+        {
+            // Arrange — Cosmos throws on GetConversationAsync
+            _repositoryMock
+                .Setup(r => r.GetConversationAsync(It.IsAny<string>()))
+                .ThrowsAsync(new InvalidOperationException("Cosmos DB unavailable"));
+
+            var capturingAgent = new MessageCapturingAgent(new TextContent("Here is your data."));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act — should not throw
+            var updates = new List<AgentResponseUpdate>();
+            await foreach (var update in _sut.HandleAsync(messages, null, null, capturingAgent, CancellationToken.None))
+            {
+                updates.Add(update);
+            }
+
+            // Assert — streaming continued with just the current message
+            updates.Should().NotBeEmpty();
+            var receivedMessages = capturingAgent.CapturedMessages!.ToList();
+            receivedMessages.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldLogError_WhenHydrationFails()
+        {
+            // Arrange
+            _repositoryMock
+                .Setup(r => r.GetConversationAsync(It.IsAny<string>()))
+                .ThrowsAsync(new InvalidOperationException("Cosmos DB unavailable"));
+
+            var capturingAgent = new MessageCapturingAgent(new TextContent("Here is your data."));
+            var messages = CreateMessages("Show me my activity");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, capturingAgent, CancellationToken.None)) { }
+
+            // Assert
+            _loggerMock.VerifyLog(l => l.LogError(
+                It.IsAny<InvalidOperationException>(),
+                It.Is<string>(s => s.Contains("Failed to hydrate conversation history"))),
+                Times.Once);
+        }
+
+        // ===== ASI06 Control: Context Window Cap =====
+
+        [Fact]
+        public async Task HandleAsync_ShouldCapHydratedMessages_WhenHistoryExceedsMaxHydration()
+        {
+            // Arrange — 10 messages in history, but cap is 4
+            var existingConversation = new ChatConversationDocument
+            {
+                SessionId = "test-session",
+                Messages = Enumerable.Range(1, 10)
+                    .Select(i => new Biotrackr.Chat.Api.Models.ChatMessage
+                    {
+                        Role = i % 2 == 1 ? "user" : "assistant",
+                        Content = $"Message {i}"
+                    })
+                    .Append(new Biotrackr.Chat.Api.Models.ChatMessage { Role = "user", Content = "Latest question" })
+                    .ToList()
+            };
+
+            _repositoryMock
+                .Setup(r => r.GetConversationAsync(It.IsAny<string>()))
+                .ReturnsAsync(existingConversation);
+
+            var sut = CreateSut(new ConversationPolicyOptions { MaxHydrationMessageCount = 4 });
+            var capturingAgent = new MessageCapturingAgent(new TextContent("Response"));
+            var messages = CreateMessages("Latest question");
+
+            // Act
+            await foreach (var _ in sut.HandleAsync(messages, null, null, capturingAgent, CancellationToken.None)) { }
+
+            // Assert — only last 4 historical + 1 current = 5 messages
+            var receivedMessages = capturingAgent.CapturedMessages!.ToList();
+            receivedMessages.Should().HaveCount(5);
+            // First hydrated message should be #7 (the 7th of the 10 historical messages)
+            receivedMessages[0].Text.Should().Contain("Message 7");
+            receivedMessages[3].Text.Should().Contain("Message 10");
+            receivedMessages[4].Text.Should().Contain("Latest question");
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldHydrateAllMessages_WhenHistoryIsUnderCap()
+        {
+            // Arrange — 4 messages in history, cap is 50
+            var existingConversation = new ChatConversationDocument
+            {
+                SessionId = "test-session",
+                Messages =
+                [
+                    new Biotrackr.Chat.Api.Models.ChatMessage { Role = "user", Content = "Q1" },
+                    new Biotrackr.Chat.Api.Models.ChatMessage { Role = "assistant", Content = "A1" },
+                    new Biotrackr.Chat.Api.Models.ChatMessage { Role = "user", Content = "Q2" },
+                    new Biotrackr.Chat.Api.Models.ChatMessage { Role = "assistant", Content = "A2" },
+                    new Biotrackr.Chat.Api.Models.ChatMessage { Role = "user", Content = "Q3" }
+                ]
+            };
+
+            _repositoryMock
+                .Setup(r => r.GetConversationAsync(It.IsAny<string>()))
+                .ReturnsAsync(existingConversation);
+
+            var capturingAgent = new MessageCapturingAgent(new TextContent("A3"));
+            var messages = CreateMessages("Q3");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, capturingAgent, CancellationToken.None)) { }
+
+            // Assert — all 4 historical + 1 current = 5 messages
+            var receivedMessages = capturingAgent.CapturedMessages!.ToList();
+            receivedMessages.Should().HaveCount(5);
+        }
+
+        // ===== ASI06 Control: Per-Message Content Length Limit =====
+
+        [Fact]
+        public async Task HandleAsync_ShouldTruncateUserMessage_WhenContentExceedsMaxLength()
+        {
+            // Arrange
+            var sut = CreateSut(new ConversationPolicyOptions { MaxMessageContentLength = 20 });
+            var longMessage = new string('A', 50);
+            var agent = new FakeAgent(new TextContent("Short response."));
+            var messages = CreateMessages(longMessage);
+
+            // Act
+            await foreach (var _ in sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert — persisted content should be truncated to 20 chars
+            _repositoryMock.Verify(r => r.SaveMessageAsync(
+                It.IsAny<string>(),
+                "user",
+                It.Is<string>(s => s.Length == 20),
+                null),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldNotTruncateUserMessage_WhenContentIsUnderMaxLength()
+        {
+            // Arrange
+            var agent = new FakeAgent(new TextContent("Response."));
+            var messages = CreateMessages("Short message");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert — full content persisted
+            _repositoryMock.Verify(r => r.SaveMessageAsync(
+                It.IsAny<string>(),
+                "user",
+                "Short message",
+                null),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldTruncateAssistantResponse_WhenContentExceedsMaxLength()
+        {
+            // Arrange
+            var longResponse = new string('B', 50);
+            var sut = CreateSut(new ConversationPolicyOptions { MaxMessageContentLength = 20 });
+            var agent = new FakeAgent(new TextContent(longResponse));
+            var messages = CreateMessages("Question");
+
+            // Act
+            await foreach (var _ in sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert — persisted assistant content should be truncated to 20 chars
+            _repositoryMock.Verify(r => r.SaveMessageAsync(
+                It.IsAny<string>(),
+                "assistant",
+                It.Is<string>(s => s.Length == 20),
+                null),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldLogWarning_WhenContentIsTruncated()
+        {
+            // Arrange
+            var sut = CreateSut(new ConversationPolicyOptions { MaxMessageContentLength = 10 });
+            var agent = new FakeAgent(new TextContent("Short."));
+            var messages = CreateMessages(new string('X', 50));
+
+            // Act
+            await foreach (var _ in sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert
+            _loggerMock.VerifyLog(l => l.LogWarning(
+                It.Is<string>(s => s.Contains("truncated"))),
+                Times.AtLeastOnce);
+        }
+
+        // ===== ASI06 Control: Conversation Message Count Cap =====
+
+        [Fact]
+        public async Task HandleAsync_ShouldNotPersistMessages_WhenConversationCapReached()
+        {
+            // Arrange — conversation already has max messages
+            var fullConversation = new ChatConversationDocument
+            {
+                SessionId = "full-session",
+                Messages = Enumerable.Range(1, 100)
+                    .Select(i => new Biotrackr.Chat.Api.Models.ChatMessage
+                    {
+                        Role = i % 2 == 1 ? "user" : "assistant",
+                        Content = $"Message {i}"
+                    })
+                    .ToList()
+            };
+
+            _repositoryMock
+                .Setup(r => r.GetConversationAsync(It.IsAny<string>()))
+                .ReturnsAsync(fullConversation);
+
+            var sut = CreateSut(new ConversationPolicyOptions { MaxMessagesPerConversation = 100 });
+            var agent = new FakeAgent(new TextContent("Still answering."));
+            var messages = CreateMessages("One more question");
+
+            // Act
+            await foreach (var _ in sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert — no new messages should be persisted
+            _repositoryMock.Verify(r => r.SaveMessageAsync(
+                It.IsAny<string>(), "user", It.IsAny<string>(), It.IsAny<List<string>?>()), Times.Never);
+            _repositoryMock.Verify(r => r.SaveMessageAsync(
+                It.IsAny<string>(), "assistant", It.IsAny<string>(), It.IsAny<List<string>?>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldStillStreamAgentResponse_WhenConversationCapReached()
+        {
+            // Arrange
+            var fullConversation = new ChatConversationDocument
+            {
+                SessionId = "full-session",
+                Messages = Enumerable.Range(1, 100)
+                    .Select(i => new Biotrackr.Chat.Api.Models.ChatMessage
+                    {
+                        Role = i % 2 == 1 ? "user" : "assistant",
+                        Content = $"Message {i}"
+                    })
+                    .ToList()
+            };
+
+            _repositoryMock
+                .Setup(r => r.GetConversationAsync(It.IsAny<string>()))
+                .ReturnsAsync(fullConversation);
+
+            var sut = CreateSut(new ConversationPolicyOptions { MaxMessagesPerConversation = 100 });
+            var agent = new FakeAgent(new TextContent("Still answering."));
+            var messages = CreateMessages("One more question");
+
+            // Act — agent should still respond even though we won't persist
+            var updates = new List<AgentResponseUpdate>();
+            await foreach (var update in sut.HandleAsync(messages, null, null, agent, CancellationToken.None))
+            {
+                updates.Add(update);
+            }
+
+            // Assert — agent response is streamed + conversation cap notice appended
+            updates.Should().HaveCountGreaterThanOrEqualTo(2);
+            var lastUpdate = updates.Last();
+            var capNotice = lastUpdate.Contents.OfType<TextContent>().FirstOrDefault();
+            capNotice.Should().NotBeNull();
+            capNotice!.Text.Should().Contain("maximum length");
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldLogWarning_WhenConversationCapReached()
+        {
+            // Arrange
+            var fullConversation = new ChatConversationDocument
+            {
+                SessionId = "full-session",
+                Messages = Enumerable.Range(1, 50)
+                    .Select(i => new Biotrackr.Chat.Api.Models.ChatMessage
+                    {
+                        Role = i % 2 == 1 ? "user" : "assistant",
+                        Content = $"Message {i}"
+                    })
+                    .ToList()
+            };
+
+            _repositoryMock
+                .Setup(r => r.GetConversationAsync(It.IsAny<string>()))
+                .ReturnsAsync(fullConversation);
+
+            var sut = CreateSut(new ConversationPolicyOptions { MaxMessagesPerConversation = 50 });
+            var agent = new FakeAgent(new TextContent("Response."));
+            var messages = CreateMessages("Question");
+
+            // Act
+            await foreach (var _ in sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert
+            _loggerMock.VerifyLog(l => l.LogWarning(
+                It.Is<string>(s => s.Contains("Conversation cap"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldPersistNormally_WhenUnderConversationCap()
+        {
+            // Arrange — conversation has 10 messages, cap is 100
+            var conversation = new ChatConversationDocument
+            {
+                SessionId = "normal-session",
+                Messages = Enumerable.Range(1, 10)
+                    .Select(i => new Biotrackr.Chat.Api.Models.ChatMessage
+                    {
+                        Role = i % 2 == 1 ? "user" : "assistant",
+                        Content = $"Message {i}"
+                    })
+                    .ToList()
+            };
+
+            _repositoryMock
+                .Setup(r => r.GetConversationAsync(It.IsAny<string>()))
+                .ReturnsAsync(conversation);
+
+            var agent = new FakeAgent(new TextContent("Response."));
+            var messages = CreateMessages("Question");
+
+            // Act
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert — both user and assistant messages should be persisted
+            _repositoryMock.Verify(r => r.SaveMessageAsync(
+                It.IsAny<string>(), "user", It.IsAny<string>(), null), Times.Once);
+            _repositoryMock.Verify(r => r.SaveMessageAsync(
+                It.IsAny<string>(), "assistant", It.IsAny<string>(), It.IsAny<List<string>?>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ShouldAssumeCapNotReached_WhenCapCheckFails()
+        {
+            // Arrange — GetConversationAsync throws on first call (cap check), returns null on second (hydration)
+            var callCount = 0;
+            _repositoryMock
+                .Setup(r => r.GetConversationAsync(It.IsAny<string>()))
+                .ReturnsAsync(() =>
+                {
+                    callCount++;
+                    if (callCount == 1) throw new InvalidOperationException("Cosmos DB error");
+                    return null;
+                });
+
+            var agent = new FakeAgent(new TextContent("Response."));
+            var messages = CreateMessages("Question");
+
+            // Act — should not throw, should persist normally
+            await foreach (var _ in _sut.HandleAsync(messages, null, null, agent, CancellationToken.None)) { }
+
+            // Assert — messages persisted since cap check failed gracefully
+            _repositoryMock.Verify(r => r.SaveMessageAsync(
+                It.IsAny<string>(), "user", It.IsAny<string>(), null), Times.Once);
+        }
+
         /// <summary>
         /// Concrete AIAgent subclass for testing that yields preconfigured content.
         /// </summary>
@@ -249,5 +681,55 @@ namespace Biotrackr.Chat.Api.UnitTests.Middleware
         }
 
         private sealed class FakeSession : AgentSession;
+
+        /// <summary>
+        /// Agent that captures the messages it receives for assertion, then yields preconfigured content.
+        /// </summary>
+        private sealed class MessageCapturingAgent(params AIContent[] contents) : AIAgent
+        {
+            public IEnumerable<ChatMessage>? CapturedMessages { get; private set; }
+
+            protected override Task<AgentResponse> RunCoreAsync(
+                IEnumerable<ChatMessage> messages,
+                AgentSession session,
+                AgentRunOptions options,
+                CancellationToken cancellationToken)
+            {
+                CapturedMessages = messages.ToList();
+                return Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, contents)));
+            }
+
+            protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+                IEnumerable<ChatMessage> messages,
+                AgentSession session,
+                AgentRunOptions options,
+                [EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                CapturedMessages = messages.ToList();
+                yield return new AgentResponseUpdate(ChatRole.Assistant, contents);
+                await Task.CompletedTask;
+            }
+
+            protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken)
+            {
+                return new ValueTask<AgentSession>(new FakeSession());
+            }
+
+            protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(
+                JsonElement sessionData,
+                JsonSerializerOptions? options,
+                CancellationToken cancellationToken)
+            {
+                return new ValueTask<AgentSession>(new FakeSession());
+            }
+
+            protected override ValueTask<JsonElement> SerializeSessionCoreAsync(
+                AgentSession session,
+                JsonSerializerOptions? options,
+                CancellationToken cancellationToken)
+            {
+                return new ValueTask<JsonElement>(JsonDocument.Parse("{}").RootElement);
+            }
+        }
     }
 }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Services/ChatHistoryRepositoryShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Services/ChatHistoryRepositoryShould.cs
@@ -257,5 +257,71 @@ namespace Biotrackr.Chat.Api.UnitTests.Services
             result.Messages[1].Role.Should().Be("assistant");
             result.Title.Should().Be("Existing conversation"); // Title should not change
         }
+
+        [Fact]
+        public async Task SaveMessageAsync_ShouldSetTtl_FromSettings()
+        {
+            // Arrange
+            var sessionId = "ttl-session";
+            _containerMock.Setup(x => x.ReadItemAsync<ChatConversationDocument>(
+                sessionId, new PartitionKey(sessionId), null, default))
+                .ThrowsAsync(new CosmosException("Not found", HttpStatusCode.NotFound, 0, "", 0));
+
+            var responseMock = new Mock<ItemResponse<ChatConversationDocument>>();
+            ChatConversationDocument? capturedDocument = null;
+            _containerMock.Setup(x => x.UpsertItemAsync(
+                It.IsAny<ChatConversationDocument>(),
+                It.IsAny<PartitionKey>(),
+                null, default))
+                .Callback<ChatConversationDocument, PartitionKey?, ItemRequestOptions?, CancellationToken>(
+                    (doc, _, _, _) => capturedDocument = doc)
+                .ReturnsAsync(responseMock.Object);
+
+            // Act
+            var result = await _sut.SaveMessageAsync(sessionId, "user", "Hello");
+
+            // Assert — TTL should match the default settings value (7,776,000 seconds = 90 days)
+            capturedDocument.Should().NotBeNull();
+            capturedDocument!.Ttl.Should().Be(7_776_000);
+        }
+
+        [Fact]
+        public async Task SaveMessageAsync_ShouldRefreshTtl_WhenAppendingToExistingConversation()
+        {
+            // Arrange
+            var sessionId = "existing-ttl-session";
+            var existingConversation = new ChatConversationDocument
+            {
+                Id = sessionId,
+                SessionId = sessionId,
+                Title = "Existing conversation",
+                Ttl = 1000, // Old TTL value
+                Messages = [new ChatMessage { Role = "user", Content = "First message" }]
+            };
+
+            var readResponseMock = new Mock<ItemResponse<ChatConversationDocument>>();
+            readResponseMock.Setup(x => x.Resource).Returns(existingConversation);
+
+            _containerMock.Setup(x => x.ReadItemAsync<ChatConversationDocument>(
+                sessionId, new PartitionKey(sessionId), null, default))
+                .ReturnsAsync(readResponseMock.Object);
+
+            ChatConversationDocument? capturedDocument = null;
+            var upsertResponseMock = new Mock<ItemResponse<ChatConversationDocument>>();
+            _containerMock.Setup(x => x.UpsertItemAsync(
+                It.IsAny<ChatConversationDocument>(),
+                It.IsAny<PartitionKey>(),
+                null, default))
+                .Callback<ChatConversationDocument, PartitionKey?, ItemRequestOptions?, CancellationToken>(
+                    (doc, _, _, _) => capturedDocument = doc)
+                .ReturnsAsync(upsertResponseMock.Object);
+
+            // Act
+            await _sut.SaveMessageAsync(sessionId, "assistant", "Here is your data.");
+
+            // Assert — TTL should be refreshed to the configured value, not the old value
+            capturedDocument.Should().NotBeNull();
+            capturedDocument!.Ttl.Should().Be(7_776_000);
+        }
     }
 }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/ConversationPolicyOptions.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/ConversationPolicyOptions.cs
@@ -1,0 +1,23 @@
+namespace Biotrackr.Chat.Api.Configuration
+{
+    /// <summary>
+    /// Conversation persistence safety limits (ASI06).
+    /// </summary>
+    public class ConversationPolicyOptions
+    {
+        /// <summary>
+        /// Maximum number of historical messages to hydrate into the agent's context window.
+        /// </summary>
+        public int MaxHydrationMessageCount { get; set; } = 50;
+
+        /// <summary>
+        /// Maximum character length for a single persisted message. Oversized messages are truncated.
+        /// </summary>
+        public int MaxMessageContentLength { get; set; } = 10_000;
+
+        /// <summary>
+        /// Maximum total messages per conversation. Once reached, new messages are not persisted.
+        /// </summary>
+        public int MaxMessagesPerConversation { get; set; } = 100;
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/Settings.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/Settings.cs
@@ -12,5 +12,10 @@ namespace Biotrackr.Chat.Api.Configuration
         public string ChatAgentModel { get; set; }
         public string ChatSystemPrompt { get; set; }
         public int ToolCallBudgetPerSession { get; set; } = 20;
+
+        /// <summary>
+        /// TTL in seconds for conversation documents in Cosmos DB. Defaults to 90 days.
+        /// </summary>
+        public int ConversationTtlSeconds { get; set; } = 7_776_000;
     }
 }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/AgentSessionExtensions.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/AgentSessionExtensions.cs
@@ -1,0 +1,25 @@
+using Microsoft.Agents.AI;
+
+namespace Biotrackr.Chat.Api.Middleware
+{
+    /// <summary>
+    /// Extension methods for extracting conversation identity from <see cref="AgentSession"/>.
+    /// </summary>
+    public static class AgentSessionExtensions
+    {
+        /// <summary>
+        /// Extracts the conversation/thread ID from the AG-UI session,
+        /// falling back to <paramref name="fallback"/> if unavailable.
+        /// </summary>
+        public static string GetConversationId(this AgentSession? session, string fallback = "unknown")
+        {
+            if (session is ChatClientAgentSession chatSession
+                && !string.IsNullOrEmpty(chatSession.ConversationId))
+            {
+                return chatSession.ConversationId;
+            }
+
+            return fallback;
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/AgentSessionExtensions.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/AgentSessionExtensions.cs
@@ -1,22 +1,28 @@
 using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
 
 namespace Biotrackr.Chat.Api.Middleware
 {
     /// <summary>
-    /// Extension methods for extracting conversation identity from <see cref="AgentSession"/>.
+    /// Extension methods for extracting the AG-UI thread ID from agent run context.
     /// </summary>
     public static class AgentSessionExtensions
     {
         /// <summary>
-        /// Extracts the conversation/thread ID from the AG-UI session,
+        /// Extracts the AG-UI thread ID from the run options (set by MapAGUI),
         /// falling back to <paramref name="fallback"/> if unavailable.
         /// </summary>
-        public static string GetConversationId(this AgentSession? session, string fallback = "unknown")
+        public static string GetConversationId(
+            this AgentRunOptions? options,
+            string fallback = "unknown")
         {
-            if (session is ChatClientAgentSession chatSession
-                && !string.IsNullOrEmpty(chatSession.ConversationId))
+            if (options is ChatClientAgentRunOptions chatRunOptions
+                && chatRunOptions.ChatOptions?.AdditionalProperties is { } props
+                && props.TryGetValue("ag_ui_thread_id", out var threadIdObj)
+                && threadIdObj is string threadId
+                && !string.IsNullOrEmpty(threadId))
             {
-                return chatSession.ConversationId;
+                return threadId;
             }
 
             return fallback;

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
@@ -30,7 +30,7 @@ namespace Biotrackr.Chat.Api.Middleware
         {
             var policy = policyOptions.Value;
             var userMessage = messages.LastOrDefault(m => m.Role == ChatRole.User);
-            var sessionId = session.GetConversationId(Guid.NewGuid().ToString());
+            var sessionId = options.GetConversationId(Guid.NewGuid().ToString());
 
             var conversationCapReached = await IsConversationCapReachedAsync(sessionId, policy);
 

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ConversationPersistenceMiddleware.cs
@@ -1,6 +1,8 @@
+using Biotrackr.Chat.Api.Configuration;
 using Biotrackr.Chat.Api.Services;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 
@@ -8,12 +10,17 @@ namespace Biotrackr.Chat.Api.Middleware
 {
     /// <summary>
     /// Agent middleware that persists conversation messages to Cosmos DB
-    /// after each agent streaming run completes.
+    /// after each agent streaming run completes. Enforces ASI06 conversation
+    /// safety limits: context window cap, message length limit, and conversation cap.
     /// </summary>
     public class ConversationPersistenceMiddleware(
         IChatHistoryRepository repository,
+        IOptions<ConversationPolicyOptions> policyOptions,
         ILogger<ConversationPersistenceMiddleware> logger)
     {
+        internal const string ConversationCapReachedMessage =
+            "This conversation has reached its maximum length. Please start a new conversation to continue.";
+
         public async IAsyncEnumerable<AgentResponseUpdate> HandleAsync(
             IEnumerable<ChatMessage> messages,
             AgentSession? session,
@@ -21,16 +28,19 @@ namespace Biotrackr.Chat.Api.Middleware
             AIAgent innerAgent,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            // Collect the user message (last message in the input)
+            var policy = policyOptions.Value;
             var userMessage = messages.LastOrDefault(m => m.Role == ChatRole.User);
-            var sessionId = session?.GetHashCode().ToString("x8") ?? Guid.NewGuid().ToString();
+            var sessionId = session.GetConversationId(Guid.NewGuid().ToString());
 
-            // Save the user message to Cosmos before streaming
-            if (userMessage is not null)
+            var conversationCapReached = await IsConversationCapReachedAsync(sessionId, policy);
+
+            if (userMessage is not null && !conversationCapReached)
             {
                 var userContent = string.Join("", userMessage.Contents.OfType<TextContent>().Select(c => c.Text));
                 if (!string.IsNullOrWhiteSpace(userContent))
                 {
+                    userContent = TruncateContent(userContent, policy.MaxMessageContentLength, sessionId);
+
                     try
                     {
                         await repository.SaveMessageAsync(sessionId, "user", userContent);
@@ -45,13 +55,20 @@ namespace Biotrackr.Chat.Api.Middleware
                 }
             }
 
-            // Stream the agent response, collecting the full text
+            if (conversationCapReached)
+            {
+                logger.LogWarning(
+                    "Conversation cap ({MaxMessages}) reached for session {SessionId}. Message not persisted.",
+                    policy.MaxMessagesPerConversation, sessionId);
+            }
+
+            var messagesWithHistory = await HydrateConversationHistoryAsync(sessionId, messages, policy);
+
             var responseText = new System.Text.StringBuilder();
             var toolCalls = new List<string>();
 
-            await foreach (var update in innerAgent.RunStreamingAsync(messages, session, options, cancellationToken))
+            await foreach (var update in innerAgent.RunStreamingAsync(messagesWithHistory, session, options, cancellationToken))
             {
-                // Collect response content for persistence
                 foreach (var content in update.Contents)
                 {
                     if (content is TextContent textContent)
@@ -72,10 +89,11 @@ namespace Biotrackr.Chat.Api.Middleware
                 yield return update;
             }
 
-            // Save the assistant response to Cosmos after streaming completes
             var assistantContent = responseText.ToString();
-            if (!string.IsNullOrWhiteSpace(assistantContent))
+            if (!string.IsNullOrWhiteSpace(assistantContent) && !conversationCapReached)
             {
+                assistantContent = TruncateContent(assistantContent, policy.MaxMessageContentLength, sessionId);
+
                 try
                 {
                     await repository.SaveMessageAsync(
@@ -93,6 +111,104 @@ namespace Biotrackr.Chat.Api.Middleware
                         "The response was delivered to the user but will not appear in conversation history.",
                         sessionId);
                 }
+            }
+
+            // Notify user when conversation cap is reached
+            if (conversationCapReached)
+            {
+                yield return new AgentResponseUpdate(
+                    ChatRole.Assistant,
+                    [new TextContent($"\n\n---\n{ConversationCapReachedMessage}")]);
+            }
+        }
+
+        /// <summary>
+        /// Loads previous conversation messages from Cosmos DB and prepends them
+        /// to the current messages so the agent has full conversation context.
+        /// Caps hydrated messages to <see cref="ConversationPolicyOptions.MaxHydrationMessageCount"/>.
+        /// </summary>
+        internal async Task<IEnumerable<ChatMessage>> HydrateConversationHistoryAsync(
+            string sessionId, IEnumerable<ChatMessage> currentMessages, ConversationPolicyOptions policy)
+        {
+            try
+            {
+                var conversation = await repository.GetConversationAsync(sessionId);
+                if (conversation is null || conversation.Messages.Count <= 1)
+                {
+                    return currentMessages;
+                }
+
+                // Exclude the last message (just persisted above) and cap to max hydration count
+                var allHistory = conversation.Messages.SkipLast(1);
+                var cappedHistory = allHistory.TakeLast(policy.MaxHydrationMessageCount);
+
+                var historicalMessages = cappedHistory
+                    .Select(m => new ChatMessage(
+                        m.Role == "assistant" ? ChatRole.Assistant : ChatRole.User,
+                        m.Content))
+                    .ToList();
+
+                var totalHistory = conversation.Messages.Count - 1;
+                if (totalHistory > policy.MaxHydrationMessageCount)
+                {
+                    logger.LogInformation(
+                        "Hydration capped: {Hydrated} of {Total} historical messages for session {SessionId} (max {Max})",
+                        historicalMessages.Count, totalHistory, sessionId, policy.MaxHydrationMessageCount);
+                }
+                else
+                {
+                    logger.LogInformation(
+                        "Hydrated {Count} historical messages for session {SessionId}",
+                        historicalMessages.Count, sessionId);
+                }
+
+                // Prepend history before current messages
+                historicalMessages.AddRange(currentMessages);
+                return historicalMessages;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Failed to hydrate conversation history for session {SessionId}. Continuing without history.",
+                    sessionId);
+                return currentMessages;
+            }
+        }
+
+        /// <summary>
+        /// Truncates content exceeding <paramref name="maxLength"/> characters.
+        /// </summary>
+        internal string TruncateContent(string content, int maxLength, string sessionId)
+        {
+            if (content.Length <= maxLength)
+            {
+                return content;
+            }
+
+            logger.LogWarning(
+                "Message content truncated from {OriginalLength} to {MaxLength} characters for session {SessionId}",
+                content.Length, maxLength, sessionId);
+
+            return content[..maxLength];
+        }
+
+        /// <summary>
+        /// Checks whether the conversation has reached the maximum message count.
+        /// </summary>
+        internal async Task<bool> IsConversationCapReachedAsync(string sessionId, ConversationPolicyOptions policy)
+        {
+            try
+            {
+                var conversation = await repository.GetConversationAsync(sessionId);
+                return conversation is not null
+                    && conversation.Messages.Count >= policy.MaxMessagesPerConversation;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Failed to check conversation cap for session {SessionId}. Assuming not reached.",
+                    sessionId);
+                return false;
             }
         }
 

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/GracefulDegradationMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/GracefulDegradationMiddleware.cs
@@ -25,7 +25,7 @@ namespace Biotrackr.Chat.Api.Middleware
             AIAgent innerAgent,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var sessionId = session?.GetHashCode().ToString("x8") ?? "unknown";
+            var sessionId = session.GetConversationId();
 
             IAsyncEnumerator<AgentResponseUpdate>? enumerator = null;
             try

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/GracefulDegradationMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/GracefulDegradationMiddleware.cs
@@ -25,7 +25,7 @@ namespace Biotrackr.Chat.Api.Middleware
             AIAgent innerAgent,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var sessionId = session.GetConversationId();
+            var sessionId = options.GetConversationId();
 
             IAsyncEnumerator<AgentResponseUpdate>? enumerator = null;
             try

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ToolPolicyMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ToolPolicyMiddleware.cs
@@ -26,7 +26,7 @@ namespace Biotrackr.Chat.Api.Middleware
             AIAgent innerAgent,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var sessionId = session?.GetHashCode().ToString("x8") ?? "unknown";
+            var sessionId = session.GetConversationId();
             var budgetKey = $"toolbudget:{sessionId}";
             var policyOptions = options.Value;
 

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ToolPolicyMiddleware.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Middleware/ToolPolicyMiddleware.cs
@@ -26,7 +26,7 @@ namespace Biotrackr.Chat.Api.Middleware
             AIAgent innerAgent,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var sessionId = session.GetConversationId();
+            var sessionId = runOptions.GetConversationId();
             var budgetKey = $"toolbudget:{sessionId}";
             var policyOptions = options.Value;
 

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Models/ChatConversationDocument.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Models/ChatConversationDocument.cs
@@ -18,5 +18,11 @@ namespace Biotrackr.Chat.Api.Models
 
         [JsonPropertyName("messages")]
         public List<ChatMessage> Messages { get; set; } = [];
+
+        /// <summary>
+        /// Cosmos DB per-document TTL in seconds. Refreshed on every upsert.
+        /// </summary>
+        [JsonPropertyName("ttl")]
+        public int Ttl { get; set; } = 7776000;
     }
 }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
@@ -8,7 +8,6 @@ using Biotrackr.Chat.Api.Middleware;
 using Biotrackr.Chat.Api.Services;
 using Biotrackr.Chat.Api.Tools;
 using Microsoft.Agents.AI;
-using Microsoft.Agents.AI.Hosting;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.AI;
@@ -187,13 +186,10 @@ AIAgent persistentAgent = chatAgent
         .Use(runFunc: null, runStreamingFunc: degradationMiddleware.HandleAsync)
     .Build();
 
-// Wrap with AIHostAgent so sessions (and their ConversationId) persist between requests
-var hostedAgent = new AIHostAgent(persistentAgent, new InMemoryAgentSessionStore());
-
 app.MapOpenApi();
 
 // AG-UI endpoint — SSE streaming, session management, protocol events
-app.MapAGUI("/", hostedAgent);
+app.MapAGUI("/", persistentAgent);
 
 // Conversation history + health check endpoints
 app.RegisterChatEndpoints();

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
@@ -163,7 +163,8 @@ AIAgent chatAgent = anthropicClient.AsAIAgent(
 // Wrap agent with conversation persistence middleware
 var chatHistoryRepository = app.Services.GetRequiredService<IChatHistoryRepository>();
 var persistenceLogger = app.Services.GetRequiredService<ILogger<ConversationPersistenceMiddleware>>();
-var persistenceMiddleware = new ConversationPersistenceMiddleware(chatHistoryRepository, persistenceLogger);
+var conversationPolicyOptions = Microsoft.Extensions.Options.Options.Create(new ConversationPolicyOptions());
+var persistenceMiddleware = new ConversationPersistenceMiddleware(chatHistoryRepository, conversationPolicyOptions, persistenceLogger);
 
 // Wrap agent with tool policy enforcement middleware (rate limiting, allowed tool validation)
 var biotrackrSettings = app.Services.GetRequiredService<Microsoft.Extensions.Options.IOptions<Settings>>().Value;

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
@@ -8,6 +8,7 @@ using Biotrackr.Chat.Api.Middleware;
 using Biotrackr.Chat.Api.Services;
 using Biotrackr.Chat.Api.Tools;
 using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Hosting;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.AI;
@@ -186,10 +187,13 @@ AIAgent persistentAgent = chatAgent
         .Use(runFunc: null, runStreamingFunc: degradationMiddleware.HandleAsync)
     .Build();
 
+// Wrap with AIHostAgent so sessions (and their ConversationId) persist between requests
+var hostedAgent = new AIHostAgent(persistentAgent, new InMemoryAgentSessionStore());
+
 app.MapOpenApi();
 
 // AG-UI endpoint — SSE streaming, session management, protocol events
-app.MapAGUI("/", persistentAgent);
+app.MapAGUI("/", hostedAgent);
 
 // Conversation history + health check endpoints
 app.RegisterChatEndpoints();

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatHistoryRepository.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatHistoryRepository.cs
@@ -111,6 +111,7 @@ namespace Biotrackr.Chat.Api.Services
                 ToolCalls = toolCalls
             });
             conversation.LastUpdated = DateTime.UtcNow;
+            conversation.Ttl = _settings.ConversationTtlSeconds;
 
             // Auto-title from first user message
             if (conversation.Title == "New conversation" && role == "user")

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Chat.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Chat.razor
@@ -144,6 +144,7 @@
 
         if (_currentSessionId is null)
         {
+            _currentSessionId = Guid.NewGuid().ToString();
             ChatTelemetry.ConversationsCreated.Add(1);
         }
 


### PR DESCRIPTION
## Problem

The chat agent had no context between messages in the same conversation. Each follow-up question was treated as a brand new conversation:

> **User:** How many steps did I take on March 14th 2026?
> **Agent:** You took 15,244 steps! *(calls GetActivityByDate tool)*
>
> **User:** And how many calories were burned during exercise?
> **Agent:** I don't have any previous context about a specific date. Could you clarify which date?

### Root Cause

Two bugs in `ConversationPersistenceMiddleware`:

1. **Session ID was random per request** — `session?.GetHashCode().ToString("x8")` produced a different value on every HTTP request because `AgentSession` is a new object instance each time. Every message created its own Cosmos DB document instead of appending to the existing conversation.

2. **No conversation history hydration** — even with a stable session ID, the middleware never loaded prior messages from Cosmos DB before passing them to the agent. The AG-UI protocol only sends the current user message, so the agent always had zero prior context.

## Changes

### Session identity fix
- New `AgentSessionExtensions.GetConversationId()` extracts the AG-UI protocol's `threadId` from `ChatClientAgentSession.ConversationId` for stable session identity
- All three middleware classes updated (`ConversationPersistenceMiddleware`, `ToolPolicyMiddleware`, `GracefulDegradationMiddleware`)

### Conversation history hydration
- `HydrateConversationHistoryAsync` loads prior messages from Cosmos DB and prepends them before the current message so the agent sees the full conversation

### ASI06 safety limits (Memory & Context Poisoning)
- **Context window cap** (`MaxHydrationMessageCount = 50`) — only the most recent N messages are hydrated, preventing context-window manipulation
- **Per-message content length limit** (`MaxMessageContentLength = 10,000`) — oversized messages truncated before persistence
- **Conversation message cap** (`MaxMessagesPerConversation = 100`) — once reached, agent still responds but messages aren't persisted; user is notified to start a new conversation
- **Cosmos DB TTL** (`defaultTtl: 7776000` / 90 days) — conversations auto-expire after 90 days of inactivity; TTL refreshed on every upsert

### New files
- `Middleware/AgentSessionExtensions.cs` — session ID extraction
- `Configuration/ConversationPolicyOptions.cs` — ASI06 limit configuration

### Modified files
- `Middleware/ConversationPersistenceMiddleware.cs` — hydration + all three safety controls
- `Middleware/GracefulDegradationMiddleware.cs` — session ID fix
- `Middleware/ToolPolicyMiddleware.cs` — session ID fix
- `Models/ChatConversationDocument.cs` — `ttl` property
- `Configuration/Settings.cs` — `ConversationTtlSeconds`
- `Services/ChatHistoryRepository.cs` — TTL refresh on upsert
- `Program.cs` — wire up `ConversationPolicyOptions`
- `infra/modules/database/serverless-cosmos-db.bicep` — `defaultTtl` on container

## Tests

All **233 tests pass** (13 new). New test coverage:

| Area | Tests |
|------|-------|
| `AgentSessionExtensionsShould` | 5 — ChatClientAgentSession extraction, null/fallback/empty scenarios |
| Conversation hydration | 4 — history prepended, no-history, failure graceful degradation, error logging |
| Context window cap | 2 — capped vs under-cap |
| Content length truncation | 4 — user truncation, no-truncation, assistant truncation, warning log |
| Conversation message cap | 5 — no persistence, still streams, warning log, normal under-cap, cap check failure |
| Cosmos DB TTL | 2 — TTL set on new conversation, TTL refreshed on existing |
