### PR TITLE
feat: render chat assistant messages as markdown

### DIFF
--- a/src/Biotrackr.UI/Biotrackr.UI/Biotrackr.UI.csproj
+++ b/src/Biotrackr.UI/Biotrackr.UI/Biotrackr.UI.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Markdig" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.2.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Chat.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Chat.razor
@@ -3,6 +3,7 @@
 @inject IChatApiService ChatApiService
 @inject IJSRuntime JS
 @using Biotrackr.UI.Telemetry
+@using Markdig
 @using ChatMessage = Biotrackr.UI.Models.Chat.ChatMessage
 
 <PageTitle>Biotrackr - Chat</PageTitle>
@@ -66,7 +67,14 @@
                 @foreach (var message in _messages)
                 {
                     <div class="message @(message.Role == "user" ? "message-user" : "message-agent")">
-                        <div class="message-content">@message.Content</div>
+                        @if (message.Role == "assistant")
+                        {
+                            <div class="message-content markdown-body">@RenderMarkdown(message.Content)</div>
+                        }
+                        else
+                        {
+                            <div class="message-content">@message.Content</div>
+                        }
                         @if (message.Role == "assistant" && message.ToolCalls is { Count: > 0 })
                         {
                             <div class="message-tool-badges">
@@ -85,7 +93,7 @@
                     <div class="message message-agent">
                         @if (!string.IsNullOrEmpty(_currentResponse))
                         {
-                            <div class="message-content">@_currentResponse</div>
+                            <div class="message-content markdown-body">@RenderMarkdown(_currentResponse)</div>
                         }
                         <div class="typing-indicator">
                             <span></span><span></span><span></span>
@@ -103,6 +111,10 @@
 </div>
 
 @code {
+    private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .Build();
+
     private List<ChatMessage> _messages = [];
     private List<ChatConversationSummary> _conversations = [];
     private string? _currentSessionId;
@@ -282,6 +294,12 @@
         _conversations.AddRange(result.Items);
         _hasMoreConversations = result.HasNextPage;
         StateHasChanged();
+    }
+
+    private static MarkupString RenderMarkdown(string content)
+    {
+        var html = Markdown.ToHtml(content, MarkdownPipeline);
+        return new MarkupString(html);
     }
 
     private async Task ScrollToBottom()

--- a/src/Biotrackr.UI/Biotrackr.UI/wwwroot/app.css
+++ b/src/Biotrackr.UI/Biotrackr.UI/wwwroot/app.css
@@ -177,6 +177,80 @@
     line-height: 1.5;
 }
 
+.message-content.markdown-body {
+    white-space: normal;
+}
+
+.markdown-body p {
+    margin: 0 0 0.5em;
+}
+
+.markdown-body p:last-child {
+    margin-bottom: 0;
+}
+
+.markdown-body table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0.5em 0;
+    font-size: 0.85rem;
+}
+
+.markdown-body th,
+.markdown-body td {
+    border: 1px solid #dee2e6;
+    padding: 0.4rem 0.6rem;
+    text-align: left;
+}
+
+.markdown-body th {
+    background-color: rgba(0, 0, 0, 0.05);
+    font-weight: 600;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+    margin: 0.3em 0;
+    padding-left: 1.5em;
+}
+
+.markdown-body li {
+    margin-bottom: 0.2em;
+}
+
+.markdown-body code {
+    background-color: rgba(0, 0, 0, 0.06);
+    padding: 0.15em 0.35em;
+    border-radius: 3px;
+    font-size: 0.85em;
+}
+
+.markdown-body pre {
+    background-color: rgba(0, 0, 0, 0.06);
+    padding: 0.6em;
+    border-radius: 4px;
+    overflow-x: auto;
+    margin: 0.5em 0;
+}
+
+.markdown-body pre code {
+    background: none;
+    padding: 0;
+}
+
+.markdown-body hr {
+    border: none;
+    border-top: 1px solid #dee2e6;
+    margin: 0.8em 0;
+}
+
+.markdown-body blockquote {
+    border-left: 3px solid #dee2e6;
+    margin: 0.5em 0;
+    padding: 0.3em 0.8em;
+    color: #6c757d;
+}
+
 .message-timestamp {
     font-size: 0.65rem;
     opacity: 0.6;


### PR DESCRIPTION
## Summary

The chat agent responds using markdown (bold, tables, lists, emoji), but the UI was rendering it as plain text. Tables appeared as pipe-delimited lines and bold markers showed as literal `**` characters.

## Changes

- **Added [Markdig](https://github.com/xoofx/markdig) 1.1.1** with `UseAdvancedExtensions()` for tables, emoji, task lists, and pipe tables
- **Assistant messages** are rendered via `Markdown.ToHtml()` → `MarkupString`. User messages remain plain text
- **Streaming responses** also render as markdown in real-time
- **CSS styles** for `.markdown-body` — tables, lists, code blocks, blockquotes, horizontal rules. The existing `white-space: pre-wrap` is preserved for user messages but overridden to `normal` for markdown so HTML layouts correctly

## Files changed

| File | Change |
|------|--------|
| `Biotrackr.UI.csproj` | Added Markdig 1.1.1 |
| `Chat.razor` | Added `@using Markdig`, static `MarkdownPipeline`, `RenderMarkdown()` helper, conditional rendering for assistant vs user messages |
| `app.css` | Added `.markdown-body` styles for tables, lists, code, blockquotes, `<hr>` |

## Testing

All 142 UI unit tests pass. Manually verified markdown rendering of bold, tables, lists, and emoji in agent responses.
