### PR TITLE
fix(mcp-server): remediate MCP07 insufficient auth and rate limiting

### DIFF
--- a/infra/apps/chat-api/main.bicep
+++ b/infra/apps/chat-api/main.bicep
@@ -375,6 +375,16 @@ resource apiSubscriptionKeySetting 'Microsoft.AppConfiguration/configurationStor
   }
 }
 
+// App Configuration: MCP Server API Key (Key Vault reference)
+resource mcpServerApiKeySetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2025-02-01-preview' = {
+  name: 'Biotrackr:McpServerApiKey'
+  parent: appConfig
+  properties: {
+    value: '{"uri":"${keyVault.properties.vaultUri}secrets/mcpserverapikey"}'
+    contentType: 'application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8'
+  }
+}
+
 // App Configuration: Chat agent system prompt (Key Vault reference)
 resource chatSystemPromptSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2025-02-01-preview' = {
   name: 'Biotrackr:ChatSystemPrompt'

--- a/infra/apps/mcp-server/main.bicep
+++ b/infra/apps/mcp-server/main.bicep
@@ -28,6 +28,9 @@ param appInsightsName string
 @description('The name of the API Management instance that this MCP Server uses')
 param apimName string
 
+@description('The name of the Key Vault instance for storing secrets')
+param keyVaultName string
+
 @description('Enable JWT validation for managed identity authentication')
 param enableManagedIdentityAuth bool = true
 
@@ -51,6 +54,10 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
 
 resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
   name: apimName
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
 }
 
 var apiProductName = 'MCP-Server'
@@ -223,5 +230,25 @@ resource biotrackrApiSubscriptionKeySetting 'Microsoft.AppConfiguration/configur
   parent: appConfig
   properties: {
     value: mcpServerApimSubscription.listSecrets().primaryKey
+  }
+}
+
+// MCP Server API Key: Generate a strong key from deterministic inputs
+var mcpApiKeyValue = '${uniqueString(resourceGroup().id, 'mcp-api-key-1')}${uniqueString(subscription().id, 'mcp-api-key-2')}${uniqueString(keyVault.id, 'mcp-api-key-3')}'
+
+resource mcpServerApiKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  name: 'mcpserverapikey'
+  parent: keyVault
+  properties: {
+    value: mcpApiKeyValue
+  }
+}
+
+resource mcpServerApiKeySetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2025-02-01-preview' = {
+  name: 'mcpserverapikey'
+  parent: appConfig
+  properties: {
+    value: '{"uri":"${keyVault.properties.vaultUri}secrets/mcpserverapikey"}'
+    contentType: 'application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8'
   }
 }

--- a/infra/apps/mcp-server/main.dev.bicepparam
+++ b/infra/apps/mcp-server/main.dev.bicepparam
@@ -14,5 +14,6 @@ param uaiName = 'uai-biotrackr-dev'
 param appConfigName = 'config-biotrackr-dev'
 param appInsightsName = 'appins-biotrackr-dev'
 param apimName = 'api-biotrackr-dev'
+param keyVaultName = 'kv-biotrackr-dev'
 param enableManagedIdentityAuth = true
 param tenantId = ''

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/Settings.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/Settings.cs
@@ -13,6 +13,7 @@ namespace Biotrackr.Chat.Api.Configuration
         /// </summary>
         public string McpServerUrl { get; set; }
         public string ApiSubscriptionKey { get; set; }
+        public string McpServerApiKey { get; set; }
         public string AnthropicApiKey { get; set; }
         public string ChatAgentModel { get; set; }
         public string ChatSystemPrompt { get; set; }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/McpToolService.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/McpToolService.cs
@@ -112,12 +112,21 @@ namespace Biotrackr.Chat.Api.Services
                     TransportMode = HttpTransportMode.AutoDetect,
                 };
 
+                var headers = new Dictionary<string, string>();
+
                 if (!string.IsNullOrWhiteSpace(_settings.ApiSubscriptionKey))
                 {
-                    transportOptions.AdditionalHeaders = new Dictionary<string, string>
-                    {
-                        [SubscriptionKeyHeader] = _settings.ApiSubscriptionKey
-                    };
+                    headers[SubscriptionKeyHeader] = _settings.ApiSubscriptionKey;
+                }
+
+                if (!string.IsNullOrWhiteSpace(_settings.McpServerApiKey))
+                {
+                    headers["X-Api-Key"] = _settings.McpServerApiKey;
+                }
+
+                if (headers.Count > 0)
+                {
+                    transportOptions.AdditionalHeaders = headers;
                 }
 
                 var transport = new HttpClientTransport(transportOptions, _loggerFactory);

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server.UnitTests/Middleware/ApiKeyAuthMiddlewareShould.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server.UnitTests/Middleware/ApiKeyAuthMiddlewareShould.cs
@@ -1,0 +1,211 @@
+using Biotrackr.Mcp.Server.Middleware;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Biotrackr.Mcp.Server.UnitTests.Middleware
+{
+    public class ApiKeyAuthMiddlewareShould
+    {
+        private const string ValidApiKey = "test-api-key-12345";
+
+        private readonly Mock<ILogger<ApiKeyAuthMiddleware>> _loggerMock;
+
+        public ApiKeyAuthMiddlewareShould()
+        {
+            _loggerMock = new Mock<ILogger<ApiKeyAuthMiddleware>>();
+        }
+
+        private ApiKeyAuthMiddleware CreateMiddleware(string? configuredApiKey, RequestDelegate? next = null)
+        {
+            next ??= _ => Task.CompletedTask;
+
+            var configData = new Dictionary<string, string?>();
+            if (configuredApiKey is not null)
+            {
+                configData["mcpserverapikey"] = configuredApiKey;
+            }
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+
+            return new ApiKeyAuthMiddleware(next, configuration, _loggerMock.Object);
+        }
+
+        private static HttpContext CreateHttpContext(string path, string? apiKey = null)
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Path = path;
+            context.Response.Body = new MemoryStream();
+
+            if (apiKey is not null)
+            {
+                context.Request.Headers["X-Api-Key"] = apiKey;
+            }
+
+            return context;
+        }
+
+        [Fact]
+        public async Task InvokeAsync_ShouldReturn401_WhenApiKeyHeaderIsMissing()
+        {
+            // Arrange
+            var middleware = CreateMiddleware(ValidApiKey);
+            var context = CreateHttpContext("/mcp");
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_ShouldReturn401_WhenApiKeyHeaderIsInvalid()
+        {
+            // Arrange
+            var middleware = CreateMiddleware(ValidApiKey);
+            var context = CreateHttpContext("/mcp", apiKey: "wrong-key");
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_ShouldCallNext_WhenApiKeyHeaderIsValid()
+        {
+            // Arrange
+            var nextCalled = false;
+            var middleware = CreateMiddleware(ValidApiKey, next: _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            });
+            var context = CreateHttpContext("/mcp", apiKey: ValidApiKey);
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            nextCalled.Should().BeTrue();
+            context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_ShouldBypassAuth_ForHealthCheckEndpoint()
+        {
+            // Arrange
+            var nextCalled = false;
+            var middleware = CreateMiddleware(ValidApiKey, next: _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            });
+            var context = CreateHttpContext("/api/healthz");
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            nextCalled.Should().BeTrue();
+            context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_ShouldAllowAllRequests_WhenNoApiKeyIsConfigured()
+        {
+            // Arrange
+            var nextCalled = false;
+            var middleware = CreateMiddleware(configuredApiKey: null, next: _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            });
+            var context = CreateHttpContext("/mcp");
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            nextCalled.Should().BeTrue();
+            context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_ShouldAllowAllRequests_WhenApiKeyIsEmptyString()
+        {
+            // Arrange
+            var nextCalled = false;
+            var middleware = CreateMiddleware(configuredApiKey: "", next: _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            });
+            var context = CreateHttpContext("/mcp");
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            nextCalled.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task InvokeAsync_ShouldLogWarning_WhenApiKeyIsInvalid()
+        {
+            // Arrange
+            var middleware = CreateMiddleware(ValidApiKey);
+            var context = CreateHttpContext("/mcp", apiKey: "wrong-key");
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            _loggerMock.VerifyLog(l => l.LogWarning(
+                It.Is<string>(s => s.Contains("missing or invalid API key"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_ShouldNotCallNext_WhenApiKeyIsInvalid()
+        {
+            // Arrange
+            var nextCalled = false;
+            var middleware = CreateMiddleware(ValidApiKey, next: _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            });
+            var context = CreateHttpContext("/mcp", apiKey: "wrong-key");
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            nextCalled.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task InvokeAsync_ShouldWriteUnauthorizedJsonResponse_WhenRejected()
+        {
+            // Arrange
+            var middleware = CreateMiddleware(ValidApiKey);
+            var context = CreateHttpContext("/mcp");
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            using var reader = new StreamReader(context.Response.Body);
+            var body = await reader.ReadToEndAsync();
+            body.Should().Contain("Unauthorized");
+        }
+    }
+}

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Middleware/ApiKeyAuthMiddleware.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Middleware/ApiKeyAuthMiddleware.cs
@@ -1,0 +1,57 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Biotrackr.Mcp.Server.Middleware;
+
+/// <summary>
+/// Validates an X-Api-Key header on all requests except health check endpoints.
+/// When no API key is configured (local dev), all requests are allowed.
+/// </summary>
+public class ApiKeyAuthMiddleware
+{
+    private const string ApiKeyHeaderName = "X-Api-Key";
+    private readonly RequestDelegate _next;
+    private readonly string? _expectedApiKey;
+    private readonly ILogger<ApiKeyAuthMiddleware> _logger;
+
+    public ApiKeyAuthMiddleware(
+        RequestDelegate next,
+        IConfiguration configuration,
+        ILogger<ApiKeyAuthMiddleware> logger)
+    {
+        _next = next;
+        _expectedApiKey = configuration.GetValue<string>("mcpserverapikey");
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        // Skip auth for health check endpoints (Container App probes)
+        if (context.Request.Path.StartsWithSegments("/api/healthz"))
+        {
+            await _next(context);
+            return;
+        }
+
+        // If no API key is configured, allow all requests (local dev / fallback)
+        if (string.IsNullOrWhiteSpace(_expectedApiKey))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (!context.Request.Headers.TryGetValue(ApiKeyHeaderName, out var providedKey) ||
+            !CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(providedKey.ToString()),
+                Encoding.UTF8.GetBytes(_expectedApiKey)))
+        {
+            _logger.LogWarning("Rejected request to {Path} — missing or invalid API key",
+                context.Request.Path);
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsJsonAsync(new { error = "Unauthorized" });
+            return;
+        }
+
+        await _next(context);
+    }
+}

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Program.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using Biotrackr.Mcp.Server.Middleware;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.RateLimiting;
 
@@ -106,17 +107,21 @@ builder.Services.AddSingleton<HttpClient>(provider =>
 builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
-    options.AddFixedWindowLimiter("McpRateLimit", limiter =>
-    {
-        limiter.PermitLimit = 100;
-        limiter.Window = TimeSpan.FromMinutes(1);
-        limiter.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-        limiter.QueueLimit = 10;
-    });
+    options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 100,
+                Window = TimeSpan.FromMinutes(1),
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 10
+            }));
 });
 
 var app = builder.Build();
 
+app.UseMiddleware<ApiKeyAuthMiddleware>();
 app.UseRateLimiter();
 
 app.MapGet("/api/healthz", async (HttpClient httpClient) =>
@@ -132,7 +137,7 @@ app.MapGet("/api/healthz", async (HttpClient httpClient) =>
     {
         return Results.Ok(new { status = "Degraded", downstream = $"Unreachable: {ex.Message}" });
     }
-}).RequireRateLimiting("McpRateLimit");
+});
 
 app.MapMcp();
 


### PR DESCRIPTION
## Summary

Remediates **MCP07:2025 — Insufficient Authentication and Authorization** finding from the [MCP Server OWASP Vulnerability Report](docs/plans/mcp-server-owasp-vulnerability-report-2026-03-21.md). Implements both Phase 1 (Global Rate Limiting) and Phase 2 (API Key Validation Middleware) from the [remediation plan](docs/plans/mcp07-remediation-plan.md).

## Problem

The MCP Server had two security gaps:

1. **Rate limiting not applied to MCP endpoints** — The named `McpRateLimit` policy only covered `/api/healthz`, not MCP transport endpoints (`MapMcp()`).
2. **No application-level authentication** — The MCP Server relied entirely on APIM for access control, but Container Apps are publicly accessible via their direct FQDN, bypassing APIM.

## Changes

### Phase 1 — Global Rate Limiting

- **`src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Program.cs`**: Replaced named `McpRateLimit` policy with a global `PartitionedRateLimiter` keyed by client IP (100 req/min, queue 10). Removed `.RequireRateLimiting("McpRateLimit")` from healthz endpoint — global limiter covers it automatically.

### Phase 2 — API Key Validation Middleware

**Code:**
- **`src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Middleware/ApiKeyAuthMiddleware.cs`** *(new)*: Validates `X-Api-Key` header on all requests except `/api/healthz`. Uses `CryptographicOperations.FixedTimeEquals` for constant-time comparison. Falls back to allow-all when no key is configured (local dev).
- **`src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Program.cs`**: Registered middleware before `UseRateLimiter()`.
- **`src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/Settings.cs`**: Added `McpServerApiKey` property.
- **`src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/McpToolService.cs`**: Updated `TryConnectAsync()` to send `X-Api-Key` header alongside APIM subscription key.

**Infrastructure:**
- **`infra/apps/mcp-server/main.bicep`**: Added `keyVaultName` parameter, Key Vault secret (`mcpserverapikey` generated via 3x `uniqueString`), and App Config Key Vault reference.
- **`infra/apps/mcp-server/main.dev.bicepparam`**: Added `keyVaultName = 'kv-biotrackr-dev'`.
- **`infra/apps/chat-api/main.bicep`**: Added `Biotrackr:McpServerApiKey` App Config Key Vault reference.

**Tests:**
- **`src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server.UnitTests/Middleware/ApiKeyAuthMiddlewareShould.cs`** *(new)*: 9 tests covering 401 rejection (missing/invalid key), valid key passthrough, healthz bypass, unconfigured key fallback, warning logging, and response body validation.

## Test Results

- **MCP Server unit tests**: 115 passed, 0 failed
- **Chat API unit tests**: 108 passed, 0 failed

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| MCP transport endpoints return 429 after 100 req/min from same IP | ✅ |
| `/api/healthz` continues to function under normal load | ✅ |
| Direct requests without `X-Api-Key` return 401 | ✅ |
| Requests through APIM (with subscription key + `X-Api-Key`) succeed | ✅ |
| Health check endpoint works without API key | ✅ |
| Local development works without API key configured | ✅ |

## Security Considerations

- `CryptographicOperations.FixedTimeEquals()` prevents timing side-channel attacks
- API key generated from deterministic `uniqueString()` inputs — stable across redeployments
- Key stored in Key Vault, referenced via App Config Key Vault references
- APIM `forward-request` passes `X-Api-Key` header to backend by default
- UAI has Key Vault Secrets Officer role — confirmed in `infra/modules/security/key-vault.bicep`

After this change, MCP07:2025 status changes from **FAIL** to **PASS**.