### PR TITLE
feat: add Azure AI Foundry Bicep module and core infrastructure wiring

### DIFF
--- a/.github/workflows/deploy-core-infra.yml
+++ b/.github/workflows/deploy-core-infra.yml
@@ -34,8 +34,22 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}
 
-    deploy-dev:
+    preview:
         needs: validate
+        name: Preview Changes (What-If)
+        uses: willvelida/biotrackr/.github/workflows/template-bicep-whatif.yml@main
+        with:
+          template-file: './infra/core/main.bicep'
+          parameters-file: './infra/core/main.dev.bicepparam'
+          scope: resourceGroup
+        secrets:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          resource-group-name: ${{ secrets.AZURE_RG_NAME_DEV }}
+
+    deploy-dev:
+        needs: preview
         name: Deploy Template to Dev
         uses: willvelida/biotrackr/.github/workflows/template-bicep-deploy.yml@main
         with:

--- a/infra/core/main.bicep
+++ b/infra/core/main.bicep
@@ -135,3 +135,16 @@ module reportStorage '../modules/storage/storage-account.bicep' = {
     uaiPrincipalId: uai.outputs.prinicpalId
   }
 }
+
+module foundry '../modules/ai/foundry.bicep' = {
+  name: 'foundry'
+  params: {
+    name: 'ai-${baseName}-${environment}'
+    projectName: '${baseName}-genaiops'
+    location: location
+    tags: union(tags, { Component: 'AI' })
+    appInsightsName: appInsights.outputs.appInsightsName
+    logAnalyticsName: logAnalytics.outputs.logAnalyticsName
+    uaiName: uai.outputs.uaiName
+  }
+}

--- a/infra/modules/ai/foundry.bicep
+++ b/infra/modules/ai/foundry.bicep
@@ -46,6 +46,9 @@ resource foundryAccount 'Microsoft.CognitiveServices/accounts@2025-09-01' = {
   location: location
   tags: tags
   kind: 'AIServices'
+  identity: {
+    type: 'SystemAssigned'
+  }
   sku: {
     name: 'S0'
   }

--- a/infra/modules/ai/foundry.bicep
+++ b/infra/modules/ai/foundry.bicep
@@ -64,6 +64,9 @@ resource foundryProject 'Microsoft.CognitiveServices/accounts/projects@2025-09-0
   name: projectName
   location: location
   tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
   properties: {
     displayName: projectName
     description: 'Biotrackr GenAIOps — evaluation, monitoring, and tracing for Claude-powered agents'

--- a/infra/modules/ai/foundry.bicep
+++ b/infra/modules/ai/foundry.bicep
@@ -1,0 +1,118 @@
+metadata name = 'Azure AI Foundry'
+metadata description = 'This module deploys an Azure AI Foundry hub account and project for GenAIOps (evaluation, monitoring, tracing).'
+
+@description('The name of the AI Foundry resource')
+@minLength(2)
+@maxLength(64)
+param name string
+
+@description('The name of the Foundry project')
+@minLength(2)
+@maxLength(64)
+param projectName string
+
+@description('The location for all resources')
+@allowed([
+  'australiaeast'
+])
+param location string
+
+@description('Tags to apply to all resources')
+param tags object
+
+@description('The name of the Application Insights instance to connect for trace correlation')
+param appInsightsName string
+
+@description('The name of the Log Analytics workspace for diagnostic settings')
+param logAnalyticsName string
+
+@description('The name of the user-assigned identity to grant Cognitive Services User role')
+param uaiName string
+
+resource uai 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: uaiName
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: appInsightsName
+}
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+  name: logAnalyticsName
+}
+
+resource foundryAccount 'Microsoft.CognitiveServices/accounts@2025-09-01' = {
+  name: name
+  location: location
+  tags: tags
+  kind: 'AIServices'
+  sku: {
+    name: 'S0'
+  }
+  properties: {
+    customSubDomainName: name
+    publicNetworkAccess: 'Enabled'
+    allowProjectManagement: true
+  }
+}
+
+resource foundryProject 'Microsoft.CognitiveServices/accounts/projects@2025-09-01' = {
+  parent: foundryAccount
+  name: projectName
+  location: location
+  tags: tags
+  properties: {
+    displayName: projectName
+    description: 'Biotrackr GenAIOps — evaluation, monitoring, and tracing for Claude-powered agents'
+  }
+}
+
+resource diagnosticLogs 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: foundryAccount.name
+  scope: foundryAccount
+  properties: {
+    workspaceId: logAnalytics.id
+    logs: [
+      {
+        category: 'Audit'
+        enabled: true
+      }
+      {
+        category: 'RequestResponse'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}
+
+// Cognitive Services User — enables Chat.Api to send correlated traces and future SDK calls
+resource cognitiveServicesUserRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, resourceGroup().id, foundryAccount.id, 'CognitiveServicesUser')
+  scope: foundryAccount
+  properties: {
+    principalId: uai.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908')
+    principalType: 'ServicePrincipal'
+  }
+}
+
+@description('The name of the deployed AI Foundry account')
+output foundryAccountName string = foundryAccount.name
+
+@description('The resource ID of the AI Foundry account')
+output foundryAccountId string = foundryAccount.id
+
+@description('The endpoint of the AI Foundry account')
+output foundryEndpoint string = foundryAccount.properties.endpoint
+
+@description('The name of the deployed Foundry project')
+output foundryProjectName string = foundryProject.name
+
+@description('The Application Insights resource ID (for portal connection)')
+output appInsightsResourceId string = appInsights.id


### PR DESCRIPTION
## Summary

Add Azure AI Foundry infrastructure (Phase 1) for GenAIOps — evaluation, monitoring, and tracing of Biotrackr's Claude-powered agents. This PR deploys the Foundry resource and project via Bicep with zero model deployments.

## Changes

### Added

- `infra/modules/ai/foundry.bicep` — New Bicep module deploying:
  - `Microsoft.CognitiveServices/accounts` with `kind: 'AIServices'` and `allowProjectManagement: true` (Foundry hub)
  - `Microsoft.CognitiveServices/accounts/projects` (Foundry project for GenAIOps)
  - Diagnostic settings (Audit, RequestResponse logs + AllMetrics) to Log Analytics
  - `Cognitive Services User` RBAC role assignment for the existing UAI

### Modified

- `infra/core/main.bicep` — Wire the Foundry module after `reportStorage`, naming resources `ai-biotrackr-dev` and `biotrackr-genaiops`

## Context

This is Phase 1 of the [Foundry GenAIOps plan](.copilot-tracking/plans/2026-03-27/foundry-genaiops-plan.instructions.md). The approach uses safety evaluators and `GroundednessProEvaluator` (Content Safety backend) instead of a GPT judge model, since Chat.Api is a data-grounded agent where GPT-judge quality evaluators would produce noise.

### What this PR does NOT include (deferred to later phases)
- No model deployments (no GPT judge, no production model)
- No Chat.Api code changes (OpenTelemetry gen_ai spans = Phase 2)
- No evaluation pipeline (Phase 3)
- No App Config wiring for `FoundryProjectEndpoint` (deferred until a consumer exists)

## Validation

- `az bicep build` passes for `foundry.bicep` and `core/main.bicep` with zero errors
- Uses `@2025-09-01` API version (latest GA, verified via Bicep type system after CLI upgrade to v0.41.2)
