### PR TITLE
feat(chat-api): Claude API token optimization — Phase 1 & 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,3 +413,6 @@ scripts/reporting-api-prompts/report-generator-prompt.txt
 
 # Reviewer system prompt — sensitive configuration, stored in Key Vault
 scripts/chat-system-prompt/reviewer-prompt.txt
+
+# researcher files
+.copilot-tracking/*

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Handlers/AnthropicMetricsHandlerShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Handlers/AnthropicMetricsHandlerShould.cs
@@ -1,0 +1,181 @@
+using System.Net;
+using Biotrackr.Chat.Api.Handlers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Biotrackr.Chat.Api.UnitTests.Handlers
+{
+    public class AnthropicMetricsHandlerShould
+    {
+        private readonly Mock<ILogger<AnthropicMetricsHandler>> _loggerMock;
+
+        public AnthropicMetricsHandlerShould()
+        {
+            _loggerMock = new Mock<ILogger<AnthropicMetricsHandler>>();
+        }
+
+        [Fact]
+        public async Task ReturnResponse_WhenRequestSucceeds()
+        {
+            // Arrange
+            var innerHandler = new FakeHandler(new HttpResponseMessage(HttpStatusCode.OK));
+            var handler = new AnthropicMetricsHandler(_loggerMock.Object)
+            {
+                InnerHandler = innerHandler
+            };
+            var invoker = new HttpMessageInvoker(handler);
+
+            // Act
+            var response = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Post, "https://api.anthropic.com/v1/messages"), CancellationToken.None);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task LogWarning_WhenRateLimitHit()
+        {
+            // Arrange
+            var innerHandler = new FakeHandler(new HttpResponseMessage(HttpStatusCode.TooManyRequests));
+            var handler = new AnthropicMetricsHandler(_loggerMock.Object)
+            {
+                InnerHandler = innerHandler
+            };
+            var invoker = new HttpMessageInvoker(handler);
+
+            // Act
+            var response = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Post, "https://api.anthropic.com/v1/messages"), CancellationToken.None);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Anthropic rate limit hit (429)")),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task CaptureRateLimitHeaders_WhenPresent()
+        {
+            // Arrange
+            var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+            responseMessage.Headers.Add("anthropic-ratelimit-input-tokens-limit", "30000");
+            responseMessage.Headers.Add("anthropic-ratelimit-input-tokens-remaining", "28500");
+            responseMessage.Headers.Add("anthropic-ratelimit-output-tokens-remaining", "7500");
+            responseMessage.Headers.Add("anthropic-ratelimit-requests-remaining", "48");
+
+            var innerHandler = new FakeHandler(responseMessage);
+            var handler = new AnthropicMetricsHandler(_loggerMock.Object)
+            {
+                InnerHandler = innerHandler
+            };
+            var invoker = new HttpMessageInvoker(handler);
+
+            // Act
+            await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Post, "https://api.anthropic.com/v1/messages"), CancellationToken.None);
+
+            // Assert — verify Debug logs emitted for each header
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("InputTokensLimit")),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("InputTokensRemaining")),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("OutputTokensRemaining")),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("RequestsRemaining")),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task NotLogHeaders_WhenHeadersNotPresent()
+        {
+            // Arrange
+            var innerHandler = new FakeHandler(new HttpResponseMessage(HttpStatusCode.OK));
+            var handler = new AnthropicMetricsHandler(_loggerMock.Object)
+            {
+                InnerHandler = innerHandler
+            };
+            var invoker = new HttpMessageInvoker(handler);
+
+            // Act
+            await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Post, "https://api.anthropic.com/v1/messages"), CancellationToken.None);
+
+            // Assert — no Debug logs for rate limit headers
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task NotLogHeader_WhenHeaderValueIsNotNumeric()
+        {
+            // Arrange
+            var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+            responseMessage.Headers.Add("anthropic-ratelimit-input-tokens-limit", "not-a-number");
+
+            var innerHandler = new FakeHandler(responseMessage);
+            var handler = new AnthropicMetricsHandler(_loggerMock.Object)
+            {
+                InnerHandler = innerHandler
+            };
+            var invoker = new HttpMessageInvoker(handler);
+
+            // Act
+            await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Post, "https://api.anthropic.com/v1/messages"), CancellationToken.None);
+
+            // Assert — non-numeric value should not produce a Debug log
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Never);
+        }
+
+        private sealed class FakeHandler : HttpMessageHandler
+        {
+            private readonly HttpResponseMessage _response;
+
+            public FakeHandler(HttpResponseMessage response) => _response = response;
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(_response);
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Services/ChatAgentProviderShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Services/ChatAgentProviderShould.cs
@@ -66,8 +66,9 @@ namespace Biotrackr.Chat.Api.UnitTests.Services
             var loggerFactory = CreateLoggerFactory();
             var settings = Options.Create(CreateSettings());
             var serviceProvider = new Mock<IServiceProvider>().Object;
+            var httpClientFactory = new Mock<IHttpClientFactory>().Object;
 
-            var act = () => new ChatAgentProvider(null!, cache, loggerFactory, settings, serviceProvider);
+            var act = () => new ChatAgentProvider(null!, cache, loggerFactory, settings, serviceProvider, httpClientFactory);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("mcpToolService");
         }
@@ -79,8 +80,9 @@ namespace Biotrackr.Chat.Api.UnitTests.Services
             var loggerFactory = CreateLoggerFactory();
             var settings = Options.Create(CreateSettings());
             var serviceProvider = new Mock<IServiceProvider>().Object;
+            var httpClientFactory = new Mock<IHttpClientFactory>().Object;
 
-            var act = () => new ChatAgentProvider(toolService, null!, loggerFactory, settings, serviceProvider);
+            var act = () => new ChatAgentProvider(toolService, null!, loggerFactory, settings, serviceProvider, httpClientFactory);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("memoryCache");
         }
@@ -92,8 +94,9 @@ namespace Biotrackr.Chat.Api.UnitTests.Services
             var cache = new MemoryCache(new MemoryCacheOptions());
             var settings = Options.Create(CreateSettings());
             var serviceProvider = new Mock<IServiceProvider>().Object;
+            var httpClientFactory = new Mock<IHttpClientFactory>().Object;
 
-            var act = () => new ChatAgentProvider(toolService, cache, null!, settings, serviceProvider);
+            var act = () => new ChatAgentProvider(toolService, cache, null!, settings, serviceProvider, httpClientFactory);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("loggerFactory");
         }
@@ -105,8 +108,9 @@ namespace Biotrackr.Chat.Api.UnitTests.Services
             var cache = new MemoryCache(new MemoryCacheOptions());
             var loggerFactory = CreateLoggerFactory();
             var serviceProvider = new Mock<IServiceProvider>().Object;
+            var httpClientFactory = new Mock<IHttpClientFactory>().Object;
 
-            var act = () => new ChatAgentProvider(toolService, cache, loggerFactory, null!, serviceProvider);
+            var act = () => new ChatAgentProvider(toolService, cache, loggerFactory, null!, serviceProvider, httpClientFactory);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("settings");
         }
@@ -118,10 +122,25 @@ namespace Biotrackr.Chat.Api.UnitTests.Services
             var cache = new MemoryCache(new MemoryCacheOptions());
             var loggerFactory = CreateLoggerFactory();
             var settings = Options.Create(CreateSettings());
+            var httpClientFactory = new Mock<IHttpClientFactory>().Object;
 
-            var act = () => new ChatAgentProvider(toolService, cache, loggerFactory, settings, null!);
+            var act = () => new ChatAgentProvider(toolService, cache, loggerFactory, settings, null!, httpClientFactory);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("serviceProvider");
+        }
+
+        [Fact]
+        public void ThrowWhenHttpClientFactoryIsNull()
+        {
+            var toolService = new Mock<IMcpToolService>().Object;
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var loggerFactory = CreateLoggerFactory();
+            var settings = Options.Create(CreateSettings());
+            var serviceProvider = new Mock<IServiceProvider>().Object;
+
+            var act = () => new ChatAgentProvider(toolService, cache, loggerFactory, settings, serviceProvider, null!);
+
+            act.Should().Throw<ArgumentNullException>().WithParameterName("httpClientFactory");
         }
 
         private static ChatAgentProvider CreateProvider(IList<AITool> mcpTools)
@@ -146,7 +165,10 @@ namespace Biotrackr.Chat.Api.UnitTests.Services
             serviceProvider.Setup(sp => sp.GetService(typeof(IEnumerable<AIFunction>)))
                 .Returns(Enumerable.Empty<AIFunction>());
 
-            return new ChatAgentProvider(toolService, cache, loggerFactory, settings, serviceProvider.Object);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            httpClientFactory.Setup(f => f.CreateClient("Anthropic")).Returns(new HttpClient());
+
+            return new ChatAgentProvider(toolService, cache, loggerFactory, settings, serviceProvider.Object, httpClientFactory.Object);
         }
 
         private static Settings CreateSettings()

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/GetReportStatusToolShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/GetReportStatusToolShould.cs
@@ -29,7 +29,9 @@ namespace Biotrackr.Chat.Api.UnitTests.Tools
                 ReviewerSystemPrompt = ""
             });
             var reviewerLogger = new Mock<ILogger<ReportReviewerService>>();
-            _reviewerService = new ReportReviewerService(reviewerSettings, reviewerLogger.Object);
+            var reviewerHttpClientFactory = new Mock<IHttpClientFactory>();
+            reviewerHttpClientFactory.Setup(f => f.CreateClient("Anthropic")).Returns(new HttpClient());
+            _reviewerService = new ReportReviewerService(reviewerSettings, reviewerLogger.Object, reviewerHttpClientFactory.Object);
         }
 
         [Fact]

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/ReportReviewerServiceShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/ReportReviewerServiceShould.cs
@@ -69,7 +69,10 @@ namespace Biotrackr.Chat.Api.UnitTests.Tools
                 ReviewerSystemPrompt = reviewerSystemPrompt
             });
 
-            return new ReportReviewerService(settings, _logger.Object);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            httpClientFactory.Setup(f => f.CreateClient("Anthropic")).Returns(new HttpClient());
+
+            return new ReportReviewerService(settings, _logger.Object, httpClientFactory.Object);
         }
     }
 }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Handlers/AnthropicMetricsHandler.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Handlers/AnthropicMetricsHandler.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Biotrackr.Chat.Api.Handlers;
+
+public sealed class AnthropicMetricsHandler : DelegatingHandler
+{
+    private static readonly Meter s_meter = new("Biotrackr.Chat.Anthropic");
+    private static readonly Counter<long> s_requestCount = s_meter.CreateCounter<long>(
+        "anthropic.requests.total", description: "Total Anthropic API requests");
+    private static readonly Counter<long> s_rateLimitHits = s_meter.CreateCounter<long>(
+        "anthropic.ratelimit.hits", description: "Rate limit 429 responses");
+    private static readonly Histogram<double> s_requestDuration = s_meter.CreateHistogram<double>(
+        "anthropic.request.duration", "ms", "Anthropic API request duration");
+
+    private readonly ILogger<AnthropicMetricsHandler> _logger;
+
+    public AnthropicMetricsHandler(ILogger<AnthropicMetricsHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        var response = await base.SendAsync(request, cancellationToken);
+        sw.Stop();
+
+        s_requestCount.Add(1);
+        s_requestDuration.Record(sw.Elapsed.TotalMilliseconds);
+
+        if ((int)response.StatusCode == 429)
+        {
+            s_rateLimitHits.Add(1);
+            _logger.LogWarning("Anthropic rate limit hit (429)");
+        }
+
+        CaptureRateLimitHeaders(response);
+        return response;
+    }
+
+    private void CaptureRateLimitHeaders(HttpResponseMessage response)
+    {
+        TryLogHeader(response, "anthropic-ratelimit-input-tokens-limit", "InputTokensLimit");
+        TryLogHeader(response, "anthropic-ratelimit-input-tokens-remaining", "InputTokensRemaining");
+        TryLogHeader(response, "anthropic-ratelimit-output-tokens-remaining", "OutputTokensRemaining");
+        TryLogHeader(response, "anthropic-ratelimit-requests-remaining", "RequestsRemaining");
+    }
+
+    private void TryLogHeader(HttpResponseMessage response, string header, string metricName)
+    {
+        if (response.Headers.TryGetValues(header, out var values))
+        {
+            var value = values.FirstOrDefault();
+            if (long.TryParse(value, out var parsed))
+            {
+                _logger.LogDebug("Anthropic {MetricName}: {Value}", metricName, parsed);
+            }
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
@@ -3,6 +3,7 @@ using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Biotrackr.Chat.Api.Configuration;
 using Biotrackr.Chat.Api.Extensions;
+using Biotrackr.Chat.Api.Handlers;
 using Biotrackr.Chat.Api.Middleware;
 using Biotrackr.Chat.Api.Services;
 using Biotrackr.Chat.Api.Tools;
@@ -95,6 +96,11 @@ builder.Services.AddHttpClient("ReportingApi", client =>
 });
 
 builder.Services.AddSingleton<ReportReviewerService>();
+
+builder.Services.AddTransient<AnthropicMetricsHandler>();
+builder.Services.AddHttpClient("Anthropic")
+    .AddHttpMessageHandler<AnthropicMetricsHandler>();
+
 builder.Services.AddSingleton<RequestReportTool>();
 builder.Services.AddSingleton<GetReportStatusTool>();
 builder.Services.AddSingleton<AIFunction>(sp => sp.GetRequiredService<RequestReportTool>().AsAIFunction());
@@ -119,6 +125,7 @@ builder.Services.AddOpenTelemetry()
         metrics.SetResourceBuilder(resourceBuilder)
             .AddAspNetCoreInstrumentation()
             .AddHttpClientInstrumentation()
+            .AddMeter("Biotrackr.Chat.Anthropic")
             .AddAzureMonitorMetricExporter(options =>
             {
                 options.ConnectionString = appInsightsConnectionString;

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatAgentProvider.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatAgentProvider.cs
@@ -21,6 +21,7 @@ namespace Biotrackr.Chat.Api.Services
         private readonly ILoggerFactory _loggerFactory;
         private readonly Settings _settings;
         private readonly IServiceProvider _serviceProvider;
+        private readonly IHttpClientFactory _httpClientFactory;
         private readonly SemaphoreSlim _buildLock = new(1, 1);
 
         private volatile AIAgent? _currentAgent;
@@ -31,19 +32,22 @@ namespace Biotrackr.Chat.Api.Services
             IMemoryCache memoryCache,
             ILoggerFactory loggerFactory,
             IOptions<Settings> settings,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            IHttpClientFactory httpClientFactory)
         {
             ArgumentNullException.ThrowIfNull(mcpToolService);
             ArgumentNullException.ThrowIfNull(memoryCache);
             ArgumentNullException.ThrowIfNull(loggerFactory);
             ArgumentNullException.ThrowIfNull(settings);
             ArgumentNullException.ThrowIfNull(serviceProvider);
+            ArgumentNullException.ThrowIfNull(httpClientFactory);
 
             _mcpToolService = mcpToolService;
             _memoryCache = memoryCache;
             _loggerFactory = loggerFactory;
             _settings = settings.Value;
             _serviceProvider = serviceProvider;
+            _httpClientFactory = httpClientFactory;
         }
 
         /// <summary>
@@ -113,7 +117,12 @@ namespace Biotrackr.Chat.Api.Services
                 .Where(f => f.Name is "RequestReport" or "GetReportStatus");
             wrappedTools.AddRange(reportTools);
 
-            AnthropicClient anthropicClient = new() { ApiKey = _settings.AnthropicApiKey };
+            var httpClient = _httpClientFactory.CreateClient("Anthropic");
+            AnthropicClient anthropicClient = new()
+            {
+                ApiKey = _settings.AnthropicApiKey,
+                HttpClient = httpClient
+            };
 
             var instructions = $"Today's date is {DateTimeOffset.UtcNow:yyyy-MM-dd} (UTC).\n\n{_settings.ChatSystemPrompt}";
 

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatAgentProvider.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatAgentProvider.cs
@@ -115,10 +115,12 @@ namespace Biotrackr.Chat.Api.Services
 
             AnthropicClient anthropicClient = new() { ApiKey = _settings.AnthropicApiKey };
 
+            var instructions = $"Today's date is {DateTimeOffset.UtcNow:yyyy-MM-dd} (UTC).\n\n{_settings.ChatSystemPrompt}";
+
             ChatClientAgent chatAgent = anthropicClient.AsAIAgent(
                 model: _settings.ChatAgentModel,
                 name: "BiotrackrChatAgent",
-                instructions: _settings.ChatSystemPrompt,
+                instructions: instructions,
                 tools: [.. wrappedTools]);
 
             // Enable concurrent tool execution — Claude batches parallel tool calls,

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatAgentProvider.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatAgentProvider.cs
@@ -115,11 +115,19 @@ namespace Biotrackr.Chat.Api.Services
 
             AnthropicClient anthropicClient = new() { ApiKey = _settings.AnthropicApiKey };
 
-            AIAgent chatAgent = anthropicClient.AsAIAgent(
+            ChatClientAgent chatAgent = anthropicClient.AsAIAgent(
                 model: _settings.ChatAgentModel,
                 name: "BiotrackrChatAgent",
                 instructions: _settings.ChatSystemPrompt,
                 tools: [.. wrappedTools]);
+
+            // Enable concurrent tool execution — Claude batches parallel tool calls,
+            // but the framework executes them sequentially by default
+            var functionInvoker = chatAgent.ChatClient.GetService<FunctionInvokingChatClient>();
+            if (functionInvoker is not null)
+            {
+                functionInvoker.AllowConcurrentInvocation = true;
+            }
 
             // Middleware pipeline
             var chatHistoryRepository = _serviceProvider.GetRequiredService<IChatHistoryRepository>();

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/ReportReviewerService.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/ReportReviewerService.cs
@@ -15,13 +15,16 @@ namespace Biotrackr.Chat.Api.Tools
     {
         private readonly Settings _settings;
         private readonly ILogger<ReportReviewerService> _logger;
+        private readonly IHttpClientFactory _httpClientFactory;
 
         public ReportReviewerService(
             IOptions<Settings> settings,
-            ILogger<ReportReviewerService> logger)
+            ILogger<ReportReviewerService> logger,
+            IHttpClientFactory httpClientFactory)
         {
             _settings = settings.Value;
             _logger = logger;
+            _httpClientFactory = httpClientFactory;
         }
 
         public async Task<ReviewResult> ReviewReportAsync(
@@ -40,7 +43,12 @@ namespace Biotrackr.Chat.Api.Tools
 
             try
             {
-                AnthropicClient anthropicClient = new() { ApiKey = _settings.AnthropicApiKey };
+                var httpClient = _httpClientFactory.CreateClient("Anthropic");
+                AnthropicClient anthropicClient = new()
+                {
+                    ApiKey = _settings.AnthropicApiKey,
+                    HttpClient = httpClient
+                };
                 AIAgent reviewer = anthropicClient.AsAIAgent(
                     model: _settings.ChatAgentModel,
                     name: "BiotrackrReportReviewer",

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/ReportReviewerService.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/ReportReviewerService.cs
@@ -46,7 +46,7 @@ namespace Biotrackr.Chat.Api.Tools
                     name: "BiotrackrReportReviewer",
                     instructions: _settings.ReviewerSystemPrompt);
 
-                var sourceDataJson = JsonSerializer.Serialize(sourceDataSnapshot, new JsonSerializerOptions { WriteIndented = true });
+                var sourceDataJson = JsonSerializer.Serialize(sourceDataSnapshot, new JsonSerializerOptions { WriteIndented = false });
 
                 var reviewPrompt = $"Review the following report for accuracy and safety.\n\n" +
                     $"Report Type: {reportType}\n" +


### PR DESCRIPTION
## Description

Optimize Chat.Api Claude API token consumption and resolve Tier 1 rate limit bottlenecks — Phase 1 (Quick Wins) and Phase 2 (Telemetry & HttpClient Lifecycle) of a multi-phase optimization plan.

## Changes

### Phase 1: Quick Wins

- **Compact JSON serialization** — Set `WriteIndented = false` in `ReportReviewerService` to reduce reviewer agent token input by ~31%
- **Concurrent tool execution** — Enable `AllowConcurrentInvocation` on `FunctionInvokingChatClient` so Claude's batched parallel tool calls execute concurrently instead of sequentially (saves ~$0.19/weekly report)
- **Parallel tool-calling guidance** — Updated `ChatSystemPrompt` Key Vault secret with rule instructing Claude to fetch multi-domain health data in a single tool-calling turn
- **UTC date injection** — Prepend current UTC date to system prompt at agent build time so Claude resolves date-relative queries correctly (fixes "past week" returning July 2025 instead of current dates)

### Phase 2: Telemetry and HttpClient Lifecycle

- **`AnthropicMetricsHandler`** — New `DelegatingHandler` capturing Anthropic rate limit headers (`anthropic-ratelimit-*`), request count, 429 hit counter, and request duration as OpenTelemetry metrics under the `Biotrackr.Chat.Anthropic` meter
- **`IHttpClientFactory` integration** — Registered named "Anthropic" `HttpClient` via `IHttpClientFactory` with the metrics handler, fixing a pre-existing `HttpClient` leak where `ChatAgentProvider` and `ReportReviewerService` created unmanaged `AnthropicClient` instances
- **DI injection** — Both `ChatAgentProvider` and `ReportReviewerService` now accept `IHttpClientFactory` and use factory-managed `HttpClient` instances for `AnthropicClient`
- **OTel meter registration** — Added `Biotrackr.Chat.Anthropic` to the metrics provider so custom Anthropic metrics export to Application Insights

### Files Changed

| File | Change |
|------|--------|
| `src/.../Handlers/AnthropicMetricsHandler.cs` | **NEW** — DelegatingHandler for Anthropic telemetry |
| `src/.../Services/ChatAgentProvider.cs` | Enable concurrent invocation, inject IHttpClientFactory, inject UTC date into prompt |
| `src/.../Tools/ReportReviewerService.cs` | `WriteIndented = false`, inject IHttpClientFactory |
| `src/.../Program.cs` | Register handler, named HttpClient, OTel meter |
| `.gitignore` | Updated ignore patterns |
| `src/.../UnitTests/Handlers/AnthropicMetricsHandlerShould.cs` | **NEW** — 5 tests for handler (success, 429, headers, missing headers, non-numeric) |
| `src/.../UnitTests/Services/ChatAgentProviderShould.cs` | Updated constructor for IHttpClientFactory |
| `src/.../UnitTests/Tools/ReportReviewerServiceShould.cs` | Updated constructor for IHttpClientFactory |
| `src/.../UnitTests/Tools/GetReportStatusToolShould.cs` | Updated for ReportReviewerService constructor change |

## Validation

- `dotnet build` — Succeeded (0 errors)
- `dotnet test` — 133/133 tests passed (131 unit + 2 integration)
- Key Vault `ChatSystemPrompt` secret updated with parallel tool-calling guidance + UTC date injection at runtime

## Remaining Phases (follow-up PRs)

- **Phase 3**: Server-Side Data Assembly (highest impact — eliminates `sourceDataSnapshot` duplication, ~80% cost reduction)
- **Phase 4**: Sleep Data Stripping (80% sleep token reduction)
- **Phase 5**: Prompt Caching for Reviewer Agent (direct SDK `CacheControlEphemeral`)

## Related

- Plan: `.copilot-tracking/plans/2026-03-31/claude-api-token-optimization-plan.instructions.md`
- Research: `.copilot-tracking/research/2026-03-31/claude-api-vs-foundry-model-research.md`