### PR TITLE
refactor(mcp-server): strip verbose fields from all domain models

### DIFF
--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Activity/ActivityItem.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Activity/ActivityItem.cs
@@ -7,6 +7,7 @@ namespace Biotrackr.Mcp.Server.Models.Activity
 {
     public class ActivityItem
     {
+        [JsonIgnore]
         [JsonPropertyName("id")]
         public string Id { get; set; } = string.Empty;
 
@@ -16,6 +17,7 @@ namespace Biotrackr.Mcp.Server.Models.Activity
         [JsonPropertyName("date")]
         public string Date { get; set; } = string.Empty;
 
+        [JsonIgnore]
         [JsonPropertyName("documentType")]
         public string DocumentType { get; set; } = string.Empty;
     }

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Activity/ActivityLog.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Activity/ActivityLog.cs
@@ -7,9 +7,11 @@ namespace Biotrackr.Mcp.Server.Models.Activity
 {
     public class ActivityLog
     {
+        [JsonIgnore]
         [JsonPropertyName("activityId")]
         public int ActivityId { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("activityParentId")]
         public int ActivityParentId { get; set; }
 
@@ -25,18 +27,23 @@ namespace Biotrackr.Mcp.Server.Models.Activity
         [JsonPropertyName("duration")]
         public long Duration { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("hasActiveZoneMinutes")]
         public bool HasActiveZoneMinutes { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("hasStartTime")]
         public bool HasStartTime { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("isFavorite")]
         public bool IsFavorite { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("lastModified")]
         public DateTime LastModified { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("logId")]
         public long LogId { get; set; }
 

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Activity/ActivitySummary.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Activity/ActivitySummary.cs
@@ -7,12 +7,14 @@ namespace Biotrackr.Mcp.Server.Models.Activity
 {
     public class ActivitySummary
     {
+        [JsonIgnore]
         [JsonPropertyName("activeScore")]
         public int ActiveScore { get; set; }
 
         [JsonPropertyName("activityCalories")]
         public int ActivityCalories { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("calorieEstimationMu")]
         public int CalorieEstimationMu { get; set; }
 
@@ -22,6 +24,7 @@ namespace Biotrackr.Mcp.Server.Models.Activity
         [JsonPropertyName("caloriesOut")]
         public int CaloriesOut { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("caloriesOutUnestimated")]
         public int CaloriesOutUnestimated { get; set; }
 
@@ -43,6 +46,7 @@ namespace Biotrackr.Mcp.Server.Models.Activity
         [JsonPropertyName("lightlyActiveMinutes")]
         public int LightlyActiveMinutes { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("marginalCalories")]
         public int MarginalCalories { get; set; }
 
@@ -55,6 +59,7 @@ namespace Biotrackr.Mcp.Server.Models.Activity
         [JsonPropertyName("steps")]
         public int Steps { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("useEstimation")]
         public bool UseEstimation { get; set; }
 

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Food/FoodEntry.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Food/FoodEntry.cs
@@ -4,12 +4,14 @@ namespace Biotrackr.Mcp.Server.Models.Food
 {
     public class FoodEntry
     {
+        [JsonIgnore]
         [JsonPropertyName("isFavorite")]
         public bool IsFavorite { get; set; }
 
         [JsonPropertyName("logDate")]
         public string LogDate { get; set; } = string.Empty;
 
+        [JsonIgnore]
         [JsonPropertyName("logId")]
         public long LogId { get; set; }
 

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Food/FoodItem.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Food/FoodItem.cs
@@ -4,6 +4,7 @@ namespace Biotrackr.Mcp.Server.Models.Food
 {
     public class FoodItem
     {
+        [JsonIgnore]
         [JsonPropertyName("id")]
         public string Id { get; set; } = string.Empty;
 
@@ -13,6 +14,7 @@ namespace Biotrackr.Mcp.Server.Models.Food
         [JsonPropertyName("date")]
         public string Date { get; set; } = string.Empty;
 
+        [JsonIgnore]
         [JsonPropertyName("documentType")]
         public string DocumentType { get; set; } = string.Empty;
     }

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Food/FoodUnit.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Food/FoodUnit.cs
@@ -4,12 +4,14 @@ namespace Biotrackr.Mcp.Server.Models.Food
 {
     public class FoodUnit
     {
+        [JsonIgnore]
         [JsonPropertyName("id")]
         public int Id { get; set; }
 
         [JsonPropertyName("name")]
         public string Name { get; set; } = string.Empty;
 
+        [JsonIgnore]
         [JsonPropertyName("plural")]
         public string Plural { get; set; } = string.Empty;
     }

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Food/LoggedFood.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Food/LoggedFood.cs
@@ -4,6 +4,7 @@ namespace Biotrackr.Mcp.Server.Models.Food
 {
     public class LoggedFood
     {
+        [JsonIgnore]
         [JsonPropertyName("accessLevel")]
         public string AccessLevel { get; set; } = string.Empty;
 
@@ -16,12 +17,15 @@ namespace Biotrackr.Mcp.Server.Models.Food
         [JsonPropertyName("calories")]
         public int Calories { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("foodId")]
         public int FoodId { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("locale")]
         public string Locale { get; set; } = string.Empty;
 
+        [JsonIgnore]
         [JsonPropertyName("mealTypeId")]
         public int MealTypeId { get; set; }
 
@@ -31,6 +35,7 @@ namespace Biotrackr.Mcp.Server.Models.Food
         [JsonPropertyName("unit")]
         public FoodUnit Unit { get; set; } = new();
 
+        [JsonIgnore]
         [JsonPropertyName("units")]
         public List<int> Units { get; set; } = [];
     }

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Sleep/SleepItem.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Sleep/SleepItem.cs
@@ -4,6 +4,7 @@ namespace Biotrackr.Mcp.Server.Models.Sleep
 {
     public class SleepItem
     {
+        [JsonIgnore]
         [JsonPropertyName("id")]
         public string Id { get; set; } = string.Empty;
 
@@ -13,6 +14,7 @@ namespace Biotrackr.Mcp.Server.Models.Sleep
         [JsonPropertyName("date")]
         public string Date { get; set; } = string.Empty;
 
+        [JsonIgnore]
         [JsonPropertyName("documentType")]
         public string DocumentType { get; set; } = string.Empty;
     }

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Sleep/SleepLevels.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Sleep/SleepLevels.cs
@@ -4,9 +4,11 @@ namespace Biotrackr.Mcp.Server.Models.Sleep
 {
     public class SleepLevels
     {
+        [JsonIgnore]
         [JsonPropertyName("data")]
         public List<SleepLevelData> Data { get; set; } = [];
 
+        [JsonIgnore]
         [JsonPropertyName("shortData")]
         public List<SleepLevelData> ShortData { get; set; } = [];
 

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Sleep/SleepRecord.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Sleep/SleepRecord.cs
@@ -16,6 +16,7 @@ namespace Biotrackr.Mcp.Server.Models.Sleep
         [JsonPropertyName("endTime")]
         public DateTime EndTime { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("infoCode")]
         public int InfoCode { get; set; }
 
@@ -25,6 +26,7 @@ namespace Biotrackr.Mcp.Server.Models.Sleep
         [JsonPropertyName("levels")]
         public SleepLevels Levels { get; set; } = new();
 
+        [JsonIgnore]
         [JsonPropertyName("logId")]
         public long LogId { get; set; }
 
@@ -40,6 +42,7 @@ namespace Biotrackr.Mcp.Server.Models.Sleep
         [JsonPropertyName("minutesToFallAsleep")]
         public int MinutesToFallAsleep { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("logType")]
         public string LogType { get; set; } = string.Empty;
 
@@ -49,6 +52,7 @@ namespace Biotrackr.Mcp.Server.Models.Sleep
         [JsonPropertyName("timeInBed")]
         public int TimeInBed { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("type")]
         public string Type { get; set; } = string.Empty;
     }

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Weight/WeightData.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Weight/WeightData.cs
@@ -13,9 +13,11 @@ namespace Biotrackr.Mcp.Server.Models.Weight
         [JsonPropertyName("fat")]
         public double Fat { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("logId")]
         public object? LogId { get; set; }
 
+        [JsonIgnore]
         [JsonPropertyName("source")]
         public string Source { get; set; } = string.Empty;
 

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Weight/WeightItem.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Weight/WeightItem.cs
@@ -4,6 +4,7 @@ namespace Biotrackr.Mcp.Server.Models.Weight
 {
     public class WeightItem
     {
+        [JsonIgnore]
         [JsonPropertyName("id")]
         public string Id { get; set; } = string.Empty;
 
@@ -13,6 +14,7 @@ namespace Biotrackr.Mcp.Server.Models.Weight
         [JsonPropertyName("date")]
         public string Date { get; set; } = string.Empty;
 
+        [JsonIgnore]
         [JsonPropertyName("documentType")]
         public string DocumentType { get; set; } = string.Empty;
     }


### PR DESCRIPTION
## Description

Strip verbose and redundant fields from all MCP Server domain models to reduce token consumption when health data is sent to Claude via MCP tools.

## Changes

Add `[JsonIgnore]` attributes to 35 model properties across 12 files in all 4 health data domains. Fields are stripped during `JsonSerializer.Serialize()` in `BaseTool.GetAsync<T>()` with zero tool code changes.

### Sleep Domain (8 properties, 3 files)
- `SleepLevels.Data` / `ShortData` — per-minute stage transition arrays (~80% sleep token reduction), redundant with `levels.summary.stages`
- `SleepRecord.LogId` / `InfoCode` / `LogType` / `Type` — Fitbit internal metadata
- `SleepItem.Id` / `DocumentType` — Cosmos DB wrapper fields

### Activity Domain (14 properties, 3 files)
- `ActivityLog.ActivityId` / `ActivityParentId` / `LogId` / `LastModified` / `HasActiveZoneMinutes` / `HasStartTime` / `IsFavorite` — Fitbit internal IDs, timestamps, boolean flags
- `ActivitySummary.ActiveScore` / `CalorieEstimationMu` / `CaloriesOutUnestimated` / `UseEstimation` / `MarginalCalories` — internal estimation metadata
- `ActivityItem.Id` / `DocumentType` — Cosmos DB wrapper fields

### Food Domain (11 properties, 4 files)
- `FoodEntry.IsFavorite` / `LogId` — Fitbit UI preference and internal ID
- `LoggedFood.AccessLevel` / `FoodId` / `Locale` / `MealTypeId` / `Units` — Fitbit internal fields
- `FoodUnit.Id` / `Plural` — internal ID and UI localization
- `FoodItem.Id` / `DocumentType` — Cosmos DB wrapper fields

### Weight Domain (4 properties, 2 files)
- `WeightData.LogId` / `Source` — Fitbit internal metadata
- `WeightItem.Id` / `DocumentType` — Cosmos DB wrapper fields

## Validation

- `dotnet build` — Succeeded (0 errors)
- `dotnet test` — 128/128 tests passed

## Impact

Estimated ~51% reduction in daily MCP tool response tokens across all domains. Sleep domain alone saves ~40% via `levels.data`/`shortData` stripping.