### PR TITLE
feat(chat-api): add prompt caching for reviewer agent

### DIFF
--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/ReportReviewerService.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/ReportReviewerService.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using Anthropic;
+using Anthropic.Models.Messages;
 using Biotrackr.Chat.Api.Configuration;
-using Microsoft.Agents.AI;
 using Microsoft.Extensions.Options;
 
 namespace Biotrackr.Chat.Api.Tools
@@ -49,10 +49,6 @@ namespace Biotrackr.Chat.Api.Tools
                     ApiKey = _settings.AnthropicApiKey,
                     HttpClient = httpClient
                 };
-                AIAgent reviewer = anthropicClient.AsAIAgent(
-                    model: _settings.ChatAgentModel,
-                    name: "BiotrackrReportReviewer",
-                    instructions: _settings.ReviewerSystemPrompt);
 
                 var sourceDataJson = JsonSerializer.Serialize(sourceDataSnapshot, new JsonSerializerOptions { WriteIndented = false });
 
@@ -67,10 +63,27 @@ namespace Biotrackr.Chat.Api.Tools
                     "  \"validatedSummary\": \"the summary with corrections and disclaimers applied\"\n" +
                     "}";
 
-                var response = await reviewer.RunAsync(reviewPrompt);
-                var responseText = response?.ToString() ?? string.Empty;
+                var result = await anthropicClient.Messages.Create(new MessageCreateParams
+                {
+                    MaxTokens = 4096,
+                    Model = _settings.ChatAgentModel,
+                    System = new List<TextBlockParam>
+                    {
+                        new TextBlockParam
+                        {
+                            Text = _settings.ReviewerSystemPrompt,
+                            CacheControl = new CacheControlEphemeral()
+                        }
+                    },
+                    Messages = [new MessageParam { Role = "user", Content = reviewPrompt }]
+                });
 
-                _logger.LogInformation("Reviewer response for {ReportType}: {Length} chars", reportType, responseText.Length);
+                var responseText = string.Join("", result.Content
+                    .OfType<TextBlock>()
+                    .Select(b => b.Text));
+
+                _logger.LogInformation("Reviewer response for {ReportType}: {Length} chars, cache_read_input_tokens: {CacheRead}",
+                    reportType, responseText.Length, result.Usage?.CacheReadInputTokens ?? 0);
 
                 // Parse the reviewer's JSON response
                 return ParseReviewResult(responseText, reportSummary);


### PR DESCRIPTION
## Description

Enable Anthropic prompt caching for the report reviewer agent to reduce token costs on repeated system prompt usage.

## Changes

Replace `AsAIAgent()` with direct `AnthropicClient.Messages.Create()` in `ReportReviewerService` to apply `CacheControlEphemeral` on the reviewer system prompt `TextBlockParam`.

### Why direct SDK?

The Agent Framework's `AsAIAgent()` does not support passing `cache_control` through to Anthropic content blocks (confirmed in research — PR [anthropics/anthropic-sdk-csharp#73](https://github.com/anthropics/anthropic-sdk-csharp/pull/73) adds this but hasn't merged). Direct SDK is the only viable path.

### What changed

- `ReportReviewerService.ReviewReportAsync()` now calls `anthropicClient.Messages.Create()` directly instead of `reviewer.RunAsync()`
- System prompt wrapped in `TextBlockParam` with `CacheControl = new CacheControlEphemeral()`
- Response parsed from `result.Content.OfType<TextBlock>()` instead of `response.ToString()`
- Added `cache_read_input_tokens` to the structured log for observability
- Removed `Microsoft.Agents.AI` using (no longer needed), added `Anthropic.Models.Messages`

### File changed

- `src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/ReportReviewerService.cs`

## Validation

- `dotnet build` — Succeeded (0 errors)
- `dotnet test` — 133/133 tests passed (131 unit + 2 integration)

## Impact

- Reviewer system prompt cached at $0.30/MTok vs $3.00/MTok on cache hits (90% cost reduction on cached tokens)
- `cache_read_input_tokens` logged for monitoring cache hit rate in Application Insights