### PR TITLE
feat: add OpenTelemetry gen_ai semantic convention spans for Anthropic

### DIFF
--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Services/ChatAgentProviderShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Services/ChatAgentProviderShould.cs
@@ -143,6 +143,27 @@ namespace Biotrackr.Chat.Api.UnitTests.Services
             act.Should().Throw<ArgumentNullException>().WithParameterName("httpClientFactory");
         }
 
+        [Fact]
+        public async Task RunStreamingWithLatestAgent_ShouldPropagateStreamingErrors()
+        {
+            // Arrange — use a handler that fails deterministically so the
+            // Anthropic SDK throws during the first MoveNextAsync iteration
+            var throwingHandler = new ThrowingHandler(new HttpRequestException("Connection refused"));
+            var provider = CreateProviderWithHandler(throwingHandler);
+            var messages = new List<ChatMessage> { new(ChatRole.User, "test") };
+
+            // Act & Assert
+            var act = async () =>
+            {
+                await foreach (var _ in provider.RunStreamingWithLatestAgentAsync(
+                    messages, null, null, CancellationToken.None))
+                {
+                }
+            };
+
+            await act.Should().ThrowAsync<Exception>();
+        }
+
         private static ChatAgentProvider CreateProvider(IList<AITool> mcpTools)
         {
             var toolService = new Mock<IMcpToolService>();
@@ -171,6 +192,29 @@ namespace Biotrackr.Chat.Api.UnitTests.Services
             return new ChatAgentProvider(toolService, cache, loggerFactory, settings, serviceProvider.Object, httpClientFactory.Object);
         }
 
+        private static ChatAgentProvider CreateProviderWithHandler(HttpMessageHandler handler)
+        {
+            var toolService = new Mock<IMcpToolService>();
+            toolService.Setup(s => s.GetToolsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<AITool>());
+
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var loggerFactory = CreateLoggerFactory();
+            var settings = Options.Create(CreateSettings());
+
+            var chatHistoryRepo = new Mock<IChatHistoryRepository>();
+            var serviceProvider = new Mock<IServiceProvider>();
+            serviceProvider.Setup(sp => sp.GetService(typeof(IChatHistoryRepository)))
+                .Returns(chatHistoryRepo.Object);
+            serviceProvider.Setup(sp => sp.GetService(typeof(IEnumerable<AIFunction>)))
+                .Returns(Enumerable.Empty<AIFunction>());
+
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            httpClientFactory.Setup(f => f.CreateClient("Anthropic")).Returns(new HttpClient(handler));
+
+            return new ChatAgentProvider(toolService.Object, cache, loggerFactory, settings, serviceProvider.Object, httpClientFactory.Object);
+        }
+
         private static Settings CreateSettings()
         {
             return new Settings
@@ -187,6 +231,17 @@ namespace Biotrackr.Chat.Api.UnitTests.Services
             var factory = new Mock<ILoggerFactory>();
             factory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
             return factory.Object;
+        }
+
+        private sealed class ThrowingHandler : HttpMessageHandler
+        {
+            private readonly Exception _exception;
+
+            public ThrowingHandler(Exception exception) => _exception = exception;
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+                => throw _exception;
         }
     }
 }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Telemetry/AnthropicTelemetryShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Telemetry/AnthropicTelemetryShould.cs
@@ -1,0 +1,215 @@
+using System.Diagnostics;
+using Biotrackr.Chat.Api.Telemetry;
+using FluentAssertions;
+
+namespace Biotrackr.Chat.Api.UnitTests.Telemetry
+{
+    public class AnthropicTelemetryShould : IDisposable
+    {
+        private readonly ActivityListener _listener;
+
+        public AnthropicTelemetryShould()
+        {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "gen_ai.anthropic",
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+        }
+
+        [Fact]
+        public void StartChatActivity_ShouldCreateActivityWithGenAiAttributes()
+        {
+            // Arrange
+            var model = "claude-sonnet-4-20250514";
+
+            // Act
+            using var activity = AnthropicTelemetry.StartChatActivity(model);
+
+            // Assert
+            activity.Should().NotBeNull();
+            activity!.DisplayName.Should().Be($"chat {model}");
+            activity.Kind.Should().Be(ActivityKind.Client);
+            activity.GetTagItem("gen_ai.operation.name").Should().Be("chat");
+            activity.GetTagItem("gen_ai.provider.name").Should().Be("anthropic");
+            activity.GetTagItem("gen_ai.request.model").Should().Be(model);
+            activity.GetTagItem("server.address").Should().Be("api.anthropic.com");
+            activity.GetTagItem("server.port").Should().Be(443);
+        }
+
+        [Fact]
+        public void StartChatActivity_ShouldIncludeAgentId_WhenProvided()
+        {
+            // Arrange
+            var model = "claude-sonnet-4-20250514";
+            var agentId = "BiotrackrChatAgent";
+
+            // Act
+            using var activity = AnthropicTelemetry.StartChatActivity(model, agentId);
+
+            // Assert
+            activity.Should().NotBeNull();
+            activity!.GetTagItem("gen_ai.agents.id").Should().Be(agentId);
+        }
+
+        [Fact]
+        public void StartChatActivity_ShouldNotIncludeAgentId_WhenNull()
+        {
+            // Arrange
+            var model = "claude-sonnet-4-20250514";
+
+            // Act
+            using var activity = AnthropicTelemetry.StartChatActivity(model, agentId: null);
+
+            // Assert
+            activity.Should().NotBeNull();
+            activity!.GetTagItem("gen_ai.agents.id").Should().BeNull();
+        }
+
+        [Fact]
+        public void RecordResponse_ShouldSetResponseAttributes()
+        {
+            // Arrange
+            var model = "claude-sonnet-4-20250514";
+            using var activity = AnthropicTelemetry.StartChatActivity(model);
+
+            // Act
+            AnthropicTelemetry.RecordResponse(
+                activity,
+                responseModel: "claude-sonnet-4-20250514",
+                responseId: "msg_01XFDUDYJgAACzvnptvVoYEL",
+                finishReason: "end_turn",
+                inputTokens: 100,
+                outputTokens: 50);
+
+            // Assert
+            activity.Should().NotBeNull();
+            activity!.GetTagItem("gen_ai.response.model").Should().Be("claude-sonnet-4-20250514");
+            activity.GetTagItem("gen_ai.response.id").Should().Be("msg_01XFDUDYJgAACzvnptvVoYEL");
+            activity.GetTagItem("gen_ai.usage.input_tokens").Should().Be(100);
+            activity.GetTagItem("gen_ai.usage.output_tokens").Should().Be(50);
+            activity.GetTagItem("gen_ai.response.finish_reasons").Should().BeEquivalentTo(new[] { "end_turn" });
+        }
+
+        [Fact]
+        public void RecordResponse_ShouldAggregateInputTokens_WithCachedTokens()
+        {
+            // Arrange
+            var model = "claude-sonnet-4-20250514";
+            using var activity = AnthropicTelemetry.StartChatActivity(model);
+
+            // Act
+            AnthropicTelemetry.RecordResponse(
+                activity,
+                responseModel: model,
+                responseId: "msg_123",
+                finishReason: "end_turn",
+                inputTokens: 100,
+                outputTokens: 50,
+                cacheReadInputTokens: 200,
+                cacheCreationInputTokens: 300);
+
+            // Assert — total input = 100 + 200 + 300 = 600
+            activity.Should().NotBeNull();
+            activity!.GetTagItem("gen_ai.usage.input_tokens").Should().Be(600);
+        }
+
+        [Fact]
+        public void RecordResponse_ShouldSetCacheTokenAttributes_WhenNonZero()
+        {
+            // Arrange
+            var model = "claude-sonnet-4-20250514";
+            using var activity = AnthropicTelemetry.StartChatActivity(model);
+
+            // Act
+            AnthropicTelemetry.RecordResponse(
+                activity,
+                responseModel: model,
+                responseId: "msg_123",
+                finishReason: "end_turn",
+                inputTokens: 100,
+                outputTokens: 50,
+                cacheReadInputTokens: 200,
+                cacheCreationInputTokens: 300);
+
+            // Assert
+            activity.Should().NotBeNull();
+            activity!.GetTagItem("gen_ai.usage.cache_read.input_tokens").Should().Be(200);
+            activity.GetTagItem("gen_ai.usage.cache_creation.input_tokens").Should().Be(300);
+        }
+
+        [Fact]
+        public void RecordResponse_ShouldNotSetCacheAttributes_WhenZero()
+        {
+            // Arrange
+            var model = "claude-sonnet-4-20250514";
+            using var activity = AnthropicTelemetry.StartChatActivity(model);
+
+            // Act
+            AnthropicTelemetry.RecordResponse(
+                activity,
+                responseModel: model,
+                responseId: "msg_123",
+                finishReason: "end_turn",
+                inputTokens: 100,
+                outputTokens: 50,
+                cacheReadInputTokens: 0,
+                cacheCreationInputTokens: 0);
+
+            // Assert
+            activity.Should().NotBeNull();
+            activity!.GetTagItem("gen_ai.usage.cache_read.input_tokens").Should().BeNull();
+            activity.GetTagItem("gen_ai.usage.cache_creation.input_tokens").Should().BeNull();
+        }
+
+        [Fact]
+        public void RecordError_ShouldSetErrorStatus()
+        {
+            // Arrange
+            var model = "claude-sonnet-4-20250514";
+            using var activity = AnthropicTelemetry.StartChatActivity(model);
+            var exception = new HttpRequestException("API unavailable");
+
+            // Act
+            AnthropicTelemetry.RecordError(activity, exception);
+
+            // Assert
+            activity.Should().NotBeNull();
+            activity!.Status.Should().Be(ActivityStatusCode.Error);
+            activity.StatusDescription.Should().Be("API unavailable");
+            activity.GetTagItem("error.type").Should().Be("HttpRequestException");
+        }
+
+        [Fact]
+        public void RecordResponse_ShouldHandleNullActivity()
+        {
+            // Act — should not throw
+            var act = () => AnthropicTelemetry.RecordResponse(
+                null,
+                responseModel: "claude-sonnet-4-20250514",
+                responseId: "msg_123",
+                finishReason: "end_turn",
+                inputTokens: 100,
+                outputTokens: 50);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordError_ShouldHandleNullActivity()
+        {
+            // Act — should not throw
+            var act = () => AnthropicTelemetry.RecordError(null, new Exception("test"));
+
+            // Assert
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
@@ -113,6 +113,7 @@ builder.Services.AddOpenTelemetry()
     .WithTracing(tracing =>
     {
         tracing.SetResourceBuilder(resourceBuilder)
+            .AddSource("gen_ai.anthropic")
             .AddAspNetCoreInstrumentation()
             .AddHttpClientInstrumentation()
             .AddAzureMonitorTraceExporter(options =>

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatAgentProvider.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Services/ChatAgentProvider.cs
@@ -1,6 +1,7 @@
 using Anthropic;
 using Biotrackr.Chat.Api.Configuration;
 using Biotrackr.Chat.Api.Middleware;
+using Biotrackr.Chat.Api.Telemetry;
 using Biotrackr.Chat.Api.Tools;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
@@ -98,10 +99,37 @@ namespace Biotrackr.Chat.Api.Services
             AgentRunOptions? options,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
         {
+            using var activity = AnthropicTelemetry.StartChatActivity(
+                model: _settings.ChatAgentModel,
+                agentId: "BiotrackrChatAgent");
+
             var currentAgent = await GetAgentAsync(cancellationToken);
-            await foreach (var update in currentAgent.RunStreamingAsync(messages, session, options, cancellationToken))
+            var enumerator = currentAgent.RunStreamingAsync(messages, session, options, cancellationToken)
+                .GetAsyncEnumerator(cancellationToken);
+
+            try
             {
-                yield return update;
+                while (true)
+                {
+                    AgentResponseUpdate current;
+                    try
+                    {
+                        if (!await enumerator.MoveNextAsync())
+                            break;
+                        current = enumerator.Current;
+                    }
+                    catch (Exception ex)
+                    {
+                        AnthropicTelemetry.RecordError(activity, ex);
+                        throw;
+                    }
+
+                    yield return current;
+                }
+            }
+            finally
+            {
+                await enumerator.DisposeAsync();
             }
         }
 

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Telemetry/AnthropicTelemetry.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Telemetry/AnthropicTelemetry.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics;
+
+namespace Biotrackr.Chat.Api.Telemetry;
+
+/// <summary>
+/// Static instrumentation class for Anthropic API calls following OpenTelemetry gen_ai semantic conventions.
+/// Creates <see cref="Activity"/> spans with standardised gen_ai.* attributes so traces are
+/// correlated across Azure Monitor / Application Insights and AI Foundry.
+/// </summary>
+public static class AnthropicTelemetry
+{
+    /// <summary>
+    /// ActivitySource registered with the OpenTelemetry pipeline in Program.cs.
+    /// Name follows the gen_ai provider convention: gen_ai.{provider}.
+    /// </summary>
+    public static readonly ActivitySource Source = new("gen_ai.anthropic");
+
+    /// <summary>
+    /// Starts an Activity for a Claude chat operation following OpenTelemetry GenAI semantic conventions.
+    /// Caller disposes the returned Activity after the API call completes and sets response attributes.
+    /// </summary>
+    public static Activity? StartChatActivity(string model, string? agentId = null)
+    {
+        var activity = Source.StartActivity($"chat {model}", ActivityKind.Client);
+        if (activity is null) return null;
+
+        activity.SetTag("gen_ai.operation.name", "chat");
+        activity.SetTag("gen_ai.provider.name", "anthropic");
+        activity.SetTag("gen_ai.request.model", model);
+        activity.SetTag("server.address", "api.anthropic.com");
+        activity.SetTag("server.port", 443);
+
+        if (agentId is not null)
+        {
+            activity.SetTag("gen_ai.agents.id", agentId);
+        }
+
+        return activity;
+    }
+
+    /// <summary>
+    /// Records response attributes on the Activity after a Claude API call completes.
+    /// Token computation follows Anthropic convention: input_tokens excludes cached tokens.
+    /// Total input = input_tokens + cache_read_input_tokens + cache_creation_input_tokens.
+    /// </summary>
+    public static void RecordResponse(
+        Activity? activity,
+        string? responseModel,
+        string? responseId,
+        string? finishReason,
+        long inputTokens,
+        long outputTokens,
+        long cacheReadInputTokens = 0,
+        long cacheCreationInputTokens = 0)
+    {
+        if (activity is null) return;
+
+        activity.SetTag("gen_ai.response.model", responseModel);
+        activity.SetTag("gen_ai.response.id", responseId);
+        activity.SetTag("gen_ai.usage.input_tokens", inputTokens + cacheReadInputTokens + cacheCreationInputTokens);
+        activity.SetTag("gen_ai.usage.output_tokens", outputTokens);
+
+        if (cacheReadInputTokens > 0)
+            activity.SetTag("gen_ai.usage.cache_read.input_tokens", cacheReadInputTokens);
+        if (cacheCreationInputTokens > 0)
+            activity.SetTag("gen_ai.usage.cache_creation.input_tokens", cacheCreationInputTokens);
+
+        if (finishReason is not null)
+            activity.SetTag("gen_ai.response.finish_reasons", new[] { finishReason });
+    }
+
+    /// <summary>
+    /// Records an error on the Activity, setting the status to Error and the error.type tag.
+    /// </summary>
+    public static void RecordError(Activity? activity, Exception ex)
+    {
+        if (activity is null) return;
+        activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+        activity.SetTag("error.type", ex.GetType().Name);
+    }
+}

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/ReportReviewerService.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/ReportReviewerService.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Anthropic;
 using Anthropic.Models.Messages;
 using Biotrackr.Chat.Api.Configuration;
+using Biotrackr.Chat.Api.Telemetry;
 using Microsoft.Extensions.Options;
 
 namespace Biotrackr.Chat.Api.Tools
@@ -41,6 +42,7 @@ namespace Biotrackr.Chat.Api.Tools
                 };
             }
 
+            System.Diagnostics.Activity? activity = null;
             try
             {
                 var httpClient = _httpClientFactory.CreateClient("Anthropic");
@@ -63,6 +65,10 @@ namespace Biotrackr.Chat.Api.Tools
                     "  \"validatedSummary\": \"the summary with corrections and disclaimers applied\"\n" +
                     "}";
 
+                activity = AnthropicTelemetry.StartChatActivity(
+                    model: _settings.ChatAgentModel,
+                    agentId: "BiotrackrReportReviewer");
+
                 var result = await anthropicClient.Messages.Create(new MessageCreateParams
                 {
                     MaxTokens = 4096,
@@ -78,6 +84,16 @@ namespace Biotrackr.Chat.Api.Tools
                     Messages = [new MessageParam { Role = "user", Content = reviewPrompt }]
                 });
 
+                AnthropicTelemetry.RecordResponse(
+                    activity,
+                    responseModel: result.Model,
+                    responseId: result.ID,
+                    finishReason: result.StopReason,
+                    inputTokens: result.Usage?.InputTokens ?? 0,
+                    outputTokens: result.Usage?.OutputTokens ?? 0,
+                    cacheReadInputTokens: result.Usage?.CacheReadInputTokens ?? 0,
+                    cacheCreationInputTokens: result.Usage?.CacheCreationInputTokens ?? 0);
+
                 var responseText = string.Join("", result.Content
                     .OfType<TextBlock>()
                     .Select(b => b.Text));
@@ -90,6 +106,7 @@ namespace Biotrackr.Chat.Api.Tools
             }
             catch (Exception ex)
             {
+                AnthropicTelemetry.RecordError(activity, ex);
                 _logger.LogError(ex, "Reviewer agent failed. Passing report through with warning.");
                 return new ReviewResult
                 {
@@ -97,6 +114,10 @@ namespace Biotrackr.Chat.Api.Tools
                     ValidatedSummary = reportSummary + "\n\n⚠️ Note: This report could not be independently reviewed. Please verify the data manually.",
                     Concerns = []
                 };
+            }
+            finally
+            {
+                activity?.Dispose();
             }
         }
 


### PR DESCRIPTION
## Summary

Adds OpenTelemetry `gen_ai.*` semantic convention spans for Anthropic API calls in Chat.Api. These spans enable Azure AI Foundry trace correlation, monitoring dashboards, and Application Insights visibility for Claude-powered agent interactions.

## Changes

### Added
- **`AnthropicTelemetry.cs`** — Static instrumentation class following [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). Provides `StartChatActivity`, `RecordResponse`, and `RecordError` methods with standardised `gen_ai.*` attributes (operation name, provider, model, token usage, cache metrics, agent ID).
- **`AnthropicTelemetryShould.cs`** — 10 unit tests covering activity creation, attribute correctness, token aggregation (including cache read/creation), null-safety, and error recording.

### Modified
- **`ChatAgentProvider.cs`** — Wraps `RunStreamingWithLatestAgentAsync` with a `gen_ai.anthropic` telemetry span (`agentId: BiotrackrChatAgent`). Uses manual async enumerator pattern since C# disallows `yield return` inside `try-catch`.
- **`ReportReviewerService.cs`** — Wraps `Messages.Create()` call with a telemetry span (`agentId: BiotrackrReportReviewer`). Records full token usage including `cache_read_input_tokens` and `cache_creation_input_tokens` from the Anthropic response.
- **`Program.cs`** — Registers `gen_ai.anthropic` ActivitySource in the OpenTelemetry tracing pipeline via `.AddSource("gen_ai.anthropic")`.

## Validation

- `dotnet build` — 0 errors, 0 warnings
- `dotnet test` — 143 passed (141 unit + 2 integration), 0 failed

## Related

Part of the Azure AI Foundry GenAIOps integration plan (Phase 2 of 6). Enables Foundry monitoring dashboard trace correlation for Phase 4 (custom agent registration).