### PR TITLE
fix: use runtime skip for live evaluation tests

### DIFF
--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.Evaluation.Tests/Biotrackr.Chat.Api.Evaluation.Tests.csproj
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.Evaluation.Tests/Biotrackr.Chat.Api.Evaluation.Tests.csproj
@@ -22,6 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.Evaluation.Tests/FoundryEvaluationTests.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.Evaluation.Tests/FoundryEvaluationTests.cs
@@ -61,12 +61,12 @@ public class FoundryEvaluationTests
         }
     }
 
-    [Fact(Skip = "Requires live Foundry endpoint — run via evaluation workflow")]
+    [SkippableFact]
     [Trait("Category", "Evaluation")]
     public async Task ChatAgentEvaluation_ShouldComplete()
     {
-        _foundryEndpoint.Should().NotBeNullOrEmpty(
-            because: "FOUNDRY_PROJECT_ENDPOINT must be set for live evaluation tests");
+        Skip.If(string.IsNullOrEmpty(_foundryEndpoint),
+            "FOUNDRY_PROJECT_ENDPOINT not set — skipping live evaluation");
 
         var runner = new FoundryEvaluationRunner(_foundryEndpoint!);
         var datasetPath = GetDatasetPath("chat-agent-eval.jsonl");
@@ -77,12 +77,12 @@ public class FoundryEvaluationTests
         status.Should().Be("completed");
     }
 
-    [Fact(Skip = "Requires live Foundry endpoint — run via evaluation workflow")]
+    [SkippableFact]
     [Trait("Category", "Evaluation")]
     public async Task ReportReviewerEvaluation_ShouldComplete()
     {
-        _foundryEndpoint.Should().NotBeNullOrEmpty(
-            because: "FOUNDRY_PROJECT_ENDPOINT must be set for live evaluation tests");
+        Skip.If(string.IsNullOrEmpty(_foundryEndpoint),
+            "FOUNDRY_PROJECT_ENDPOINT not set — skipping live evaluation");
 
         var runner = new FoundryEvaluationRunner(_foundryEndpoint!);
         var datasetPath = GetDatasetPath("report-reviewer-eval.jsonl");


### PR DESCRIPTION
## Summary

Replaces compile-time `[Fact(Skip = "...")]` with runtime `[SkippableFact]` + `Skip.If()` on the live evaluation tests. This ensures tests actually execute when `FOUNDRY_PROJECT_ENDPOINT` is set in the GitHub Actions environment, rather than being unconditionally skipped.

## Changes

- **`FoundryEvaluationTests.cs`** — `[Fact(Skip = "...")]` → `[SkippableFact]` with `Skip.If(string.IsNullOrEmpty(_foundryEndpoint))` for both `ChatAgentEvaluation_ShouldComplete` and `ReportReviewerEvaluation_ShouldComplete`
- **`.csproj`** — Added `Xunit.SkippableFact` v1.5.61 package reference

## Behavior

| Environment | Before | After |
|---|---|---|
| Local (no env var) | Always skipped | Skipped at runtime |
| GitHub Actions (with secret) | Always skipped | **Executes against Foundry** |

## Validation

- Build: 0 errors
- Tests: 3 passed, 2 skipped (expected without endpoint)