### PR TITLE
feat: add evaluation storage account and Foundry project connection

### DIFF
--- a/infra/core/main.bicep
+++ b/infra/core/main.bicep
@@ -146,5 +146,6 @@ module foundry '../modules/ai/foundry.bicep' = {
     appInsightsName: appInsights.outputs.appInsightsName
     logAnalyticsName: logAnalytics.outputs.logAnalyticsName
     uaiName: uai.outputs.uaiName
+    evaluationStorageAccountName: 'st${replace(baseName, '-', '')}eval${environment}'
   }
 }

--- a/infra/modules/ai/foundry.bicep
+++ b/infra/modules/ai/foundry.bicep
@@ -29,6 +29,11 @@ param logAnalyticsName string
 @description('The name of the user-assigned identity to grant Cognitive Services User role')
 param uaiName string
 
+@description('The name of the evaluation storage account for dataset uploads')
+@minLength(3)
+@maxLength(24)
+param evaluationStorageAccountName string
+
 resource uai 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
   name: uaiName
 }
@@ -108,6 +113,79 @@ resource cognitiveServicesUserRole 'Microsoft.Authorization/roleAssignments@2022
   }
 }
 
+// --- Evaluation Storage ---
+// Dedicated storage account for Foundry evaluation dataset uploads.
+// The SDK's UploadFileAsync requires a connected storage resource on the project.
+resource evaluationStorage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+  name: evaluationStorageAccountName
+  location: location
+  tags: tags
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource evaluationBlobService 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
+  name: 'default'
+  parent: evaluationStorage
+}
+
+resource evaluationDatasetsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2024-01-01' = {
+  name: 'evaluation-datasets'
+  parent: evaluationBlobService
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+// Storage Blob Data Contributor for the Foundry account's system-assigned identity
+// so the SDK can upload datasets via PendingUpload
+var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+
+resource foundryStorageRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(evaluationStorage.id, foundryAccount.id, storageBlobDataContributorRoleId)
+  scope: evaluationStorage
+  properties: {
+    principalId: foundryAccount.identity.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleId)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Storage Blob Data Contributor for the project's system-assigned identity
+resource projectStorageRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(evaluationStorage.id, foundryProject.id, storageBlobDataContributorRoleId)
+  scope: evaluationStorage
+  properties: {
+    principalId: foundryProject.identity.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleId)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Connect storage to the Foundry project so the Datasets API can upload files
+resource storageConnection 'Microsoft.CognitiveServices/accounts/projects/connections@2025-12-01' = {
+  parent: foundryProject
+  name: 'evaluation-storage'
+  properties: {
+    category: 'AzureBlob'
+    target: evaluationStorage.properties.primaryEndpoints.blob
+    authType: 'AAD'
+    metadata: {
+      storageAccountResourceId: evaluationStorage.id
+      AccountName: evaluationStorage.name
+      ContainerName: 'evaluation-datasets'
+    }
+  }
+}
+
 @description('The name of the deployed AI Foundry account')
 output foundryAccountName string = foundryAccount.name
 
@@ -122,3 +200,9 @@ output foundryProjectName string = foundryProject.name
 
 @description('The Application Insights resource ID (for portal connection)')
 output appInsightsResourceId string = appInsights.id
+
+@description('The project endpoint for SDK calls (e.g., evaluations, datasets)')
+output foundryProjectEndpoint string = foundryProject.properties.endpoints['AI Foundry API']
+
+@description('The name of the evaluation storage account')
+output evaluationStorageAccountName string = evaluationStorage.name

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.Evaluation.Tests/FoundryEvaluationRunner.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.Evaluation.Tests/FoundryEvaluationRunner.cs
@@ -33,7 +33,8 @@ public class FoundryEvaluationRunner
         return await _projectClient.Datasets.UploadFileAsync(
             name: datasetName,
             version: version,
-            filePath: datasetPath);
+            filePath: datasetPath,
+            connectionName: "evaluation-storage");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Adds a dedicated evaluation storage account and connects it to the Foundry project so the `Azure.AI.Projects` SDK can upload JSONL datasets via `UploadFileAsync`. Fixes the 404 error from the evaluation workflow (#217).

## Changes

### Infrastructure
- **`foundry.bicep`** — Add `stbiotrackrevaldev` storage account (Standard_LRS), grant `Storage Blob Data Contributor` to both the Foundry account and project system-assigned identities, create `evaluation-storage` connection on the project using managed identity auth
- **`main.bicep`** — Pass `evaluationStorageAccountName` parameter to Foundry module

### Code
- **`FoundryEvaluationRunner.cs`** — Pass `connectionName: "evaluation-storage"` to `UploadFileAsync` so the SDK uses the correct connected storage

## Deployment Notes

After merging and deploying core infrastructure:
1. The `evaluation-storage` connection will appear in Foundry portal → project → Connected resources
2. Update `FOUNDRY_PROJECT_ENDPOINT` GitHub secret to: `https://ai-biotrackr-dev.services.ai.azure.com/api/projects/biotrackr-genaiops` (project endpoint, not account endpoint)
3. Re-run the evaluation workflow via `workflow_dispatch` to validate

## Validation

- Bicep lint: 0 errors, 0 warnings
- `dotnet build`: 0 errors