### PR TITLE
fix: use OpenAI-compatible /openai/evals REST path for Foundry evaluations

### DIFF
--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.Evaluation.Tests/FoundryEvaluationRunner.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.Evaluation.Tests/FoundryEvaluationRunner.cs
@@ -1,7 +1,8 @@
 using Azure.AI.Projects;
+using Azure.Core;
 using Azure.Identity;
-using System.ClientModel;
-using System.ClientModel.Primitives;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 
 namespace Biotrackr.Chat.Api.Evaluation.Tests;
@@ -9,16 +10,22 @@ namespace Biotrackr.Chat.Api.Evaluation.Tests;
 /// <summary>
 /// Runs dataset-based evaluations against Azure AI Foundry using safety evaluators
 /// and GroundednessProEvaluator. No GPT judge model required.
-/// Uses the Schedules API with a one-time trigger for ad-hoc evaluation runs.
+/// Uses the Foundry OpenAI-compatible REST API (/openai/evals) directly since
+/// the .NET SDK v2.0.0-beta.2 has evaluations listed as a Known Issue (will fail).
+/// See: .copilot-tracking/research/subagents/2026-03-31/azure-ai-projects-evaluation-api-research.md
 /// </summary>
 public class FoundryEvaluationRunner
 {
     private readonly AIProjectClient _projectClient;
+    private readonly string _projectEndpoint;
+    private readonly TokenCredential _credential;
 
-    public FoundryEvaluationRunner(string foundryEndpoint)
+    public FoundryEvaluationRunner(string foundryProjectEndpoint)
     {
+        _projectEndpoint = foundryProjectEndpoint.TrimEnd('/');
+        _credential = new DefaultAzureCredential();
         _projectClient = new AIProjectClient(
-            new Uri(foundryEndpoint), new DefaultAzureCredential());
+            new Uri(_projectEndpoint), _credential);
     }
 
     /// <summary>
@@ -37,111 +44,137 @@ public class FoundryEvaluationRunner
     }
 
     /// <summary>
-    /// Creates an evaluation schedule with safety + groundedness evaluators
-    /// using a one-time trigger. Returns the schedule ID for polling.
+    /// Creates an evaluation definition with safety + groundedness evaluators.
+    /// Returns the evaluation ID.
     /// </summary>
-    public async Task<string> CreateEvaluationScheduleAsync(
-        string evaluationName, string datasetId)
+    public async Task<string> CreateEvaluationAsync(string evaluationName)
     {
-        var evalConfig = new
-        {
-            evaluators = new Dictionary<string, object>
+        object[] testingCriteria =
+        [
+            new
             {
-                ["violence"] = new
+                type = "azure_ai_evaluator",
+                name = "violence_detection",
+                evaluator_name = "builtin.violence",
+                data_mapping = new { query = "{{item.query}}", response = "{{item.response}}" }
+            },
+            new
+            {
+                type = "azure_ai_evaluator",
+                name = "self_harm_detection",
+                evaluator_name = "builtin.self_harm",
+                data_mapping = new { query = "{{item.query}}", response = "{{item.response}}" }
+            },
+            new
+            {
+                type = "azure_ai_evaluator",
+                name = "sexual_content_detection",
+                evaluator_name = "builtin.sexual",
+                data_mapping = new { query = "{{item.query}}", response = "{{item.response}}" }
+            },
+            new
+            {
+                type = "azure_ai_evaluator",
+                name = "hate_unfairness_detection",
+                evaluator_name = "builtin.hate_unfairness",
+                data_mapping = new { query = "{{item.query}}", response = "{{item.response}}" }
+            },
+            new
+            {
+                type = "azure_ai_evaluator",
+                name = "groundedness_pro",
+                evaluator_name = "builtin.groundedness_pro",
+                data_mapping = new
                 {
-                    id = "azureai://built-in-evaluators/violence",
-                    init_params = new { },
-                    data_mapping = new { query = "${data.query}", response = "${data.response}" }
-                },
-                ["self_harm"] = new
-                {
-                    id = "azureai://built-in-evaluators/self-harm",
-                    init_params = new { },
-                    data_mapping = new { query = "${data.query}", response = "${data.response}" }
-                },
-                ["sexual"] = new
-                {
-                    id = "azureai://built-in-evaluators/sexual",
-                    init_params = new { },
-                    data_mapping = new { query = "${data.query}", response = "${data.response}" }
-                },
-                ["hate_unfairness"] = new
-                {
-                    id = "azureai://built-in-evaluators/hate-unfairness",
-                    init_params = new { },
-                    data_mapping = new { query = "${data.query}", response = "${data.response}" }
-                },
-                ["groundedness_pro"] = new
-                {
-                    id = "azureai://built-in-evaluators/groundedness-pro",
-                    init_params = new { },
-                    data_mapping = new
-                    {
-                        query = "${data.query}",
-                        response = "${data.response}",
-                        context = "${data.context}"
-                    }
+                    query = "{{item.query}}",
+                    response = "{{item.response}}",
+                    context = "{{item.context}}"
                 }
             },
-            data = new
-            {
-                type = "dataset",
-                id = datasetId
-            }
-        };
+        ];
 
-        var schedulePayload = new
+        object dataSourceConfig = new
         {
-            display_name = evaluationName,
-            trigger = new
+            type = "custom",
+            item_schema = new
             {
-                type = "one_time",
-                trigger_at = DateTime.UtcNow.AddSeconds(5).ToString("O")
-            },
-            task = new
-            {
-                type = "evaluation",
-                eval_id = evaluationName,
-                eval_run = evalConfig
+                type = "object",
+                properties = new
+                {
+                    query = new { type = "string" },
+                    response = new { type = "string" },
+                    context = new { type = "string" },
+                    ground_truth = new { type = "string" }
+                },
+                required = new[] { "query", "response", "context" }
             }
         };
 
-        var scheduleId = $"eval-{evaluationName}-{DateTime.UtcNow:yyyyMMddHHmmss}";
-        BinaryData scheduleData = BinaryData.FromObjectAsJson(schedulePayload);
-        using BinaryContent content = BinaryContent.Create(scheduleData);
+        var payload = new
+        {
+            name = evaluationName,
+            data_source_config = dataSourceConfig,
+            testing_criteria = testingCriteria
+        };
 
-        ClientResult result = await _projectClient.Schedules.CreateOrUpdateAsync(
-            scheduleId, content, new RequestOptions());
+        var response = await PostToFoundryAsync("openai/evals", payload);
 
-        using var doc = JsonDocument.Parse(result.GetRawResponse().Content.ToString());
-        return doc.RootElement.TryGetProperty("id", out var idProp)
-            ? idProp.GetString() ?? scheduleId
-            : scheduleId;
+        using var doc = JsonDocument.Parse(response);
+        return doc.RootElement.GetProperty("id").GetString()!;
     }
 
     /// <summary>
-    /// Polls a schedule until it reaches a terminal state.
+    /// Runs an evaluation against an uploaded dataset.
+    /// Returns the evaluation run ID.
+    /// </summary>
+    public async Task<string> CreateEvaluationRunAsync(
+        string evaluationId, string datasetId, string runName)
+    {
+        var payload = new
+        {
+            name = runName,
+            data_source = new
+            {
+                type = "jsonl",
+                source = new
+                {
+                    type = "file_id",
+                    id = datasetId
+                }
+            },
+            metadata = new
+            {
+                team = "biotrackr-genaiops",
+                scenario = "dataset-evaluation"
+            }
+        };
+
+        var response = await PostToFoundryAsync(
+            $"openai/evals/{evaluationId}/runs", payload);
+
+        using var doc = JsonDocument.Parse(response);
+        return doc.RootElement.GetProperty("id").GetString()!;
+    }
+
+    /// <summary>
+    /// Polls an evaluation run until it reaches a terminal state.
     /// Returns "completed", "failed", or "timeout".
     /// </summary>
     public async Task<string> WaitForCompletionAsync(
-        string scheduleId, TimeSpan? timeout = null)
+        string evaluationId, string runId, TimeSpan? timeout = null)
     {
         var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromMinutes(10));
 
         while (DateTime.UtcNow < deadline)
         {
-            ClientResult scheduleResult = await _projectClient.Schedules.GetAsync(
-                scheduleId, new RequestOptions());
+            var response = await GetFromFoundryAsync(
+                $"openai/evals/{evaluationId}/runs/{runId}");
 
-            using var doc = JsonDocument.Parse(
-                scheduleResult.GetRawResponse().Content.ToString());
+            using var doc = JsonDocument.Parse(response);
+            var status = doc.RootElement.GetProperty("status").GetString()!;
 
-            if (doc.RootElement.TryGetProperty("provisioning_status", out var statusProp))
-            {
-                var status = statusProp.GetString();
-                if (status is "completed" or "failed")
-                    return status;
-            }
+            if (status is "completed" or "failed")
+                return status;
 
             await Task.Delay(TimeSpan.FromSeconds(10));
         }
@@ -150,14 +183,65 @@ public class FoundryEvaluationRunner
     }
 
     /// <summary>
-    /// Convenience method: uploads dataset, creates evaluation schedule, and waits.
+    /// Convenience method: uploads dataset, creates evaluation, runs it, and waits.
     /// Returns the final status.
     /// </summary>
     public async Task<string> RunEvaluationAsync(
         string evaluationName, string datasetPath, TimeSpan? timeout = null)
     {
         var dataset = await UploadDatasetAsync(datasetPath);
-        var scheduleId = await CreateEvaluationScheduleAsync(evaluationName, dataset.Id);
-        return await WaitForCompletionAsync(scheduleId, timeout);
+        var evaluationId = await CreateEvaluationAsync(evaluationName);
+        var runId = await CreateEvaluationRunAsync(
+            evaluationId, dataset.Id, $"{evaluationName}-run");
+        return await WaitForCompletionAsync(evaluationId, runId, timeout);
+    }
+
+    private async Task<string> PostToFoundryAsync(string path, object payload)
+    {
+        using var httpClient = await CreateAuthenticatedClientAsync();
+        var json = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await httpClient.PostAsync(
+            $"{_projectEndpoint}/{path}?api-version=2025-11-15-preview", content);
+
+        var body = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"Foundry API {path} returned {response.StatusCode}: {body}");
+        }
+
+        return body;
+    }
+
+    private async Task<string> GetFromFoundryAsync(string path)
+    {
+        using var httpClient = await CreateAuthenticatedClientAsync();
+
+        var response = await httpClient.GetAsync(
+            $"{_projectEndpoint}/{path}?api-version=2025-11-15-preview");
+
+        var body = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"Foundry API {path} returned {response.StatusCode}: {body}");
+        }
+
+        return body;
+    }
+
+    private async Task<HttpClient> CreateAuthenticatedClientAsync()
+    {
+        var token = await _credential.GetTokenAsync(
+            new TokenRequestContext(["https://ai.azure.com/.default"]),
+            CancellationToken.None);
+
+        var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token.Token);
+
+        return httpClient;
     }
 }


### PR DESCRIPTION
## Summary

Rewrites the `FoundryEvaluationRunner` to use the correct OpenAI-compatible REST API path that Foundry actually exposes for evaluations.

## Root Cause

The .NET SDK v2.0.0-beta.2 has evaluations explicitly listed as a **Known Issue** ("will fail"). Previous attempts used the SDK's `Schedules` API and then a direct REST API at `/evaluations` — both wrong. Research confirmed that:

- The evaluation API is **OpenAI-protocol-based** at `/openai/evals`
- The correct API version is `2025-11-15-preview`
- Auth scope is `https://ai.azure.com/.default`
- This matches exactly what the Python SDK's `project_client.get_openai_client().evals` does internally

See: `.copilot-tracking/research/subagents/2026-03-31/azure-ai-projects-evaluation-api-research.md`

## Changes

- **`FoundryEvaluationRunner.cs`** — Complete rewrite:
  - REST path: `/evaluations` → `/openai/evals`
  - API version: `2025-05-15-preview` → `2025-11-15-preview`  
  - Removed Schedules API dependency (was wrong approach)
  - Removed `System.ClientModel.Primitives` import (no longer needed)
  - Kept dataset upload via `AIProjectClient.Datasets.UploadFileAsync()` (working)
  - Kept `https://ai.azure.com/.default` auth scope (confirmed correct)

## Validation

- Build: 0 errors, 0 warnings