### PR TITLE
feat: add body composition display to Weight page

### DIFF
--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/WeightPageShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/WeightPageShould.cs
@@ -100,17 +100,35 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
         }
 
         [Fact]
-        public void RenderBodyFat_WhenGreaterThanZero()
+        public void RenderBodyComposition_WhenWithingsDataAvailable()
         {
-            var weightItem = CreateWeightItem(weight: 80, bmi: 24.5, fat: 18.5);
+            var weightItem = CreateWeightItem(weight: 80, bmi: 22.7, muscleMass: 45.2, fatMass: 15.23, boneMass: 3.1, waterMass: 48.9, visceralFat: 10);
 
             _mockApiService.Setup(s => s.GetWeightByDateAsync(It.IsAny<string>()))
                 .ReturnsAsync(weightItem);
 
             var cut = Render<Weight>();
 
-            cut.Markup.Should().Contain("Body Fat");
-            cut.Markup.Should().Contain("18.5%");
+            cut.Markup.Should().Contain("Body Composition");
+            cut.Markup.Should().Contain("Muscle Mass");
+            cut.Markup.Should().Contain("45.2 kg");
+            cut.Markup.Should().Contain("Fat Mass");
+            cut.Markup.Should().Contain("15.2 kg");
+            cut.Markup.Should().Contain("Bone Mass");
+            cut.Markup.Should().Contain("3.1 kg");
+        }
+
+        [Fact]
+        public void NotRenderBodyComposition_WhenFitbitDataOnly()
+        {
+            var weightItem = CreateWeightItem(weight: 80, bmi: 24.5);
+
+            _mockApiService.Setup(s => s.GetWeightByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync(weightItem);
+
+            var cut = Render<Weight>();
+
+            cut.Markup.Should().NotContain("Body Composition");
         }
 
         [Fact]
@@ -173,19 +191,29 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
             cut.Markup.Should().NotBeEmpty();
         }
 
-        private static WeightItem CreateWeightItem(double weight = 0, double bmi = 0, double fat = 0)
+        private static WeightItem CreateWeightItem(
+            double weight = 0, double bmi = 0, double fat = 0,
+            double? muscleMass = null, double? fatMass = null,
+            double? boneMass = null, double? waterMass = null,
+            int? visceralFat = null, string provider = "Withings")
         {
             return new WeightItem
             {
                 Id = "test-id",
                 Date = "2026-03-05",
+                Provider = provider,
                 Weight = new WeightData
                 {
                     Weight = weight,
                     Bmi = bmi,
                     Fat = fat,
-                    Source = "Fitbit",
-                    Time = "08:00:00"
+                    Source = provider,
+                    Time = "08:00:00",
+                    MuscleMassKg = muscleMass,
+                    FatMassKg = fatMass,
+                    BoneMassKg = boneMass,
+                    WaterMassKg = waterMass,
+                    VisceralFatIndex = visceralFat
                 }
             };
         }

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Weight.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Weight.razor
@@ -23,16 +23,53 @@
             <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
                 <SummaryCard Title="BMI" Value="@($"{_singleItem.Weight.Bmi:F1}")" Subtitle="@GetBmiCategory(_singleItem.Weight.Bmi)" />
             </RadzenColumn>
-            @if (_singleItem.Weight.Fat > 0)
-            {
-                <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-                    <SummaryCard Title="Body Fat" Value="@($"{_singleItem.Weight.Fat:F1}%")" />
-                </RadzenColumn>
-            }
             <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-                <SummaryCard Title="Recorded" Value="@_singleItem.Weight.Time" Subtitle="@_singleItem.Weight.Source" />
+                <SummaryCard Title="Recorded" Value="@_singleItem.Weight.Time" Subtitle="@(_singleItem.Provider ?? _singleItem.Weight.Source)" />
             </RadzenColumn>
         </RadzenRow>
+
+        @if (_singleItem.Weight.MuscleMassKg is not null || _singleItem.Weight.FatMassKg is not null)
+        {
+            <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Body Composition</RadzenText>
+            <RadzenRow Gap="1rem" class="rz-mb-4">
+                @if (_singleItem.Weight.FatMassKg is not null)
+                {
+                    <RadzenColumn Size="12" SizeMD="2" SizeSM="4">
+                        <SummaryCard Title="Fat Mass" Value="@($"{_singleItem.Weight.FatMassKg:F1} kg")" />
+                    </RadzenColumn>
+                }
+                @if (_singleItem.Weight.FatFreeMassKg is not null)
+                {
+                    <RadzenColumn Size="12" SizeMD="2" SizeSM="4">
+                        <SummaryCard Title="Fat-Free Mass" Value="@($"{_singleItem.Weight.FatFreeMassKg:F1} kg")" />
+                    </RadzenColumn>
+                }
+                @if (_singleItem.Weight.MuscleMassKg is not null)
+                {
+                    <RadzenColumn Size="12" SizeMD="2" SizeSM="4">
+                        <SummaryCard Title="Muscle Mass" Value="@($"{_singleItem.Weight.MuscleMassKg:F1} kg")" />
+                    </RadzenColumn>
+                }
+                @if (_singleItem.Weight.BoneMassKg is not null)
+                {
+                    <RadzenColumn Size="12" SizeMD="2" SizeSM="4">
+                        <SummaryCard Title="Bone Mass" Value="@($"{_singleItem.Weight.BoneMassKg:F1} kg")" />
+                    </RadzenColumn>
+                }
+                @if (_singleItem.Weight.WaterMassKg is not null)
+                {
+                    <RadzenColumn Size="12" SizeMD="2" SizeSM="4">
+                        <SummaryCard Title="Water Mass" Value="@($"{_singleItem.Weight.WaterMassKg:F1} kg")" />
+                    </RadzenColumn>
+                }
+                @if (_singleItem.Weight.VisceralFatIndex is not null)
+                {
+                    <RadzenColumn Size="12" SizeMD="2" SizeSM="4">
+                        <SummaryCard Title="Visceral Fat" Value="@($"{_singleItem.Weight.VisceralFatIndex}")" />
+                    </RadzenColumn>
+                }
+            </RadzenRow>
+        }
     }
     else
     {
@@ -53,14 +90,23 @@
             <RadzenDataGridColumn TItem="WeightItem" Title="BMI">
                 <Template Context="item">@item.Weight.Bmi.ToString("F1")</Template>
             </RadzenDataGridColumn>
-            <RadzenDataGridColumn TItem="WeightItem" Title="Body Fat %">
-                <Template Context="item">@(item.Weight.Fat > 0 ? item.Weight.Fat.ToString("F1") : "--")</Template>
+            <RadzenDataGridColumn TItem="WeightItem" Title="Muscle (kg)">
+                <Template Context="item">@(item.Weight.MuscleMassKg?.ToString("F1") ?? "--")</Template>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="WeightItem" Title="Fat Mass (kg)">
+                <Template Context="item">@(item.Weight.FatMassKg?.ToString("F1") ?? "--")</Template>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="WeightItem" Title="Bone (kg)">
+                <Template Context="item">@(item.Weight.BoneMassKg?.ToString("F1") ?? "--")</Template>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="WeightItem" Title="Water (kg)">
+                <Template Context="item">@(item.Weight.WaterMassKg?.ToString("F1") ?? "--")</Template>
             </RadzenDataGridColumn>
             <RadzenDataGridColumn TItem="WeightItem" Title="Time">
                 <Template Context="item">@item.Weight.Time</Template>
             </RadzenDataGridColumn>
-            <RadzenDataGridColumn TItem="WeightItem" Title="Source">
-                <Template Context="item">@item.Weight.Source</Template>
+            <RadzenDataGridColumn TItem="WeightItem" Title="Provider">
+                <Template Context="item">@(item.Provider ?? item.Weight.Source)</Template>
             </RadzenDataGridColumn>
         </Columns>
     </RadzenDataGrid>

--- a/src/Biotrackr.UI/Biotrackr.UI/Models/Weight/WeightData.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI/Models/Weight/WeightData.cs
@@ -24,5 +24,23 @@ namespace Biotrackr.UI.Models.Weight
 
         [JsonPropertyName("weight")]
         public double Weight { get; set; }
+
+        [JsonPropertyName("fatMassKg")]
+        public double? FatMassKg { get; set; }
+
+        [JsonPropertyName("fatFreeMassKg")]
+        public double? FatFreeMassKg { get; set; }
+
+        [JsonPropertyName("muscleMassKg")]
+        public double? MuscleMassKg { get; set; }
+
+        [JsonPropertyName("boneMassKg")]
+        public double? BoneMassKg { get; set; }
+
+        [JsonPropertyName("waterMassKg")]
+        public double? WaterMassKg { get; set; }
+
+        [JsonPropertyName("visceralFatIndex")]
+        public int? VisceralFatIndex { get; set; }
     }
 }

--- a/src/Biotrackr.UI/Biotrackr.UI/Models/Weight/WeightItem.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI/Models/Weight/WeightItem.cs
@@ -15,5 +15,8 @@ namespace Biotrackr.UI.Models.Weight
 
         [JsonPropertyName("documentType")]
         public string DocumentType { get; set; } = string.Empty;
+
+        [JsonPropertyName("provider")]
+        public string? Provider { get; set; }
     }
 }


### PR DESCRIPTION
## Summary

Add Withings body composition display to the Weight page in the Blazor UI. Body composition data from the Withings Body Comp scale is now visible in both single-date and range views.

## Changes

### Models
- **WeightData.cs**: Added 6 nullable body composition properties (`FatMassKg`, `FatFreeMassKg`, `MuscleMassKg`, `BoneMassKg`, `WaterMassKg`, `VisceralFatIndex`)
- **WeightItem.cs**: Added nullable `Provider` property

### Weight.razor Page
- **Single date view**: Added "Body Composition" section with conditional SummaryCards (only shown for Withings data with body comp). Cards: Fat Mass, Fat-Free Mass, Muscle Mass, Bone Mass, Water Mass, Visceral Fat
- **Range view**: Replaced "Body Fat %" column with Muscle, Fat Mass, Bone, Water columns. Replaced "Source" with "Provider". Null values display as "--"
- **Recorded card**: Shows Provider name instead of raw source

### Removed
- Body Fat % SummaryCard (replaced by richer body comp data)
- Body Fat % data grid column (replaced by Fat Mass column)

## Backward Compatibility
Old Fitbit weight records show "--" for body composition fields since those values are null. Provider shows "Fitbit" (from backfill) or falls back to Source field.

## Part of: Withings Weight Integration
PR 5 of 6.