### PR TITLE
feat: add body composition fields to MCP Server weight models

### DIFF
--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Weight/WeightData.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Weight/WeightData.cs
@@ -26,5 +26,23 @@ namespace Biotrackr.Mcp.Server.Models.Weight
 
         [JsonPropertyName("weight")]
         public double Weight { get; set; }
+
+        [JsonPropertyName("fatMassKg")]
+        public double? FatMassKg { get; set; }
+
+        [JsonPropertyName("fatFreeMassKg")]
+        public double? FatFreeMassKg { get; set; }
+
+        [JsonPropertyName("muscleMassKg")]
+        public double? MuscleMassKg { get; set; }
+
+        [JsonPropertyName("boneMassKg")]
+        public double? BoneMassKg { get; set; }
+
+        [JsonPropertyName("waterMassKg")]
+        public double? WaterMassKg { get; set; }
+
+        [JsonPropertyName("visceralFatIndex")]
+        public int? VisceralFatIndex { get; set; }
     }
 }

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Weight/WeightItem.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Weight/WeightItem.cs
@@ -17,5 +17,8 @@ namespace Biotrackr.Mcp.Server.Models.Weight
         [JsonIgnore]
         [JsonPropertyName("documentType")]
         public string DocumentType { get; set; } = string.Empty;
+
+        [JsonPropertyName("provider")]
+        public string? Provider { get; set; }
     }
 }


### PR DESCRIPTION
## Summary

Add Withings body composition fields to MCP Server weight models, enabling AI tools to access muscle mass, bone mass, water mass, fat mass, fat-free mass, and visceral fat data for health analysis.

## Changes

- **WeightData.cs**: Added 6 nullable body composition properties (`FatMassKg`, `FatFreeMassKg`, `MuscleMassKg`, `BoneMassKg`, `WaterMassKg`, `VisceralFatIndex`)
- **WeightItem.cs**: Added nullable `Provider` property

## Tests

All 128 existing tests pass (115 unit + 13 integration). No test changes needed — new nullable fields deserialize as `null` from existing mock responses, which is correct behavior for legacy Fitbit data.

## Impact

AI assistants querying weight data via MCP tools now receive body composition metrics when available (Withings data). For Fitbit data, body comp fields are `null`. No tool code or endpoint changes needed — automatic deserialization passthrough.

## Final PR: Withings Weight Integration

PR 6 of 6. This completes the Withings Body Comp scale integration into Biotrackr.