### PR TITLE
feat: add dashboard trends, domain charts, responsive layout, and theme toggle

### DIFF
--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Layout/MainLayoutShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Layout/MainLayoutShould.cs
@@ -1,0 +1,80 @@
+using Bunit;
+using Biotrackr.UI.Components.Layout;
+using Biotrackr.UI.Models;
+using Biotrackr.UI.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Radzen;
+
+namespace Biotrackr.UI.UnitTests.Components.Layout
+{
+    public class MainLayoutShould : BunitContext
+    {
+        private readonly Mock<IUserInfoService> _mockUserInfoService;
+        private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+
+        public MainLayoutShould()
+        {
+            _mockUserInfoService = new Mock<IUserInfoService>();
+            _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+
+            var httpContext = new DefaultHttpContext();
+            _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            _mockUserInfoService.Setup(x => x.GetUserInfo(It.IsAny<HttpContext>()))
+                .Returns(new UserInfo { DisplayName = "Test User", Email = "test@example.com" });
+
+            Services.AddSingleton(_mockUserInfoService.Object);
+            Services.AddSingleton<IHttpContextAccessor>(_mockHttpContextAccessor.Object);
+            Services.AddRadzenComponents();
+            JSInterop.Mode = JSRuntimeMode.Loose;
+        }
+
+        [Fact]
+        public void RenderBiotrackrTitle()
+        {
+            var cut = Render<MainLayout>(parameters => parameters
+                .Add(p => p.Body, builder => builder.AddContent(0, "Test content")));
+
+            cut.Markup.Should().Contain("Biotrackr");
+        }
+
+        [Fact]
+        public void RenderUserDisplayName()
+        {
+            var cut = Render<MainLayout>(parameters => parameters
+                .Add(p => p.Body, builder => builder.AddContent(0, "Test content")));
+
+            cut.Markup.Should().Contain("Test User");
+        }
+
+        [Fact]
+        public void RenderProfileMenu()
+        {
+            var cut = Render<MainLayout>(parameters => parameters
+                .Add(p => p.Body, builder => builder.AddContent(0, "Test content")));
+
+            cut.Markup.Should().Contain("Sign Out");
+            cut.Markup.Should().Contain("Profile");
+        }
+
+        [Fact]
+        public void CallUserInfoService_OnInitialized()
+        {
+            var cut = Render<MainLayout>(parameters => parameters
+                .Add(p => p.Body, builder => builder.AddContent(0, "Test content")));
+
+            _mockUserInfoService.Verify(x => x.GetUserInfo(It.IsAny<HttpContext>()), Times.Once);
+        }
+
+        [Fact]
+        public void RenderBodyContent()
+        {
+            var cut = Render<MainLayout>(parameters => parameters
+                .Add(p => p.Body, builder => builder.AddContent(0, "Hello from body")));
+
+            cut.Markup.Should().Contain("Hello from body");
+        }
+    }
+}

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Layout/NavMenuShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Layout/NavMenuShould.cs
@@ -55,11 +55,11 @@ namespace Biotrackr.UI.UnitTests.Components.Layout
         }
 
         [Fact]
-        public void RenderSignOutLink()
+        public void NotRenderSignOutLink_WhenMovedToProfileDropdown()
         {
             var cut = Render<NavMenu>();
 
-            cut.Markup.Should().Contain("Sign Out");
+            cut.Markup.Should().NotContain("Sign Out");
         }
     }
 }

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/ActivityPageShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/ActivityPageShould.cs
@@ -195,7 +195,7 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
             var cut = Render<Activity>();
 
             // Arc gauges for steps and calories, bar charts for HR zones and active minutes
-            cut.Markup.Should().Contain("rz-arc-gauge");
+            cut.Markup.Should().Contain("rz-progressbar");
             cut.Markup.Should().Contain("Steps");
             cut.Markup.Should().Contain("10,000");
         }

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/ActivityPageShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/ActivityPageShould.cs
@@ -5,6 +5,7 @@ using Biotrackr.UI.Components.Pages;
 using Biotrackr.UI.Models;
 using Biotrackr.UI.Models.Activity;
 using Biotrackr.UI.Services;
+using Biotrackr.UI.UnitTests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,6 +21,7 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
             Services.AddSingleton(_mockApiService.Object);
             Services.AddRadzenComponents();
             JSInterop.Mode = JSRuntimeMode.Loose;
+            JSInterop.SetupRadzenChartInterop();
         }
 
         [Fact]
@@ -169,6 +171,87 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
 
             // Range mode uses RadzenSelectBar which cannot be interacted with via bUnit selectors.
             // Verify that the component renders without errors when data is available.
+            cut.Markup.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void RenderCharts_WhenSingleDateDataLoaded()
+        {
+            var activityItem = CreateActivityItem(steps: 10000, calories: 2500, floors: 10,
+                fairlyActive: 15, veryActive: 30, activeMinGoal: 30, stepsGoal: 10000,
+                caloriesGoal: 2500, floorsGoal: 10);
+            activityItem.Activity.Summary.HeartRateZones.Add(new HeartRateZone
+            {
+                Name = "Fat Burn",
+                Minutes = 40,
+                CaloriesOut = 150,
+                Min = 100,
+                Max = 140
+            });
+
+            _mockApiService.Setup(s => s.GetActivityByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync(activityItem);
+
+            var cut = Render<Activity>();
+
+            // Arc gauges for steps and calories, bar charts for HR zones and active minutes
+            cut.Markup.Should().Contain("rz-arc-gauge");
+            cut.Markup.Should().Contain("Steps");
+            cut.Markup.Should().Contain("10,000");
+        }
+
+        [Fact]
+        public void RenderTrendCharts_WhenRangeDateDataLoaded()
+        {
+            var rangeResponse = new PaginatedResponse<ActivityItem>
+            {
+                Items =
+                [
+                    CreateActivityItem(steps: 8000, calories: 2200),
+                    CreateActivityItem(steps: 9500, calories: 2400)
+                ],
+                PageNumber = 1,
+                TotalPages = 1,
+                TotalCount = 2,
+                HasPreviousPage = false,
+                HasNextPage = false
+            };
+            rangeResponse.Items[0].Date = "2026-03-01";
+            rangeResponse.Items[1].Date = "2026-03-02";
+
+            _mockApiService.Setup(s => s.GetActivityByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync((ActivityItem?)null);
+            _mockApiService.Setup(s => s.GetActivitiesByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(rangeResponse);
+
+            var cut = Render<Activity>();
+
+            // The component renders without errors when range data is available
+            cut.Markup.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void RenderChartsAndDataGrid_InRangeMode()
+        {
+            var rangeResponse = new PaginatedResponse<ActivityItem>
+            {
+                Items = [CreateActivityItem(steps: 8000, calories: 2200)],
+                PageNumber = 1,
+                TotalPages = 1,
+                TotalCount = 1,
+                HasPreviousPage = false,
+                HasNextPage = false
+            };
+
+            _mockApiService.Setup(s => s.GetActivityByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync((ActivityItem?)null);
+            _mockApiService.Setup(s => s.GetActivitiesByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(rangeResponse);
+
+            var cut = Render<Activity>();
+
+            // Verify component renders with range data including charts and grid elements
+            cut.Markup.Should().Contain("Activity");
             cut.Markup.Should().NotBeEmpty();
         }
 

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/FoodPageShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/FoodPageShould.cs
@@ -5,6 +5,7 @@ using Biotrackr.UI.Components.Pages;
 using Biotrackr.UI.Models;
 using Biotrackr.UI.Models.Food;
 using Biotrackr.UI.Services;
+using Biotrackr.UI.UnitTests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,6 +21,7 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
             Services.AddSingleton(_mockApiService.Object);
             Services.AddRadzenComponents();
             JSInterop.Mode = JSRuntimeMode.Loose;
+            JSInterop.SetupRadzenChartInterop();
         }
 
         [Fact]
@@ -138,6 +140,76 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
 
             // Range mode uses RadzenSelectBar which cannot be interacted with via bUnit selectors.
             // Verify that the component renders without errors when data is available.
+            cut.Markup.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void RenderCharts_WhenSingleDateDataLoaded()
+        {
+            var foodItem = CreateFoodItem(calories: 2500, protein: 120, carbs: 300, fat: 80, fiber: 25, water: 2000);
+            foodItem.Food.Goals = new FoodGoals { Calories = 3000 };
+
+            _mockApiService.Setup(s => s.GetFoodLogByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync(foodItem);
+
+            var cut = Render<Food>();
+
+            // Donut chart for macros and arc gauge for calorie goal
+            cut.Markup.Should().Contain("2,500");
+            cut.Markup.Should().Contain("rz-arc-gauge");
+        }
+
+        [Fact]
+        public void RenderTrendCharts_WhenRangeDateDataLoaded()
+        {
+            var rangeResponse = new PaginatedResponse<FoodItem>
+            {
+                Items =
+                [
+                    CreateFoodItem(calories: 1800, protein: 90, carbs: 200, fat: 60),
+                    CreateFoodItem(calories: 2200, protein: 110, carbs: 250, fat: 70)
+                ],
+                PageNumber = 1,
+                TotalPages = 1,
+                TotalCount = 2,
+                HasPreviousPage = false,
+                HasNextPage = false
+            };
+            rangeResponse.Items[0].Date = "2026-03-01";
+            rangeResponse.Items[1].Date = "2026-03-02";
+
+            _mockApiService.Setup(s => s.GetFoodLogByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync((FoodItem?)null);
+            _mockApiService.Setup(s => s.GetFoodLogsByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(rangeResponse);
+
+            var cut = Render<Food>();
+
+            // The component renders without errors when range data is available
+            cut.Markup.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void RenderChartsAndDataGrid_InRangeMode()
+        {
+            var rangeResponse = new PaginatedResponse<FoodItem>
+            {
+                Items = [CreateFoodItem(calories: 1800, protein: 90, carbs: 200, fat: 60, fiber: 20)],
+                PageNumber = 1,
+                TotalPages = 1,
+                TotalCount = 1,
+                HasPreviousPage = false,
+                HasNextPage = false
+            };
+
+            _mockApiService.Setup(s => s.GetFoodLogByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync((FoodItem?)null);
+            _mockApiService.Setup(s => s.GetFoodLogsByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(rangeResponse);
+
+            var cut = Render<Food>();
+
+            cut.Markup.Should().Contain("Food");
             cut.Markup.Should().NotBeEmpty();
         }
 

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/FoodPageShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/FoodPageShould.cs
@@ -156,7 +156,7 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
 
             // Donut chart for macros and arc gauge for calorie goal
             cut.Markup.Should().Contain("2,500");
-            cut.Markup.Should().Contain("rz-arc-gauge");
+            cut.Markup.Should().Contain("rz-progressbar");
         }
 
         [Fact]

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/HomePageShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/HomePageShould.cs
@@ -2,11 +2,13 @@ using Bunit;
 using Moq;
 using Radzen;
 using Biotrackr.UI.Components.Pages;
+using Biotrackr.UI.Models;
 using Biotrackr.UI.Models.Activity;
 using Biotrackr.UI.Models.Food;
 using Biotrackr.UI.Models.Sleep;
 using Biotrackr.UI.Models.Weight;
 using Biotrackr.UI.Services;
+using Biotrackr.UI.UnitTests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,6 +24,7 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
             Services.AddSingleton(_mockApiService.Object);
             Services.AddRadzenComponents();
             JSInterop.Mode = JSRuntimeMode.Loose;
+            JSInterop.SetupRadzenChartInterop();
         }
 
         [Fact]
@@ -135,7 +138,90 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
 
             var cut = Render<Home>();
 
-            cut.Markup.Should().Contain("BMI: 23.1");
+            cut.Markup.Should().Contain("BMI");
+            cut.Markup.Should().Contain("23.1");
+        }
+
+        [Fact]
+        public void RenderDomainSections_WhenAllDataLoaded()
+        {
+            SetupEmptyApiResponses();
+            SetupEmptyRangeResponses();
+
+            var cut = Render<Home>();
+
+            cut.Markup.Should().Contain("Activity");
+            cut.Markup.Should().Contain("Sleep");
+            cut.Markup.Should().Contain("Weight");
+            cut.Markup.Should().Contain("Food");
+        }
+
+        [Fact]
+        public void RenderTrendCards_WithSparklines_WhenRangeDataAvailable()
+        {
+            SetupEmptyApiResponses();
+            _mockApiService.Setup(s => s.GetActivitiesByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(new PaginatedResponse<ActivityItem>
+                {
+                    Items =
+                    [
+                        new ActivityItem { Date = "2026-03-01", Activity = new ActivityData { Summary = new ActivitySummary { Steps = 8000, CaloriesOut = 2200, FairlyActiveMinutes = 10, VeryActiveMinutes = 20, Floors = 5, RestingHeartRate = 62 }, Goals = new ActivityGoals() } },
+                        new ActivityItem { Date = "2026-03-02", Activity = new ActivityData { Summary = new ActivitySummary { Steps = 9500, CaloriesOut = 2400, FairlyActiveMinutes = 15, VeryActiveMinutes = 25, Floors = 7, RestingHeartRate = 60 }, Goals = new ActivityGoals() } }
+                    ],
+                    TotalCount = 2
+                });
+            SetupEmptyRangeResponses(skipActivity: true);
+
+            var cut = Render<Home>();
+
+            // TrendCard renders sparklines via RadzenSparkline (which extends RadzenChart)
+            cut.Markup.Should().Contain("rz-chart");
+        }
+
+        [Fact]
+        public void RenderDefaultValues_WhenDomainApiFailsSilently()
+        {
+            // Single-day data loads normally
+            _mockApiService.Setup(s => s.GetActivityByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ActivityItem
+                {
+                    Activity = new ActivityData
+                    {
+                        Summary = new ActivitySummary { Steps = 5000 },
+                        Goals = new ActivityGoals()
+                    }
+                });
+            _mockApiService.Setup(s => s.GetFoodLogByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync(new FoodItem());
+            _mockApiService.Setup(s => s.GetSleepByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync(new SleepItem());
+            _mockApiService.Setup(s => s.GetWeightByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync(new WeightItem());
+
+            // Range API throws — trend data should silently degrade
+            _mockApiService.Setup(s => s.GetActivitiesByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ThrowsAsync(new HttpRequestException("API error"));
+            SetupEmptyRangeResponses(skipActivity: true);
+
+            var cut = Render<Home>();
+
+            // Dashboard still renders with single-day data
+            cut.Markup.Should().Contain("5,000");
+            cut.Markup.Should().Contain("Activity");
+        }
+
+        [Fact]
+        public void FetchSevenDayRangeData_OnLoad()
+        {
+            SetupEmptyApiResponses();
+            SetupEmptyRangeResponses();
+
+            var cut = Render<Home>();
+
+            _mockApiService.Verify(s => s.GetActivitiesByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+            _mockApiService.Verify(s => s.GetSleepByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+            _mockApiService.Verify(s => s.GetWeightByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+            _mockApiService.Verify(s => s.GetFoodLogsByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
         }
 
         private void SetupEmptyApiResponses()
@@ -148,6 +234,22 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
                 .ReturnsAsync(new SleepItem());
             _mockApiService.Setup(s => s.GetWeightByDateAsync(It.IsAny<string>()))
                 .ReturnsAsync(new WeightItem());
+        }
+
+        private void SetupEmptyRangeResponses(bool skipActivity = false, bool skipSleep = false, bool skipWeight = false, bool skipFood = false)
+        {
+            if (!skipActivity)
+                _mockApiService.Setup(s => s.GetActivitiesByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                    .ReturnsAsync(new PaginatedResponse<ActivityItem> { Items = [], TotalCount = 0 });
+            if (!skipSleep)
+                _mockApiService.Setup(s => s.GetSleepByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                    .ReturnsAsync(new PaginatedResponse<SleepItem> { Items = [], TotalCount = 0 });
+            if (!skipWeight)
+                _mockApiService.Setup(s => s.GetWeightByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                    .ReturnsAsync(new PaginatedResponse<WeightItem> { Items = [], TotalCount = 0 });
+            if (!skipFood)
+                _mockApiService.Setup(s => s.GetFoodLogsByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                    .ReturnsAsync(new PaginatedResponse<FoodItem> { Items = [], TotalCount = 0 });
         }
     }
 }

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/SleepPageShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/SleepPageShould.cs
@@ -189,7 +189,7 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
 
             // Donut chart for sleep stages and arc gauge for efficiency
             cut.Markup.Should().Contain("Sleep Stages");
-            cut.Markup.Should().Contain("rz-arc-gauge");
+            cut.Markup.Should().Contain("rz-progressbar");
         }
 
         [Fact]

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/SleepPageShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/SleepPageShould.cs
@@ -5,6 +5,7 @@ using Biotrackr.UI.Components.Pages;
 using Biotrackr.UI.Models;
 using Biotrackr.UI.Models.Sleep;
 using Biotrackr.UI.Services;
+using Biotrackr.UI.UnitTests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,6 +21,7 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
             Services.AddSingleton(_mockApiService.Object);
             Services.AddRadzenComponents();
             JSInterop.Mode = JSRuntimeMode.Loose;
+            JSInterop.SetupRadzenChartInterop();
         }
 
         [Fact]
@@ -158,6 +160,89 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
 
             // Range mode uses RadzenSelectBar which cannot be interacted with via bUnit selectors.
             // Verify that the component renders without errors when data is available.
+            cut.Markup.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void RenderCharts_WhenSingleDateDataLoaded()
+        {
+            var sleepItem = CreateSleepItem(minutesAsleep: 420, timeInBed: 480, records: 1);
+            sleepItem.Sleep.Summary.Stages = new SleepStages
+            {
+                Deep = 90,
+                Light = 180,
+                Rem = 100,
+                Wake = 30
+            };
+            sleepItem.Sleep.Sleep.Add(new SleepRecord
+            {
+                IsMainSleep = true,
+                Efficiency = 88,
+                StartTime = DateTime.Now.AddHours(-8),
+                EndTime = DateTime.Now
+            });
+
+            _mockApiService.Setup(s => s.GetSleepByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync(sleepItem);
+
+            var cut = Render<Sleep>();
+
+            // Donut chart for sleep stages and arc gauge for efficiency
+            cut.Markup.Should().Contain("Sleep Stages");
+            cut.Markup.Should().Contain("rz-arc-gauge");
+        }
+
+        [Fact]
+        public void RenderTrendCharts_WhenRangeDateDataLoaded()
+        {
+            var rangeResponse = new PaginatedResponse<SleepItem>
+            {
+                Items =
+                [
+                    CreateSleepItem(minutesAsleep: 400, timeInBed: 450, records: 1),
+                    CreateSleepItem(minutesAsleep: 420, timeInBed: 470, records: 1)
+                ],
+                PageNumber = 1,
+                TotalPages = 1,
+                TotalCount = 2,
+                HasPreviousPage = false,
+                HasNextPage = false
+            };
+            rangeResponse.Items[0].Date = "2026-03-01";
+            rangeResponse.Items[1].Date = "2026-03-02";
+
+            _mockApiService.Setup(s => s.GetSleepByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync((SleepItem?)null);
+            _mockApiService.Setup(s => s.GetSleepByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(rangeResponse);
+
+            var cut = Render<Sleep>();
+
+            // The component renders without errors when range data is available
+            cut.Markup.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void RenderChartsAndDataGrid_InRangeMode()
+        {
+            var rangeResponse = new PaginatedResponse<SleepItem>
+            {
+                Items = [CreateSleepItem(minutesAsleep: 400, timeInBed: 450, records: 1)],
+                PageNumber = 1,
+                TotalPages = 1,
+                TotalCount = 1,
+                HasPreviousPage = false,
+                HasNextPage = false
+            };
+
+            _mockApiService.Setup(s => s.GetSleepByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync((SleepItem?)null);
+            _mockApiService.Setup(s => s.GetSleepByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(rangeResponse);
+
+            var cut = Render<Sleep>();
+
+            cut.Markup.Should().Contain("Sleep");
             cut.Markup.Should().NotBeEmpty();
         }
 

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/WeightPageShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Pages/WeightPageShould.cs
@@ -5,6 +5,7 @@ using Biotrackr.UI.Components.Pages;
 using Biotrackr.UI.Models;
 using Biotrackr.UI.Models.Weight;
 using Biotrackr.UI.Services;
+using Biotrackr.UI.UnitTests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,6 +21,7 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
             Services.AddSingleton(_mockApiService.Object);
             Services.AddRadzenComponents();
             JSInterop.Mode = JSRuntimeMode.Loose;
+            JSInterop.SetupRadzenChartInterop();
         }
 
         [Fact]
@@ -188,6 +190,75 @@ namespace Biotrackr.UI.UnitTests.Components.Pages
 
             // Range mode uses RadzenSelectBar which cannot be interacted with via bUnit selectors.
             // Verify that the component renders without errors when data is available.
+            cut.Markup.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void RenderCharts_WhenSingleDateDataLoaded()
+        {
+            var weightItem = CreateWeightItem(weight: 80, bmi: 22.7, muscleMass: 45.2, fatMass: 15.23, boneMass: 3.1, waterMass: 48.9, visceralFat: 10);
+
+            _mockApiService.Setup(s => s.GetWeightByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync(weightItem);
+
+            var cut = Render<Weight>();
+
+            // Donut chart for body composition
+            cut.Markup.Should().Contain("Body Composition");
+            cut.Markup.Should().Contain("80");
+        }
+
+        [Fact]
+        public void RenderTrendCharts_WhenRangeDateDataLoaded()
+        {
+            var rangeResponse = new PaginatedResponse<WeightItem>
+            {
+                Items =
+                [
+                    CreateWeightItem(weight: 80.5, bmi: 24.5),
+                    CreateWeightItem(weight: 80.2, bmi: 24.4)
+                ],
+                PageNumber = 1,
+                TotalPages = 1,
+                TotalCount = 2,
+                HasPreviousPage = false,
+                HasNextPage = false
+            };
+            rangeResponse.Items[0].Date = "2026-03-01";
+            rangeResponse.Items[1].Date = "2026-03-02";
+
+            _mockApiService.Setup(s => s.GetWeightByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync((WeightItem?)null);
+            _mockApiService.Setup(s => s.GetWeightByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(rangeResponse);
+
+            var cut = Render<Weight>();
+
+            // The component renders without errors when range data is available
+            cut.Markup.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void RenderChartsAndDataGrid_InRangeMode()
+        {
+            var rangeResponse = new PaginatedResponse<WeightItem>
+            {
+                Items = [CreateWeightItem(weight: 81.2, bmi: 25.1)],
+                PageNumber = 1,
+                TotalPages = 1,
+                TotalCount = 1,
+                HasPreviousPage = false,
+                HasNextPage = false
+            };
+
+            _mockApiService.Setup(s => s.GetWeightByDateAsync(It.IsAny<string>()))
+                .ReturnsAsync((WeightItem?)null);
+            _mockApiService.Setup(s => s.GetWeightByDateRangeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(rangeResponse);
+
+            var cut = Render<Weight>();
+
+            cut.Markup.Should().Contain("Weight");
             cut.Markup.Should().NotBeEmpty();
         }
 

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Shared/TrendCardShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Components/Shared/TrendCardShould.cs
@@ -1,0 +1,102 @@
+using Bunit;
+using Biotrackr.UI.Components.Shared;
+using Biotrackr.UI.Models;
+using Biotrackr.UI.UnitTests.Helpers;
+using FluentAssertions;
+using Radzen;
+
+namespace Biotrackr.UI.UnitTests.Components.Shared
+{
+    public class TrendCardShould : BunitContext
+    {
+        public TrendCardShould()
+        {
+            Services.AddRadzenComponents();
+            JSInterop.Mode = JSRuntimeMode.Loose;
+            JSInterop.SetupRadzenChartInterop();
+        }
+
+        [Fact]
+        public void RenderTitle_AndValue()
+        {
+            var cut = Render<TrendCard>(parameters => parameters
+                .Add(p => p.Title, "Steps")
+                .Add(p => p.Value, "10,000"));
+
+            cut.Markup.Should().Contain("Steps");
+            cut.Markup.Should().Contain("10,000");
+        }
+
+        [Fact]
+        public void RenderSparkline_WhenTrendDataProvided()
+        {
+            var trendData = new List<TrendDataPoint>
+            {
+                new() { Date = "2026-03-01", Value = 8000 },
+                new() { Date = "2026-03-02", Value = 9500 },
+                new() { Date = "2026-03-03", Value = 7200 }
+            };
+
+            var cut = Render<TrendCard>(parameters => parameters
+                .Add(p => p.Title, "Steps")
+                .Add(p => p.Value, "9,500")
+                .Add(p => p.TrendData, trendData));
+
+            cut.Markup.Should().Contain("rz-chart");
+        }
+
+        [Fact]
+        public void RenderNoSparkline_WhenTrendDataIsNull()
+        {
+            var cut = Render<TrendCard>(parameters => parameters
+                .Add(p => p.Title, "Steps")
+                .Add(p => p.Value, "10,000")
+                .Add(p => p.TrendData, (IEnumerable<TrendDataPoint>?)null));
+
+            cut.Markup.Should().NotContain("rz-sparkline");
+        }
+
+        [Fact]
+        public void RenderNoSparkline_WhenTrendDataIsEmpty()
+        {
+            var cut = Render<TrendCard>(parameters => parameters
+                .Add(p => p.Title, "Steps")
+                .Add(p => p.Value, "10,000")
+                .Add(p => p.TrendData, new List<TrendDataPoint>()));
+
+            cut.Markup.Should().NotContain("rz-sparkline");
+        }
+
+        [Fact]
+        public void RenderSubtitle_WhenProvided()
+        {
+            var cut = Render<TrendCard>(parameters => parameters
+                .Add(p => p.Title, "Calories")
+                .Add(p => p.Value, "2,500")
+                .Add(p => p.Subtitle, "Goal: 3,000"));
+
+            cut.Markup.Should().Contain("Goal: 3,000");
+        }
+
+        [Fact]
+        public void RenderNoSubtitle_WhenNotProvided()
+        {
+            var cut = Render<TrendCard>(parameters => parameters
+                .Add(p => p.Title, "Steps")
+                .Add(p => p.Value, "10,000"));
+
+            cut.Markup.Should().NotContain("rz-text-caption");
+        }
+
+        [Fact]
+        public void RenderIconContent_WhenProvided()
+        {
+            var cut = Render<TrendCard>(parameters => parameters
+                .Add(p => p.Title, "Steps")
+                .Add(p => p.Value, "1,000")
+                .Add(p => p.IconContent, "<span class=\"test-icon\">icon</span>"));
+
+            cut.Find(".card-icon").InnerHtml.Should().Contain("test-icon");
+        }
+    }
+}

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Helpers/RadzenJsInteropHelper.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Helpers/RadzenJsInteropHelper.cs
@@ -1,0 +1,24 @@
+using Bunit;
+using Radzen.Blazor.Rendering;
+
+namespace Biotrackr.UI.UnitTests.Helpers;
+
+public static class RadzenJsInteropHelper
+{
+    /// <summary>
+    /// Sets up bUnit JSInterop mocks for Radzen Blazor chart and gauge components.
+    /// RadzenChart calls <c>InvokeAsync&lt;Rect&gt;("Radzen.createChart")</c> and
+    /// GaugeBase calls <c>InvokeAsync&lt;Rect&gt;("Radzen.createGauge")</c> during
+    /// OnAfterRenderAsync. Since Rect is a reference type, Loose mode returns null,
+    /// causing NRE when Radzen accesses rect.Width/Height. This sets up planned
+    /// invocations that return non-null Rect instances.
+    /// </summary>
+    public static void SetupRadzenChartInterop(this BunitJSInterop jsInterop)
+    {
+        var defaultRect = new Rect { Width = 300, Height = 300 };
+
+        jsInterop.Setup<Rect>("Radzen.createChart", _ => true).SetResult(defaultRect);
+        jsInterop.Setup<Rect>("Radzen.createGauge", _ => true).SetResult(defaultRect);
+        jsInterop.Setup<Rect>("Radzen.createResizable", _ => true).SetResult(defaultRect);
+    }
+}

--- a/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Services/UserInfoServiceShould.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI.UnitTests/Services/UserInfoServiceShould.cs
@@ -1,0 +1,114 @@
+using System.Text;
+using System.Text.Json;
+using Biotrackr.UI.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Biotrackr.UI.UnitTests.Services
+{
+    public class UserInfoServiceShould
+    {
+        private readonly Mock<ILogger<UserInfoService>> _loggerMock;
+
+        public UserInfoServiceShould()
+        {
+            _loggerMock = new Mock<ILogger<UserInfoService>>();
+        }
+
+        private UserInfoService CreateSut()
+        {
+            return new UserInfoService(_loggerMock.Object);
+        }
+
+        private static string CreateBase64Principal(string? name = null, string? email = null, string? nameIdentifier = null, string? authType = null)
+        {
+            var claims = new List<object>();
+
+            if (name is not null)
+                claims.Add(new { typ = "name", val = name });
+
+            if (email is not null)
+                claims.Add(new { typ = "preferred_username", val = email });
+
+            if (nameIdentifier is not null)
+                claims.Add(new { typ = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", val = nameIdentifier });
+
+            var principal = new { auth_typ = authType ?? "aad", claims };
+            var json = JsonSerializer.Serialize(principal);
+            return Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
+        }
+
+        [Fact]
+        public void GetUserInfo_ShouldReturnDisplayNameAndEmail_WhenClientPrincipalHeaderPresent()
+        {
+            var sut = CreateSut();
+            var context = new DefaultHttpContext();
+            context.Request.Headers["X-MS-CLIENT-PRINCIPAL"] = CreateBase64Principal(
+                name: "Will Velida",
+                email: "will@example.com");
+
+            var result = sut.GetUserInfo(context);
+
+            result.DisplayName.Should().Be("Will Velida");
+            result.Email.Should().Be("will@example.com");
+        }
+
+        [Fact]
+        public void GetUserInfo_ShouldFallbackToClientPrincipalName_WhenFullHeaderInvalid()
+        {
+            var sut = CreateSut();
+            var context = new DefaultHttpContext();
+            context.Request.Headers["X-MS-CLIENT-PRINCIPAL"] = "not-valid-base64!!!";
+            context.Request.Headers["X-MS-CLIENT-PRINCIPAL-NAME"] = "Fallback User";
+
+            var result = sut.GetUserInfo(context);
+
+            result.DisplayName.Should().Be("Fallback User");
+        }
+
+        [Fact]
+        public void GetUserInfo_ShouldReturnDefaults_WhenNoHeadersPresent()
+        {
+            var sut = CreateSut();
+            var context = new DefaultHttpContext();
+
+            var result = sut.GetUserInfo(context);
+
+            result.DisplayName.Should().Be("User");
+            result.Email.Should().Be("");
+        }
+
+        [Fact]
+        public void GetUserInfo_ShouldHandleMalformedBase64_Gracefully()
+        {
+            var sut = CreateSut();
+            var context = new DefaultHttpContext();
+            context.Request.Headers["X-MS-CLIENT-PRINCIPAL"] = "!!!completely-garbage-data@@@";
+
+            var act = () => sut.GetUserInfo(context);
+
+            act.Should().NotThrow();
+            var result = act();
+            result.DisplayName.Should().Be("User");
+        }
+
+        [Fact]
+        public void GetUserInfo_ShouldExtractUserId_WhenNameIdentifierClaimPresent()
+        {
+            var sut = CreateSut();
+            var context = new DefaultHttpContext();
+            context.Request.Headers["X-MS-CLIENT-PRINCIPAL"] = CreateBase64Principal(
+                name: "Will Velida",
+                email: "will@example.com",
+                nameIdentifier: "user-id-12345");
+
+            var result = sut.GetUserInfo(context);
+
+            result.UserId.Should().Be("user-id-12345");
+            result.DisplayName.Should().Be("Will Velida");
+            result.Email.Should().Be("will@example.com");
+        }
+    }
+}

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/App.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/App.razor
@@ -19,6 +19,14 @@
     <ReconnectModal />
     <script src="_content/Radzen.Blazor/Radzen.Blazor.js"></script>
     <script src="@Assets["_framework/blazor.web.js"]"></script>
+    <script>
+        if (!document.cookie.includes('BiotrackrTheme=')) {
+            if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                document.cookie = 'BiotrackrTheme=material-dark;path=/;max-age=31536000;SameSite=Lax';
+                location.reload();
+            }
+        }
+    </script>
 </body>
 
 </html>

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/App.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/App.razor
@@ -22,3 +22,23 @@
 </body>
 
 </html>
+
+@code {
+    [CascadingParameter]
+    private HttpContext? HttpContext { get; set; }
+
+    [Inject]
+    private ThemeService ThemeService { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        if (HttpContext is not null)
+        {
+            var theme = HttpContext.Request.Cookies["BiotrackrTheme"];
+            if (!string.IsNullOrEmpty(theme))
+            {
+                ThemeService.SetTheme(theme, false);
+            }
+        }
+    }
+}

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/App.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/App.razor
@@ -15,7 +15,7 @@
 </head>
 
 <body>
-    <Routes />
+    <Routes @rendermode="InteractiveServer" />
     <ReconnectModal />
     <script src="_content/Radzen.Blazor/Radzen.Blazor.js"></script>
     <script src="@Assets["_framework/blazor.web.js"]"></script>

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Layout/MainLayout.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Layout/MainLayout.razor
@@ -1,16 +1,52 @@
 ﻿@inherits LayoutComponentBase
+@inject IUserInfoService UserInfoService
 
-<RadzenLayout>
+<RadzenLayout style="position: relative;">
     <RadzenHeader>
-        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0" class="rz-p-x-2">
-            <RadzenSidebarToggle Click="@(() => _sidebarExpanded = !_sidebarExpanded)" />
-            <RadzenText Text="Biotrackr" TextStyle="TextStyle.H6" class="rz-m-0 rz-color-white" />
+        <RadzenStack Orientation="Orientation.Horizontal"
+                     AlignItems="AlignItems.Center" Gap="0"
+                     JustifyContent="JustifyContent.SpaceBetween"
+                     class="rz-p-x-2" Style="width: 100%;">
+            <RadzenStack Orientation="Orientation.Horizontal"
+                         AlignItems="AlignItems.Center" Gap="0">
+                <RadzenSidebarToggle Click="@(() => _sidebarExpanded = !_sidebarExpanded)" />
+                <RadzenText Text="Biotrackr" TextStyle="TextStyle.H6"
+                            class="rz-m-0 rz-color-white" />
+            </RadzenStack>
+            <RadzenStack Orientation="Orientation.Horizontal"
+                         AlignItems="AlignItems.Center" Gap="0.5rem">
+                <RadzenAppearanceToggle />
+                <RadzenProfileMenu>
+                    <Template>
+                        <RadzenStack Orientation="Orientation.Horizontal"
+                                     AlignItems="AlignItems.Center" Gap="0.5rem">
+                            <RadzenGravatar Email="@_userInfo.Email" Size="32" />
+                            <RadzenText TextStyle="TextStyle.Body2"
+                                        class="rz-m-0 rz-color-white rz-display-none rz-display-md-block">
+                                @_userInfo.DisplayName
+                            </RadzenText>
+                        </RadzenStack>
+                    </Template>
+                    <ChildContent>
+                        <RadzenProfileMenuItem Text="Profile" Icon="account_circle"
+                                               Style="opacity: 0.5; pointer-events: none;" />
+                        <RadzenProfileMenuItem Text="Sign Out" Icon="logout"
+                                               Path=".auth/logout?post_logout_redirect_uri=/login" />
+                    </ChildContent>
+                </RadzenProfileMenu>
+            </RadzenStack>
         </RadzenStack>
     </RadzenHeader>
 
-    <RadzenSidebar @bind-Expanded="@_sidebarExpanded">
+    <RadzenSidebar @bind-Expanded="@_sidebarExpanded"
+                   Style="position: absolute; z-index: 3;">
         <NavMenu />
     </RadzenSidebar>
+
+    @if (_sidebarExpanded)
+    {
+        <div class="sidebar-overlay" @onclick="@(() => _sidebarExpanded = false)"></div>
+    }
 
     <RadzenBody>
         <div class="rz-p-4">
@@ -22,5 +58,16 @@
 <RadzenComponents @rendermode="InteractiveServer" />
 
 @code {
-    private bool _sidebarExpanded = true;
+    private bool _sidebarExpanded = false;
+    private UserInfo _userInfo = new();
+
+    [Inject] private IHttpContextAccessor HttpContextAccessor { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        if (HttpContextAccessor.HttpContext is not null)
+        {
+            _userInfo = UserInfoService.GetUserInfo(HttpContextAccessor.HttpContext);
+        }
+    }
 }

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Layout/MainLayout.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Layout/MainLayout.razor
@@ -38,15 +38,9 @@
         </RadzenStack>
     </RadzenHeader>
 
-    <RadzenSidebar @bind-Expanded="@_sidebarExpanded"
-                   Style="position: absolute; z-index: 3;">
+    <RadzenSidebar @bind-Expanded="@_sidebarExpanded" Responsive="false">
         <NavMenu />
     </RadzenSidebar>
-
-    @if (_sidebarExpanded)
-    {
-        <div class="sidebar-overlay" @onclick="@(() => _sidebarExpanded = false)"></div>
-    }
 
     <RadzenBody>
         <div class="rz-p-4">
@@ -58,7 +52,7 @@
 <RadzenComponents @rendermode="InteractiveServer" />
 
 @code {
-    private bool _sidebarExpanded = false;
+    private bool _sidebarExpanded = true;
     private UserInfo _userInfo = new();
 
     [Inject] private IHttpContextAccessor HttpContextAccessor { get; set; } = default!;

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Layout/MainLayout.razor.css
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Layout/MainLayout.razor.css
@@ -5,3 +5,21 @@
 ::deep .rz-header {
     background-image: linear-gradient(90deg, rgb(5, 39, 103) 0%, #3a0647 100%);
 }
+
+.sidebar-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 2;
+}
+
+:global(.rz-material-dark) ::deep .rz-sidebar {
+    background-image: linear-gradient(180deg, rgb(15, 55, 130) 0%, #5a1067 70%);
+}
+
+:global(.rz-material-dark) ::deep .rz-header {
+    background-image: linear-gradient(90deg, rgb(15, 55, 130) 0%, #5a1067 100%);
+}

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Layout/MainLayout.razor.css
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Layout/MainLayout.razor.css
@@ -6,16 +6,6 @@
     background-image: linear-gradient(90deg, rgb(5, 39, 103) 0%, #3a0647 100%);
 }
 
-.sidebar-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.4);
-    z-index: 2;
-}
-
 :global(.rz-material-dark) ::deep .rz-sidebar {
     background-image: linear-gradient(180deg, rgb(15, 55, 130) 0%, #5a1067 70%);
 }

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Layout/NavMenu.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Layout/NavMenu.razor
@@ -5,5 +5,4 @@
     <RadzenPanelMenuItem Text="Sleep" Icon="bedtime" Path="sleep" />
     <RadzenPanelMenuItem Text="Weight" Icon="monitor_weight" Path="weight" />
     <RadzenPanelMenuItem Text="Chat" Icon="chat" Path="chat" />
-    <RadzenPanelMenuItem Text="Sign Out" Icon="logout" Path=".auth/logout?post_logout_redirect_uri=/login" />
 </RadzenPanelMenu>

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Activity.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Activity.razor
@@ -33,6 +33,52 @@
         </RadzenColumn>
     </RadzenRow>
 
+    <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Goal Progress</RadzenText>
+    <RadzenRow Gap="1rem" class="rz-mb-4" AlignItems="AlignItems.Center">
+        <RadzenColumn Size="12" SizeMD="6" SizeSM="6">
+            <RadzenStack AlignItems="AlignItems.Center" Gap="0.25rem">
+                <RadzenText TextStyle="TextStyle.Subtitle2">Steps</RadzenText>
+                <RadzenArcGauge Style="width: 200px; height: 200px;">
+                    <RadzenArcGaugeScale Min="0" Max="@(Math.Max(_singleItem.Activity.Goals.Steps, 1))" Step="@(Math.Max(_singleItem.Activity.Goals.Steps / 4, 1))" TickPosition="GaugeTickPosition.Outside">
+                        <RadzenArcGaugeScaleValue Value="@((double)_singleItem.Activity.Summary.Steps)" ShowValue="true" />
+                    </RadzenArcGaugeScale>
+                </RadzenArcGauge>
+            </RadzenStack>
+        </RadzenColumn>
+        <RadzenColumn Size="12" SizeMD="6" SizeSM="6">
+            <RadzenStack AlignItems="AlignItems.Center" Gap="0.25rem">
+                <RadzenText TextStyle="TextStyle.Subtitle2">Calories Burned</RadzenText>
+                <RadzenArcGauge Style="width: 200px; height: 200px;">
+                    <RadzenArcGaugeScale Min="0" Max="@(Math.Max(_singleItem.Activity.Goals.CaloriesOut, 1))" Step="@(Math.Max(_singleItem.Activity.Goals.CaloriesOut / 4, 1))" TickPosition="GaugeTickPosition.Outside">
+                        <RadzenArcGaugeScaleValue Value="@((double)_singleItem.Activity.Summary.CaloriesOut)" ShowValue="true" />
+                    </RadzenArcGaugeScale>
+                </RadzenArcGauge>
+            </RadzenStack>
+        </RadzenColumn>
+    </RadzenRow>
+
+    @if (_singleItem.Activity.Summary.HeartRateZones.Any())
+    {
+        <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Heart Rate Zones Chart</RadzenText>
+        <RadzenChart Style="height: 300px;" class="rz-mb-4">
+            <RadzenBarSeries Data="@_singleItem.Activity.Summary.HeartRateZones" CategoryProperty="Name"
+                ValueProperty="Minutes" Title="Minutes" />
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis>
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+    }
+
+    <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Active Minutes Breakdown</RadzenText>
+    <RadzenChart Style="height: 300px;" class="rz-mb-4">
+        <RadzenBarSeries Data="@GetActiveMinutesBreakdown()" CategoryProperty="Category" ValueProperty="Minutes" Title="Minutes" />
+        <RadzenCategoryAxis Padding="20" />
+        <RadzenValueAxis>
+            <RadzenGridLines Visible="true" />
+        </RadzenValueAxis>
+    </RadzenChart>
+
     @if (_singleItem.Activity.Summary.HeartRateZones.Any())
     {
         <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Heart Rate Zones</RadzenText>
@@ -87,6 +133,45 @@
 
 @if (!_isLoading && _rangeItems is not null && _mode == "range")
 {
+    @if (_rangeItems.Items.Any())
+    {
+        <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Steps Over Time</RadzenText>
+        <RadzenChart Style="height: 300px;" class="rz-mb-4">
+            <RadzenLineSeries Data="@GetRangeStepsData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Steps" Smooth="true" />
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis>
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+
+        <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Resting Heart Rate Over Time</RadzenText>
+        <RadzenChart Style="height: 300px;" class="rz-mb-4">
+            <RadzenLineSeries Data="@GetRangeRestingHrData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Resting HR (bpm)" Smooth="true" />
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis>
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+
+        <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Active Minutes Breakdown Over Time</RadzenText>
+        <RadzenChart Style="height: 300px;" class="rz-mb-4">
+            <RadzenAreaSeries Data="@GetRangeSedentaryData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Sedentary" Smooth="true" />
+            <RadzenAreaSeries Data="@GetRangeLightlyActiveData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Lightly Active" Smooth="true" />
+            <RadzenAreaSeries Data="@GetRangeFairlyActiveData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Fairly Active" Smooth="true" />
+            <RadzenAreaSeries Data="@GetRangeVeryActiveData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Very Active" Smooth="true" />
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis>
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+    }
+
     <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Activity Records</RadzenText>
     <RadzenDataGrid Data="@_rangeItems.Items" TItem="ActivityItem" Density="Density.Compact"
                     AllowPaging="true" PageSize="10" Count="@_rangeItems.TotalCount" LoadData="@OnLoadData" class="rz-mb-4">
@@ -207,4 +292,40 @@
         var ts = TimeSpan.FromMilliseconds(milliseconds);
         return ts.TotalHours >= 1 ? $"{(int)ts.TotalHours}h {ts.Minutes}m" : $"{ts.Minutes}m";
     }
+
+    private record ActiveMinuteItem(string Category, int Minutes);
+
+    private List<ActiveMinuteItem> GetActiveMinutesBreakdown()
+    {
+        var s = _singleItem!.Activity.Summary;
+        return
+        [
+            new("Sedentary", s.SedentaryMinutes),
+            new("Lightly Active", s.LightlyActiveMinutes),
+            new("Fairly Active", s.FairlyActiveMinutes),
+            new("Very Active", s.VeryActiveMinutes)
+        ];
+    }
+
+    private record ChartDataPoint(string Date, double Value);
+
+    private List<ChartDataPoint> GetRangeStepsData() =>
+        _rangeItems!.Items.Select(a => new ChartDataPoint(a.Date, a.Activity.Summary.Steps)).ToList();
+
+    private List<ChartDataPoint> GetRangeRestingHrData() =>
+        _rangeItems!.Items
+            .Where(a => a.Activity.Summary.RestingHeartRate > 0)
+            .Select(a => new ChartDataPoint(a.Date, a.Activity.Summary.RestingHeartRate)).ToList();
+
+    private List<ChartDataPoint> GetRangeSedentaryData() =>
+        _rangeItems!.Items.Select(a => new ChartDataPoint(a.Date, a.Activity.Summary.SedentaryMinutes)).ToList();
+
+    private List<ChartDataPoint> GetRangeLightlyActiveData() =>
+        _rangeItems!.Items.Select(a => new ChartDataPoint(a.Date, a.Activity.Summary.LightlyActiveMinutes)).ToList();
+
+    private List<ChartDataPoint> GetRangeFairlyActiveData() =>
+        _rangeItems!.Items.Select(a => new ChartDataPoint(a.Date, a.Activity.Summary.FairlyActiveMinutes)).ToList();
+
+    private List<ChartDataPoint> GetRangeVeryActiveData() =>
+        _rangeItems!.Items.Select(a => new ChartDataPoint(a.Date, a.Activity.Summary.VeryActiveMinutes)).ToList();
 }

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Activity.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Activity.razor
@@ -133,6 +133,9 @@
 
 @if (!_isLoading && _rangeItems is not null && _mode == "range")
 {
+    <RadzenTabs>
+        <Tabs>
+            <RadzenTabsItem Text="Charts">
     @if (_rangeItems.Items.Any())
     {
         <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Steps Over Time</RadzenText>
@@ -171,7 +174,8 @@
             </RadzenValueAxis>
         </RadzenChart>
     }
-
+            </RadzenTabsItem>
+            <RadzenTabsItem Text="Table">
     <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Activity Records</RadzenText>
     <RadzenDataGrid Data="@_rangeItems.Items" TItem="ActivityItem" Density="Density.Compact"
                     AllowPaging="true" PageSize="10" Count="@_rangeItems.TotalCount" LoadData="@OnLoadData" class="rz-mb-4">
@@ -194,6 +198,9 @@
             </RadzenDataGridColumn>
         </Columns>
     </RadzenDataGrid>
+            </RadzenTabsItem>
+        </Tabs>
+    </RadzenTabs>
 }
 
 @if (!_isLoading && _singleItem is null && _mode == "date" && _errorMessage is null)

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Activity.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Activity.razor
@@ -36,23 +36,15 @@
     <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Goal Progress</RadzenText>
     <RadzenRow Gap="1rem" class="rz-mb-4" AlignItems="AlignItems.Center">
         <RadzenColumn Size="12" SizeMD="6" SizeSM="6">
-            <RadzenStack AlignItems="AlignItems.Center" Gap="0.25rem">
-                <RadzenText TextStyle="TextStyle.Subtitle2">Steps</RadzenText>
-                <RadzenArcGauge Style="width: 200px; height: 200px;">
-                    <RadzenArcGaugeScale Min="0" Max="@(Math.Max(_singleItem.Activity.Goals.Steps, 1))" Step="@(Math.Max(_singleItem.Activity.Goals.Steps / 4, 1))" TickPosition="GaugeTickPosition.Outside">
-                        <RadzenArcGaugeScaleValue Value="@((double)_singleItem.Activity.Summary.Steps)" ShowValue="true" />
-                    </RadzenArcGaugeScale>
-                </RadzenArcGauge>
+            <RadzenStack Gap="0.25rem">
+                <RadzenText TextStyle="TextStyle.Subtitle2">Steps: @_singleItem.Activity.Summary.Steps.ToString("N0") / @_singleItem.Activity.Goals.Steps.ToString("N0")</RadzenText>
+                <RadzenProgressBar Value="@GetGoalPercent(_singleItem.Activity.Summary.Steps, _singleItem.Activity.Goals.Steps)" ShowValue="true" Mode="ProgressBarMode.Determinate" Style="height: 20px;" />
             </RadzenStack>
         </RadzenColumn>
         <RadzenColumn Size="12" SizeMD="6" SizeSM="6">
-            <RadzenStack AlignItems="AlignItems.Center" Gap="0.25rem">
-                <RadzenText TextStyle="TextStyle.Subtitle2">Calories Burned</RadzenText>
-                <RadzenArcGauge Style="width: 200px; height: 200px;">
-                    <RadzenArcGaugeScale Min="0" Max="@(Math.Max(_singleItem.Activity.Goals.CaloriesOut, 1))" Step="@(Math.Max(_singleItem.Activity.Goals.CaloriesOut / 4, 1))" TickPosition="GaugeTickPosition.Outside">
-                        <RadzenArcGaugeScaleValue Value="@((double)_singleItem.Activity.Summary.CaloriesOut)" ShowValue="true" />
-                    </RadzenArcGaugeScale>
-                </RadzenArcGauge>
+            <RadzenStack Gap="0.25rem">
+                <RadzenText TextStyle="TextStyle.Subtitle2">Calories Burned: @_singleItem.Activity.Summary.CaloriesOut.ToString("N0") / @_singleItem.Activity.Goals.CaloriesOut.ToString("N0")</RadzenText>
+                <RadzenProgressBar Value="@GetGoalPercent(_singleItem.Activity.Summary.CaloriesOut, _singleItem.Activity.Goals.CaloriesOut)" ShowValue="true" Mode="ProgressBarMode.Determinate" Style="height: 20px;" />
             </RadzenStack>
         </RadzenColumn>
     </RadzenRow>
@@ -292,6 +284,12 @@
         if (goal == 0) return "";
         var pct = (double)actual / goal * 100;
         return $"{pct:F0}% of {goal:N0} goal";
+    }
+
+    private static double GetGoalPercent(int actual, int goal)
+    {
+        if (goal == 0) return 0;
+        return Math.Min((double)actual / goal * 100, 100);
     }
 
     private static string FormatDuration(long milliseconds)

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Food.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Food.razor
@@ -49,12 +49,9 @@
             {
                 <RadzenColumn Size="12" SizeMD="6" SizeSM="12">
                     <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Calories vs Goal</RadzenText>
-                    <RadzenStack AlignItems="AlignItems.Center">
-                        <RadzenArcGauge Style="width: 200px; height: 200px;">
-                            <RadzenArcGaugeScale Min="0" Max="@((double)_singleItem.Food.Goals.Calories)" Step="@(Math.Max(_singleItem.Food.Goals.Calories / 4, 1))" TickPosition="GaugeTickPosition.Outside">
-                                <RadzenArcGaugeScaleValue Value="@(_singleItem.Food.Summary.Calories)" ShowValue="true" />
-                            </RadzenArcGaugeScale>
-                        </RadzenArcGauge>
+                    <RadzenStack Gap="0.25rem">
+                        <RadzenText TextStyle="TextStyle.Subtitle2">@($"{_singleItem.Food.Summary.Calories:N0} / {_singleItem.Food.Goals.Calories:N0}")</RadzenText>
+                        <RadzenProgressBar Value="@(Math.Min(_singleItem.Food.Summary.Calories / _singleItem.Food.Goals.Calories * 100, 100))" ShowValue="true" Mode="ProgressBarMode.Determinate" Style="height: 20px;" />
                     </RadzenStack>
                 </RadzenColumn>
             }

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Food.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Food.razor
@@ -94,6 +94,9 @@
 
 @if (!_isLoading && _rangeItems is not null && _mode == "range")
 {
+    <RadzenTabs>
+        <Tabs>
+            <RadzenTabsItem Text="Charts">
     @if (_rangeItems.Items.Any())
     {
         <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Calories Over Time</RadzenText>
@@ -125,7 +128,8 @@
             </RadzenValueAxis>
         </RadzenChart>
     }
-
+            </RadzenTabsItem>
+            <RadzenTabsItem Text="Table">
     <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Food Records</RadzenText>
     <RadzenDataGrid Data="@_rangeItems.Items" TItem="FoodItem" Density="Density.Compact"
                     AllowPaging="true" PageSize="10" Count="@_rangeItems.TotalCount" LoadData="@OnLoadData" class="rz-mb-4">
@@ -151,6 +155,9 @@
             </RadzenDataGridColumn>
         </Columns>
     </RadzenDataGrid>
+            </RadzenTabsItem>
+        </Tabs>
+    </RadzenTabs>
 }
 
 @if (!_isLoading && _singleItem is null && _mode == "date" && _errorMessage is null)

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Food.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Food.razor
@@ -35,6 +35,32 @@
         </RadzenColumn>
     </RadzenRow>
 
+    @if (_singleItem.Food?.Summary is not null)
+    {
+        <RadzenRow Gap="1rem" class="rz-mb-4" AlignItems="AlignItems.Center">
+            <RadzenColumn Size="12" SizeMD="6" SizeSM="12">
+                <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Macronutrient Split</RadzenText>
+                <RadzenChart Style="height: 300px;">
+                    <RadzenDonutSeries Data="@GetMacroData()" CategoryProperty="Nutrient"
+                        ValueProperty="Grams" Title="Macronutrients (g)" />
+                </RadzenChart>
+            </RadzenColumn>
+            @if (_singleItem.Food.Goals.Calories > 0)
+            {
+                <RadzenColumn Size="12" SizeMD="6" SizeSM="12">
+                    <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Calories vs Goal</RadzenText>
+                    <RadzenStack AlignItems="AlignItems.Center">
+                        <RadzenArcGauge Style="width: 200px; height: 200px;">
+                            <RadzenArcGaugeScale Min="0" Max="@((double)_singleItem.Food.Goals.Calories)" Step="@(Math.Max(_singleItem.Food.Goals.Calories / 4, 1))" TickPosition="GaugeTickPosition.Outside">
+                                <RadzenArcGaugeScaleValue Value="@(_singleItem.Food.Summary.Calories)" ShowValue="true" />
+                            </RadzenArcGaugeScale>
+                        </RadzenArcGauge>
+                    </RadzenStack>
+                </RadzenColumn>
+            }
+        </RadzenRow>
+    }
+
     @if (_singleItem.Food?.Foods?.Any() == true)
     {
         <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Food Log</RadzenText>
@@ -68,6 +94,38 @@
 
 @if (!_isLoading && _rangeItems is not null && _mode == "range")
 {
+    @if (_rangeItems.Items.Any())
+    {
+        <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Calories Over Time</RadzenText>
+        <RadzenChart Style="height: 300px;" class="rz-mb-4">
+            <RadzenLineSeries Data="@GetRangeCaloriesData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Calories" Smooth="true" />
+            @if (GetRangeGoalLineData().Any())
+            {
+                <RadzenLineSeries Data="@GetRangeGoalLineData()" CategoryProperty="Date" ValueProperty="Value"
+                    Title="Goal" LineType="LineType.Dashed" />
+            }
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis>
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+
+        <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Macronutrients Over Time</RadzenText>
+        <RadzenChart Style="height: 300px;" class="rz-mb-4">
+            <RadzenAreaSeries Data="@GetRangeCarbsData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Carbs" Smooth="true" />
+            <RadzenAreaSeries Data="@GetRangeFatData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Fat" Smooth="true" />
+            <RadzenAreaSeries Data="@GetRangeProteinData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Protein" Smooth="true" />
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis>
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+    }
+
     <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Food Records</RadzenText>
     <RadzenDataGrid Data="@_rangeItems.Items" TItem="FoodItem" Density="Density.Compact"
                     AllowPaging="true" PageSize="10" Count="@_rangeItems.TotalCount" LoadData="@OnLoadData" class="rz-mb-4">
@@ -187,4 +245,38 @@
         var pct = summary.Calories / _singleItem.Food.Goals.Calories * 100;
         return $"{pct:F0}% of {_singleItem.Food.Goals.Calories:N0} goal";
     }
+
+    private record MacroDataPoint(string Nutrient, double Grams);
+
+    private List<MacroDataPoint> GetMacroData()
+    {
+        var s = _singleItem!.Food!.Summary!;
+        return
+        [
+            new("Protein", Math.Round(s.Protein, 1)),
+            new("Carbs", Math.Round(s.Carbs, 1)),
+            new("Fat", Math.Round(s.Fat, 1))
+        ];
+    }
+
+    private record ChartDataPoint(string Date, double Value);
+
+    private List<ChartDataPoint> GetRangeCaloriesData() =>
+        _rangeItems!.Items.Select(f => new ChartDataPoint(f.Date, f.Food?.Summary?.Calories ?? 0)).ToList();
+
+    private List<ChartDataPoint> GetRangeGoalLineData()
+    {
+        var goal = _rangeItems!.Items.FirstOrDefault()?.Food?.Goals?.Calories ?? 0;
+        if (goal == 0) return [];
+        return _rangeItems.Items.Select(f => new ChartDataPoint(f.Date, goal)).ToList();
+    }
+
+    private List<ChartDataPoint> GetRangeCarbsData() =>
+        _rangeItems!.Items.Select(f => new ChartDataPoint(f.Date, f.Food?.Summary?.Carbs ?? 0)).ToList();
+
+    private List<ChartDataPoint> GetRangeFatData() =>
+        _rangeItems!.Items.Select(f => new ChartDataPoint(f.Date, f.Food?.Summary?.Fat ?? 0)).ToList();
+
+    private List<ChartDataPoint> GetRangeProteinData() =>
+        _rangeItems!.Items.Select(f => new ChartDataPoint(f.Date, f.Food?.Summary?.Protein ?? 0)).ToList();
 }

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Home.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Home.razor
@@ -12,82 +12,119 @@
 
 @if (!_isLoading)
 {
+    <RadzenText TextStyle="TextStyle.H5" class="rz-mb-2">Activity</RadzenText>
     <RadzenRow Gap="1rem" class="rz-mb-4">
         <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-            <SummaryCard Title="Steps" Value="@FormatNumber(_activitySummary?.Steps)" CardClass="card-activity">
+            <TrendCard Title="Steps" Value="@FormatNumber(_activitySummary?.Steps)" CardClass="card-activity" TrendData="@_stepsTrend">
                 <IconContent>
                     <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#0d6efd" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M6 2a.5.5 0 0 1 .47.33L10 12.036l1.53-4.208A.5.5 0 0 1 12 7.5h3.5a.5.5 0 0 1 0 1h-3.15l-1.88 5.17a.5.5 0 0 1-.94 0L6 3.964 4.47 8.171A.5.5 0 0 1 4 8.5H.5a.5.5 0 0 1 0-1h3.15l1.88-5.17A.5.5 0 0 1 6 2Z"/>
                     </svg>
                 </IconContent>
-            </SummaryCard>
+            </TrendCard>
         </RadzenColumn>
         <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-            <SummaryCard Title="Calories Burned" Value="@FormatNumber(_activitySummary?.CaloriesOut)" Subtitle="@GetCalorieGoalText()" CardClass="card-calories">
+            <TrendCard Title="Calories Burned" Value="@FormatNumber(_activitySummary?.CaloriesOut)" Subtitle="@GetCalorieGoalText()" CardClass="card-calories" TrendData="@_caloriesBurnedTrend">
                 <IconContent>
                     <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#dc3545" viewBox="0 0 16 16">
                         <path d="M8 16c3.314 0 6-2.686 6-6 0-2.61-1.72-4.865-3.313-6.558A26 26 0 0 0 8 1.02a26 26 0 0 0-2.687 2.422C3.72 5.135 2 7.39 2 10c0 3.314 2.686 6 6 6M6.5 10a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0"/>
                     </svg>
                 </IconContent>
-            </SummaryCard>
+            </TrendCard>
         </RadzenColumn>
         <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-            <SummaryCard Title="Calories Consumed" Value="@FormatCalories(_foodSummary?.Calories)" Subtitle="@GetFoodGoalText()" CardClass="card-food">
-                <IconContent>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#198754" viewBox="0 0 16 16">
-                        <path d="M2.5 13.5A.5.5 0 0 1 3 13h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zM13.991 3l.024.001a1.46 1.46 0 0 1 .538.143.757.757 0 0 1 .302.254c.067.1.145.277.145.602v.669a.72.72 0 0 1-.038.258.67.67 0 0 1-.1.18c-.07.08-.164.15-.283.207a.86.86 0 0 1-.382.104h-.001c-.16.006-.32-.012-.478-.04a4.7 4.7 0 0 1-.36-.09c-.172-.05-.324-.115-.464-.197a2.3 2.3 0 0 1-.118-.08l-.012-.009a.6.6 0 0 1-.1-.112A4 4 0 0 0 8 3.5a4 4 0 0 0-4.664.895.6.6 0 0 1-.1.112l-.012.009a2.3 2.3 0 0 1-.118.08c-.14.082-.292.147-.464.197a4.7 4.7 0 0 1-.36.09c-.158.028-.318.046-.478.04h-.001a.86.86 0 0 1-.382-.104.67.67 0 0 1-.283-.207.72.72 0 0 1-.1-.18A.72.72 0 0 1 1 4.669V4c0-.325.078-.502.145-.602a.757.757 0 0 1 .302-.254A1.46 1.46 0 0 1 1.985 3L2.01 3zM1 6a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-.1a3 3 0 0 0-.4 1.475c-.1.476-.2 1.007-.406 1.465-.206.458-.504.876-.979 1.06H3.384c-.475-.184-.773-.602-.978-1.06a8 8 0 0 1-.407-1.465A3 3 0 0 0 1.6 7.5H1.5A.5.5 0 0 1 1 7V6z"/>
-                    </svg>
-                </IconContent>
-            </SummaryCard>
-        </RadzenColumn>
-        <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-            <SummaryCard Title="Sleep" Value="@FormatSleepDuration()" CardClass="card-sleep">
-                <IconContent>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#6f42c1" viewBox="0 0 16 16">
-                        <path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/>
-                    </svg>
-                </IconContent>
-            </SummaryCard>
-        </RadzenColumn>
-    </RadzenRow>
-
-    <RadzenRow Gap="1rem" class="rz-mb-4">
-        <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-            <SummaryCard Title="Weight" Value="@FormatWeight()" Subtitle="@GetBmiText()" CardClass="card-weight">
-                <IconContent>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#fd7e14" viewBox="0 0 16 16">
-                        <path d="M8 1a2 2 0 0 1 2 2v.5H6V3a2 2 0 0 1 2-2m3 2.5V3a3 3 0 1 0-6 0v.5H1.5A.5.5 0 0 0 1 4v1.419l.027.058.054.127c.05.114.124.27.225.467.201.395.516.904.958 1.407C3.16 8.494 4.475 9.5 6.5 9.5c.673 0 1.27-.116 1.79-.318a.5.5 0 1 1 .38.926A5.6 5.6 0 0 1 6.5 10.5c-2.35 0-3.87-1.168-4.813-2.25A10.3 10.3 0 0 1 .618 6.5H.5v8a.5.5 0 0 0 .5.5h14a.5.5 0 0 0 .5-.5v-8h-.118q-.149.232-.354.492c-.526.636-1.32 1.41-2.4 2.04a.5.5 0 1 1-.51-.858C13.487 7.47 14.2 6.794 14.66 6.24c.231-.28.397-.524.505-.72a4 4 0 0 0 .173-.37L15.5 5V4a.5.5 0 0 0-.5-.5z"/>
-                    </svg>
-                </IconContent>
-            </SummaryCard>
-        </RadzenColumn>
-        <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-            <SummaryCard Title="Active Minutes" Value="@FormatActiveMinutes()" Subtitle="@GetActiveMinutesGoalText()" CardClass="card-active">
+            <TrendCard Title="Active Minutes" Value="@FormatActiveMinutes()" Subtitle="@GetActiveMinutesGoalText()" CardClass="card-active" TrendData="@_activeMinutesTrend">
                 <IconContent>
                     <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#20c997" viewBox="0 0 16 16">
                         <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71z"/>
                         <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0"/>
                     </svg>
                 </IconContent>
-            </SummaryCard>
+            </TrendCard>
         </RadzenColumn>
         <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-            <SummaryCard Title="Resting Heart Rate" Value="@FormatHeartRate()" Subtitle="bpm" CardClass="card-heart">
+            <TrendCard Title="Resting Heart Rate" Value="@FormatHeartRate()" Subtitle="bpm" CardClass="card-heart" TrendData="@_restingHrTrend">
                 <IconContent>
                     <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#e91e63" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314"/>
                     </svg>
                 </IconContent>
-            </SummaryCard>
+            </TrendCard>
         </RadzenColumn>
         <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-            <SummaryCard Title="Floors" Value="@FormatNumber(_activitySummary?.Floors)" Subtitle="@GetFloorsGoalText()" CardClass="card-floors">
+            <TrendCard Title="Floors" Value="@FormatNumber(_activitySummary?.Floors)" Subtitle="@GetFloorsGoalText()" CardClass="card-floors" TrendData="@_floorsTrend">
                 <IconContent>
                     <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#6610f2" viewBox="0 0 16 16">
                         <path d="M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.414a.5.5 0 1 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M3.757 4.464a.5.5 0 0 1-.707 0L1.636 3.05a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707"/>
                     </svg>
                 </IconContent>
-            </SummaryCard>
+            </TrendCard>
+        </RadzenColumn>
+    </RadzenRow>
+
+    <RadzenText TextStyle="TextStyle.H5" class="rz-mb-2">Sleep</RadzenText>
+    <RadzenRow Gap="1rem" class="rz-mb-4">
+        <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
+            <TrendCard Title="Sleep Duration" Value="@FormatSleepDuration()" CardClass="card-sleep" TrendData="@_sleepDurationTrend">
+                <IconContent>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#6f42c1" viewBox="0 0 16 16">
+                        <path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/>
+                    </svg>
+                </IconContent>
+            </TrendCard>
+        </RadzenColumn>
+        <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
+            <TrendCard Title="Sleep Efficiency" Value="@FormatSleepEfficiency()" Subtitle="%" CardClass="card-sleep" TrendData="@_sleepEfficiencyTrend">
+                <IconContent>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#6f42c1" viewBox="0 0 16 16">
+                        <path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/>
+                    </svg>
+                </IconContent>
+            </TrendCard>
+        </RadzenColumn>
+    </RadzenRow>
+
+    <RadzenText TextStyle="TextStyle.H5" class="rz-mb-2">Weight</RadzenText>
+    <RadzenRow Gap="1rem" class="rz-mb-4">
+        <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
+            <TrendCard Title="Weight" Value="@FormatWeight()" CardClass="card-weight" TrendData="@_weightTrend">
+                <IconContent>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#fd7e14" viewBox="0 0 16 16">
+                        <path d="M8 1a2 2 0 0 1 2 2v.5H6V3a2 2 0 0 1 2-2m3 2.5V3a3 3 0 1 0-6 0v.5H1.5A.5.5 0 0 0 1 4v1.419l.027.058.054.127c.05.114.124.27.225.467.201.395.516.904.958 1.407C3.16 8.494 4.475 9.5 6.5 9.5c.673 0 1.27-.116 1.79-.318a.5.5 0 1 1 .38.926A5.6 5.6 0 0 1 6.5 10.5c-2.35 0-3.87-1.168-4.813-2.25A10.3 10.3 0 0 1 .618 6.5H.5v8a.5.5 0 0 0 .5.5h14a.5.5 0 0 0 .5-.5v-8h-.118q-.149.232-.354.492c-.526.636-1.32 1.41-2.4 2.04a.5.5 0 1 1-.51-.858C13.487 7.47 14.2 6.794 14.66 6.24c.231-.28.397-.524.505-.72a4 4 0 0 0 .173-.37L15.5 5V4a.5.5 0 0 0-.5-.5z"/>
+                    </svg>
+                </IconContent>
+            </TrendCard>
+        </RadzenColumn>
+        <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
+            <TrendCard Title="BMI" Value="@FormatBmi()" CardClass="card-weight" TrendData="@_bmiTrend">
+                <IconContent>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#fd7e14" viewBox="0 0 16 16">
+                        <path d="M8 1a2 2 0 0 1 2 2v.5H6V3a2 2 0 0 1 2-2m3 2.5V3a3 3 0 1 0-6 0v.5H1.5A.5.5 0 0 0 1 4v1.419l.027.058.054.127c.05.114.124.27.225.467.201.395.516.904.958 1.407C3.16 8.494 4.475 9.5 6.5 9.5c.673 0 1.27-.116 1.79-.318a.5.5 0 1 1 .38.926A5.6 5.6 0 0 1 6.5 10.5c-2.35 0-3.87-1.168-4.813-2.25A10.3 10.3 0 0 1 .618 6.5H.5v8a.5.5 0 0 0 .5.5h14a.5.5 0 0 0 .5-.5v-8h-.118q-.149.232-.354.492c-.526.636-1.32 1.41-2.4 2.04a.5.5 0 1 1-.51-.858C13.487 7.47 14.2 6.794 14.66 6.24c.231-.28.397-.524.505-.72a4 4 0 0 0 .173-.37L15.5 5V4a.5.5 0 0 0-.5-.5z"/>
+                    </svg>
+                </IconContent>
+            </TrendCard>
+        </RadzenColumn>
+    </RadzenRow>
+
+    <RadzenText TextStyle="TextStyle.H5" class="rz-mb-2">Food</RadzenText>
+    <RadzenRow Gap="1rem" class="rz-mb-4">
+        <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
+            <TrendCard Title="Calories Consumed" Value="@FormatCalories(_foodSummary?.Calories)" Subtitle="@GetFoodGoalText()" CardClass="card-food" TrendData="@_caloriesConsumedTrend">
+                <IconContent>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#198754" viewBox="0 0 16 16">
+                        <path d="M2.5 13.5A.5.5 0 0 1 3 13h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zM13.991 3l.024.001a1.46 1.46 0 0 1 .538.143.757.757 0 0 1 .302.254c.067.1.145.277.145.602v.669a.72.72 0 0 1-.038.258.67.67 0 0 1-.1.18c-.07.08-.164.15-.283.207a.86.86 0 0 1-.382.104h-.001c-.16.006-.32-.012-.478-.04a4.7 4.7 0 0 1-.36-.09c-.172-.05-.324-.115-.464-.197a2.3 2.3 0 0 1-.118-.08l-.012-.009a.6.6 0 0 1-.1-.112A4 4 0 0 0 8 3.5a4 4 0 0 0-4.664.895.6.6 0 0 1-.1.112l-.012.009a2.3 2.3 0 0 1-.118.08c-.14.082-.292.147-.464.197a4.7 4.7 0 0 1-.36.09c-.158.028-.318.046-.478.04h-.001a.86.86 0 0 1-.382-.104.67.67 0 0 1-.283-.207.72.72 0 0 1-.1-.18A.72.72 0 0 1 1 4.669V4c0-.325.078-.502.145-.602a.757.757 0 0 1 .302-.254A1.46 1.46 0 0 1 1.985 3L2.01 3zM1 6a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-.1a3 3 0 0 0-.4 1.475c-.1.476-.2 1.007-.406 1.465-.206.458-.504.876-.979 1.06H3.384c-.475-.184-.773-.602-.978-1.06a8 8 0 0 1-.407-1.465A3 3 0 0 0 1.6 7.5H1.5A.5.5 0 0 1 1 7V6z"/>
+                    </svg>
+                </IconContent>
+            </TrendCard>
+        </RadzenColumn>
+        <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
+            <TrendCard Title="Protein" Value="@FormatProtein()" CardClass="card-food" TrendData="@_proteinTrend">
+                <IconContent>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#198754" viewBox="0 0 16 16">
+                        <path d="M2.5 13.5A.5.5 0 0 1 3 13h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zM13.991 3l.024.001a1.46 1.46 0 0 1 .538.143.757.757 0 0 1 .302.254c.067.1.145.277.145.602v.669a.72.72 0 0 1-.038.258.67.67 0 0 1-.1.18c-.07.08-.164.15-.283.207a.86.86 0 0 1-.382.104h-.001c-.16.006-.32-.012-.478-.04a4.7 4.7 0 0 1-.36-.09c-.172-.05-.324-.115-.464-.197a2.3 2.3 0 0 1-.118-.08l-.012-.009a.6.6 0 0 1-.1-.112A4 4 0 0 0 8 3.5a4 4 0 0 0-4.664.895.6.6 0 0 1-.1.112l-.012.009a2.3 2.3 0 0 1-.118.08c-.14.082-.292.147-.464.197a4.7 4.7 0 0 1-.36.09c-.158.028-.318.046-.478.04h-.001a.86.86 0 0 1-.382-.104.67.67 0 0 1-.283-.207.72.72 0 0 1-.1-.18A.72.72 0 0 1 1 4.669V4c0-.325.078-.502.145-.602a.757.757 0 0 1 .302-.254A1.46 1.46 0 0 1 1.985 3L2.01 3zM1 6a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-.1a3 3 0 0 0-.4 1.475c-.1.476-.2 1.007-.406 1.465-.206.458-.504.876-.979 1.06H3.384c-.475-.184-.773-.602-.978-1.06a8 8 0 0 1-.407-1.465A3 3 0 0 0 1.6 7.5H1.5A.5.5 0 0 1 1 7V6z"/>
+                    </svg>
+                </IconContent>
+            </TrendCard>
         </RadzenColumn>
     </RadzenRow>
 }
@@ -103,6 +140,19 @@
     private SleepSummary? _sleepSummary;
     private WeightData? _latestWeight;
 
+    // Trend data (7-day sparklines)
+    private List<TrendDataPoint>? _stepsTrend;
+    private List<TrendDataPoint>? _caloriesBurnedTrend;
+    private List<TrendDataPoint>? _activeMinutesTrend;
+    private List<TrendDataPoint>? _restingHrTrend;
+    private List<TrendDataPoint>? _floorsTrend;
+    private List<TrendDataPoint>? _sleepDurationTrend;
+    private List<TrendDataPoint>? _sleepEfficiencyTrend;
+    private List<TrendDataPoint>? _weightTrend;
+    private List<TrendDataPoint>? _bmiTrend;
+    private List<TrendDataPoint>? _caloriesConsumedTrend;
+    private List<TrendDataPoint>? _proteinTrend;
+
     protected override async Task OnInitializedAsync()
     {
         await LoadTodayData();
@@ -116,13 +166,22 @@
         try
         {
             var today = DateOnly.FromDateTime(DateTime.Today.AddDays(-1)).ToString("yyyy-MM-dd");
+            var sevenDaysAgo = DateOnly.FromDateTime(DateTime.Today.AddDays(-8)).ToString("yyyy-MM-dd");
 
+            // Single-day data
             var activityTask = ApiService.GetActivityByDateAsync(today);
             var foodTask = ApiService.GetFoodLogByDateAsync(today);
             var sleepTask = ApiService.GetSleepByDateAsync(today);
             var weightTask = ApiService.GetWeightByDateAsync(today);
 
-            await Task.WhenAll(activityTask, foodTask, sleepTask, weightTask);
+            // 7-day trend data (each domain has own error handling)
+            var activityTrendTask = LoadActivityTrendsAsync(sevenDaysAgo, today);
+            var sleepTrendTask = LoadSleepTrendsAsync(sevenDaysAgo, today);
+            var weightTrendTask = LoadWeightTrendsAsync(sevenDaysAgo, today);
+            var foodTrendTask = LoadFoodTrendsAsync(sevenDaysAgo, today);
+
+            await Task.WhenAll(activityTask, foodTask, sleepTask, weightTask,
+                activityTrendTask, sleepTrendTask, weightTrendTask, foodTrendTask);
 
             var activity = await activityTask;
             _activitySummary = activity?.Activity?.Summary;
@@ -148,6 +207,74 @@
         }
     }
 
+    private async Task LoadActivityTrendsAsync(string from, string to)
+    {
+        try
+        {
+            var result = await ApiService.GetActivitiesByDateRangeAsync(from, to, 1, 100);
+            if (result?.Items is { Count: > 0 })
+            {
+                var ordered = result.Items.OrderBy(a => a.Date).ToList();
+                _stepsTrend = ordered.Select(a => new TrendDataPoint { Date = a.Date, Value = a.Activity.Summary.Steps }).ToList();
+                _caloriesBurnedTrend = ordered.Select(a => new TrendDataPoint { Date = a.Date, Value = a.Activity.Summary.CaloriesOut }).ToList();
+                _activeMinutesTrend = ordered.Select(a => new TrendDataPoint { Date = a.Date, Value = a.Activity.Summary.FairlyActiveMinutes + a.Activity.Summary.VeryActiveMinutes }).ToList();
+                _restingHrTrend = ordered.Where(a => a.Activity.Summary.RestingHeartRate > 0).Select(a => new TrendDataPoint { Date = a.Date, Value = a.Activity.Summary.RestingHeartRate }).ToList();
+                _floorsTrend = ordered.Select(a => new TrendDataPoint { Date = a.Date, Value = a.Activity.Summary.Floors }).ToList();
+            }
+        }
+        catch { /* silent degradation */ }
+    }
+
+    private async Task LoadSleepTrendsAsync(string from, string to)
+    {
+        try
+        {
+            var result = await ApiService.GetSleepByDateRangeAsync(from, to, 1, 100);
+            if (result?.Items is { Count: > 0 })
+            {
+                var ordered = result.Items.OrderBy(s => s.Date).ToList();
+                _sleepDurationTrend = ordered
+                    .Select(s => new TrendDataPoint { Date = s.Date, Value = s.Sleep.Summary.TotalMinutesAsleep / 60.0 })
+                    .ToList();
+                _sleepEfficiencyTrend = ordered
+                    .Where(s => s.Sleep.Summary.TotalTimeInBed > 0)
+                    .Select(s => new TrendDataPoint { Date = s.Date, Value = Math.Round((double)s.Sleep.Summary.TotalMinutesAsleep / s.Sleep.Summary.TotalTimeInBed * 100, 0) })
+                    .ToList();
+            }
+        }
+        catch { /* silent degradation */ }
+    }
+
+    private async Task LoadWeightTrendsAsync(string from, string to)
+    {
+        try
+        {
+            var result = await ApiService.GetWeightByDateRangeAsync(from, to, 1, 100);
+            if (result?.Items is { Count: > 0 })
+            {
+                var ordered = result.Items.OrderBy(w => w.Date).ToList();
+                _weightTrend = ordered.Where(w => w.Weight.Weight > 0).Select(w => new TrendDataPoint { Date = w.Date, Value = w.Weight.Weight }).ToList();
+                _bmiTrend = ordered.Where(w => w.Weight.Bmi > 0).Select(w => new TrendDataPoint { Date = w.Date, Value = w.Weight.Bmi }).ToList();
+            }
+        }
+        catch { /* silent degradation */ }
+    }
+
+    private async Task LoadFoodTrendsAsync(string from, string to)
+    {
+        try
+        {
+            var result = await ApiService.GetFoodLogsByDateRangeAsync(from, to, 1, 100);
+            if (result?.Items is { Count: > 0 })
+            {
+                var ordered = result.Items.OrderBy(f => f.Date).ToList();
+                _caloriesConsumedTrend = ordered.Select(f => new TrendDataPoint { Date = f.Date, Value = f.Food.Summary.Calories }).ToList();
+                _proteinTrend = ordered.Select(f => new TrendDataPoint { Date = f.Date, Value = f.Food.Summary.Protein }).ToList();
+            }
+        }
+        catch { /* silent degradation */ }
+    }
+
     private static string FormatNumber(int? value) => value.HasValue ? value.Value.ToString("N0") : "--";
     private static string FormatCalories(double? value) => value.HasValue ? ((int)value.Value).ToString("N0") : "--";
 
@@ -159,16 +286,23 @@
         return $"{hours}h {mins}m";
     }
 
+    private string FormatSleepEfficiency()
+    {
+        if (_sleepSummary is null || _sleepSummary.TotalTimeInBed == 0) return "--";
+        var efficiency = (double)_sleepSummary.TotalMinutesAsleep / _sleepSummary.TotalTimeInBed * 100;
+        return $"{efficiency:F0}";
+    }
+
     private string FormatWeight()
     {
         if (_latestWeight is null || _latestWeight.Weight == 0) return "--";
         return $"{_latestWeight.Weight:F1} kg";
     }
 
-    private string GetBmiText()
+    private string FormatBmi()
     {
-        if (_latestWeight is null || _latestWeight.Bmi == 0) return "";
-        return $"BMI: {_latestWeight.Bmi:F1}";
+        if (_latestWeight is null || _latestWeight.Bmi == 0) return "--";
+        return $"{_latestWeight.Bmi:F1}";
     }
 
     private string FormatActiveMinutes()
@@ -182,6 +316,12 @@
     {
         if (_activitySummary is null || _activitySummary.RestingHeartRate == 0) return "--";
         return _activitySummary.RestingHeartRate.ToString();
+    }
+
+    private string FormatProtein()
+    {
+        if (_foodSummary is null) return "--";
+        return $"{_foodSummary.Protein:F0}g";
     }
 
     private string GetCalorieGoalText()

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Home.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Home.razor
@@ -15,7 +15,7 @@
     <RadzenText TextStyle="TextStyle.H5" class="rz-mb-2">Activity</RadzenText>
     <RadzenRow Gap="1rem" class="rz-mb-4">
         <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-            <TrendCard Title="Steps" Value="@FormatNumber(_activitySummary?.Steps)" CardClass="card-activity" TrendData="@_stepsTrend">
+            <TrendCard Title="Steps" Value="@FormatNumber(_activitySummary?.Steps)" CardClass="card-activity" TrendData="@_stepsTrend" GaugeValue="@(_activitySummary?.Steps ?? 0)" GaugeMax="@(_activityGoals?.Steps ?? 0)">
                 <IconContent>
                     <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#0d6efd" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M6 2a.5.5 0 0 1 .47.33L10 12.036l1.53-4.208A.5.5 0 0 1 12 7.5h3.5a.5.5 0 0 1 0 1h-3.15l-1.88 5.17a.5.5 0 0 1-.94 0L6 3.964 4.47 8.171A.5.5 0 0 1 4 8.5H.5a.5.5 0 0 1 0-1h3.15l1.88-5.17A.5.5 0 0 1 6 2Z"/>
@@ -24,7 +24,7 @@
             </TrendCard>
         </RadzenColumn>
         <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-            <TrendCard Title="Calories Burned" Value="@FormatNumber(_activitySummary?.CaloriesOut)" Subtitle="@GetCalorieGoalText()" CardClass="card-calories" TrendData="@_caloriesBurnedTrend">
+            <TrendCard Title="Calories Burned" Value="@FormatNumber(_activitySummary?.CaloriesOut)" Subtitle="@GetCalorieGoalText()" CardClass="card-calories" TrendData="@_caloriesBurnedTrend" GaugeValue="@(_activitySummary?.CaloriesOut ?? 0)" GaugeMax="@(_activityGoals?.CaloriesOut ?? 0)">
                 <IconContent>
                     <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#dc3545" viewBox="0 0 16 16">
                         <path d="M8 16c3.314 0 6-2.686 6-6 0-2.61-1.72-4.865-3.313-6.558A26 26 0 0 0 8 1.02a26 26 0 0 0-2.687 2.422C3.72 5.135 2 7.39 2 10c0 3.314 2.686 6 6 6M6.5 10a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0"/>
@@ -109,7 +109,7 @@
     <RadzenText TextStyle="TextStyle.H5" class="rz-mb-2">Food</RadzenText>
     <RadzenRow Gap="1rem" class="rz-mb-4">
         <RadzenColumn Size="12" SizeMD="3" SizeSM="6">
-            <TrendCard Title="Calories Consumed" Value="@FormatCalories(_foodSummary?.Calories)" Subtitle="@GetFoodGoalText()" CardClass="card-food" TrendData="@_caloriesConsumedTrend">
+            <TrendCard Title="Calories Consumed" Value="@FormatCalories(_foodSummary?.Calories)" Subtitle="@GetFoodGoalText()" CardClass="card-food" TrendData="@_caloriesConsumedTrend" GaugeValue="@(_foodSummary?.Calories ?? 0)" GaugeMax="@(_foodGoals?.Calories ?? 0)">
                 <IconContent>
                     <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#198754" viewBox="0 0 16 16">
                         <path d="M2.5 13.5A.5.5 0 0 1 3 13h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zM13.991 3l.024.001a1.46 1.46 0 0 1 .538.143.757.757 0 0 1 .302.254c.067.1.145.277.145.602v.669a.72.72 0 0 1-.038.258.67.67 0 0 1-.1.18c-.07.08-.164.15-.283.207a.86.86 0 0 1-.382.104h-.001c-.16.006-.32-.012-.478-.04a4.7 4.7 0 0 1-.36-.09c-.172-.05-.324-.115-.464-.197a2.3 2.3 0 0 1-.118-.08l-.012-.009a.6.6 0 0 1-.1-.112A4 4 0 0 0 8 3.5a4 4 0 0 0-4.664.895.6.6 0 0 1-.1.112l-.012.009a2.3 2.3 0 0 1-.118.08c-.14.082-.292.147-.464.197a4.7 4.7 0 0 1-.36.09c-.158.028-.318.046-.478.04h-.001a.86.86 0 0 1-.382-.104.67.67 0 0 1-.283-.207.72.72 0 0 1-.1-.18A.72.72 0 0 1 1 4.669V4c0-.325.078-.502.145-.602a.757.757 0 0 1 .302-.254A1.46 1.46 0 0 1 1.985 3L2.01 3zM1 6a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-.1a3 3 0 0 0-.4 1.475c-.1.476-.2 1.007-.406 1.465-.206.458-.504.876-.979 1.06H3.384c-.475-.184-.773-.602-.978-1.06a8 8 0 0 1-.407-1.465A3 3 0 0 0 1.6 7.5H1.5A.5.5 0 0 1 1 7V6z"/>

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Sleep.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Sleep.razor
@@ -42,12 +42,9 @@
         }
         <RadzenColumn Size="12" SizeMD="6" SizeSM="12">
             <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Sleep Efficiency</RadzenText>
-            <RadzenStack AlignItems="AlignItems.Center">
-                <RadzenArcGauge Style="width: 200px; height: 200px;">
-                    <RadzenArcGaugeScale Min="0" Max="100" Step="25" TickPosition="GaugeTickPosition.Outside">
-                        <RadzenArcGaugeScaleValue Value="@GetEfficiencyValue()" ShowValue="true" />
-                    </RadzenArcGaugeScale>
-                </RadzenArcGauge>
+            <RadzenStack Gap="0.25rem">
+                <RadzenText TextStyle="TextStyle.Subtitle2">@($"{GetEfficiencyValue():F0}%")</RadzenText>
+                <RadzenProgressBar Value="@GetEfficiencyValue()" ShowValue="false" Mode="ProgressBarMode.Determinate" Style="height: 20px;" />
             </RadzenStack>
         </RadzenColumn>
     </RadzenRow>

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Sleep.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Sleep.razor
@@ -87,6 +87,19 @@
         </RadzenRow>
     }
 
+    @if (_hypnogramData is not null && _hypnogramData.Any())
+    {
+        <RadzenText TextStyle="TextStyle.Subtitle1" class="rz-mb-2">Sleep Timeline</RadzenText>
+        <RadzenChart Style="height: 200px;" class="rz-mb-4">
+            <RadzenAreaSeries Data="@_hypnogramData" CategoryProperty="Time" ValueProperty="Level"
+                Smooth="false" StrokeWidth="1" Title="Sleep Stage" />
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis Min="0" Max="3">
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+    }
+
     @if (_singleItem.Sleep.Sleep.Any())
     {
         <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Sleep Logs</RadzenText>
@@ -122,6 +135,9 @@
 
 @if (!_isLoading && _rangeItems is not null && _mode == "range")
 {
+    <RadzenTabs>
+        <Tabs>
+            <RadzenTabsItem Text="Charts">
     @if (_rangeItems.Items.Any())
     {
         <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Sleep Duration Over Time</RadzenText>
@@ -160,7 +176,8 @@
             </RadzenValueAxis>
         </RadzenChart>
     }
-
+            </RadzenTabsItem>
+            <RadzenTabsItem Text="Table">
     <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Sleep Records</RadzenText>
     <RadzenDataGrid Data="@_rangeItems.Items" TItem="SleepItem" Density="Density.Compact"
                     AllowPaging="true" PageSize="10" Count="@_rangeItems.TotalCount" LoadData="@OnLoadData" class="rz-mb-4">
@@ -189,6 +206,9 @@
             </RadzenDataGridColumn>
         </Columns>
     </RadzenDataGrid>
+            </RadzenTabsItem>
+        </Tabs>
+    </RadzenTabs>
 }
 
 @if (!_isLoading && _singleItem is null && _mode == "date" && _errorMessage is null)
@@ -207,6 +227,9 @@
 
     private SleepItem? _singleItem;
     private PaginatedResponse<SleepItem>? _rangeItems;
+    private List<HypnogramPoint>? _hypnogramData;
+
+    private record HypnogramPoint(string Time, int Level);
 
     protected override async Task OnInitializedAsync()
     {
@@ -220,10 +243,22 @@
         _isLoading = true;
         _errorMessage = null;
         _singleItem = null;
+        _hypnogramData = null;
 
         try
         {
             _singleItem = await ApiService.GetSleepByDateAsync(date);
+
+            var mainSleep = _singleItem?.Sleep?.Sleep?.FirstOrDefault(r => r.IsMainSleep);
+            if (mainSleep?.Levels?.Data is { Count: > 0 })
+            {
+                _hypnogramData = mainSleep.Levels.Data
+                    .OrderBy(d => d.DateTime)
+                    .Select(d => new HypnogramPoint(
+                        d.DateTime.ToString("HH:mm"),
+                        d.Level switch { "wake" => 3, "rem" => 2, "light" => 1, "deep" => 0, _ => 0 }))
+                    .ToList();
+            }
         }
         catch (Exception)
         {

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Sleep.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Sleep.razor
@@ -29,6 +29,29 @@
         </RadzenColumn>
     </RadzenRow>
 
+    <RadzenRow Gap="1rem" class="rz-mb-4" AlignItems="AlignItems.Center">
+        @if (_singleItem.Sleep.Summary.Stages is not null)
+        {
+            <RadzenColumn Size="12" SizeMD="6" SizeSM="12">
+                <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Sleep Stages</RadzenText>
+                <RadzenChart Style="height: 300px;">
+                    <RadzenDonutSeries Data="@GetSleepStagesData()" CategoryProperty="Stage"
+                        ValueProperty="Minutes" Title="Sleep Stages" />
+                </RadzenChart>
+            </RadzenColumn>
+        }
+        <RadzenColumn Size="12" SizeMD="6" SizeSM="12">
+            <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Sleep Efficiency</RadzenText>
+            <RadzenStack AlignItems="AlignItems.Center">
+                <RadzenArcGauge Style="width: 200px; height: 200px;">
+                    <RadzenArcGaugeScale Min="0" Max="100" Step="25" TickPosition="GaugeTickPosition.Outside">
+                        <RadzenArcGaugeScaleValue Value="@GetEfficiencyValue()" ShowValue="true" />
+                    </RadzenArcGaugeScale>
+                </RadzenArcGauge>
+            </RadzenStack>
+        </RadzenColumn>
+    </RadzenRow>
+
     @if (_singleItem.Sleep.Summary.Stages is not null)
     {
         <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Sleep Stages</RadzenText>
@@ -99,6 +122,45 @@
 
 @if (!_isLoading && _rangeItems is not null && _mode == "range")
 {
+    @if (_rangeItems.Items.Any())
+    {
+        <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Sleep Duration Over Time</RadzenText>
+        <RadzenChart Style="height: 300px;" class="rz-mb-4">
+            <RadzenLineSeries Data="@GetRangeDurationData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Hours Asleep" Smooth="true" />
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis>
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+
+        <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Sleep Efficiency Over Time</RadzenText>
+        <RadzenChart Style="height: 300px;" class="rz-mb-4">
+            <RadzenLineSeries Data="@GetRangeEfficiencyData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Efficiency %" Smooth="true" />
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis>
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+
+        <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Sleep Stages Over Time</RadzenText>
+        <RadzenChart Style="height: 300px;" class="rz-mb-4">
+            <RadzenAreaSeries Data="@GetRangeDeepData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Deep" Smooth="true" />
+            <RadzenAreaSeries Data="@GetRangeLightData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Light" Smooth="true" />
+            <RadzenAreaSeries Data="@GetRangeRemData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="REM" Smooth="true" />
+            <RadzenAreaSeries Data="@GetRangeWakeData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Awake" Smooth="true" />
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis>
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+    }
+
     <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Sleep Records</RadzenText>
     <RadzenDataGrid Data="@_rangeItems.Items" TItem="SleepItem" Density="Density.Compact"
                     AllowPaging="true" PageSize="10" Count="@_rangeItems.TotalCount" LoadData="@OnLoadData" class="rz-mb-4">
@@ -226,6 +288,48 @@
         var mainSleep = _singleItem?.Sleep.Sleep.FirstOrDefault(s => s.IsMainSleep);
         return mainSleep is not null ? $"{mainSleep.Efficiency}%" : "--";
     }
+
+    private double GetEfficiencyValue()
+    {
+        var mainSleep = _singleItem?.Sleep.Sleep.FirstOrDefault(s => s.IsMainSleep);
+        return mainSleep?.Efficiency ?? 0;
+    }
+
+    private record SleepStageDataPoint(string Stage, int Minutes);
+
+    private List<SleepStageDataPoint> GetSleepStagesData()
+    {
+        var stages = _singleItem!.Sleep.Summary.Stages;
+        return
+        [
+            new("Deep", stages.Deep),
+            new("Light", stages.Light),
+            new("REM", stages.Rem),
+            new("Awake", stages.Wake)
+        ];
+    }
+
+    private record ChartDataPoint(string Date, double Value);
+
+    private List<ChartDataPoint> GetRangeDurationData() =>
+        _rangeItems!.Items.Select(s => new ChartDataPoint(s.Date, Math.Round(s.Sleep.Summary.TotalMinutesAsleep / 60.0, 1))).ToList();
+
+    private List<ChartDataPoint> GetRangeEfficiencyData() =>
+        _rangeItems!.Items
+            .Where(s => s.Sleep.Sleep.Any(r => r.IsMainSleep))
+            .Select(s => new ChartDataPoint(s.Date, s.Sleep.Sleep.First(r => r.IsMainSleep).Efficiency)).ToList();
+
+    private List<ChartDataPoint> GetRangeDeepData() =>
+        _rangeItems!.Items.Select(s => new ChartDataPoint(s.Date, s.Sleep.Summary.Stages?.Deep ?? 0)).ToList();
+
+    private List<ChartDataPoint> GetRangeLightData() =>
+        _rangeItems!.Items.Select(s => new ChartDataPoint(s.Date, s.Sleep.Summary.Stages?.Light ?? 0)).ToList();
+
+    private List<ChartDataPoint> GetRangeRemData() =>
+        _rangeItems!.Items.Select(s => new ChartDataPoint(s.Date, s.Sleep.Summary.Stages?.Rem ?? 0)).ToList();
+
+    private List<ChartDataPoint> GetRangeWakeData() =>
+        _rangeItems!.Items.Select(s => new ChartDataPoint(s.Date, s.Sleep.Summary.Stages?.Wake ?? 0)).ToList();
 
     private int GetStageHeight(int minutes)
     {

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Weight.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Weight.razor
@@ -69,6 +69,15 @@
                     </RadzenColumn>
                 }
             </RadzenRow>
+
+            @if (GetBodyCompositionData().Any())
+            {
+                <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Body Composition</RadzenText>
+                <RadzenChart Style="height: 300px;" class="rz-mb-4">
+                    <RadzenDonutSeries Data="@GetBodyCompositionData()" CategoryProperty="Component"
+                        ValueProperty="Mass" Title="Body Composition (kg)" />
+                </RadzenChart>
+            }
         }
     }
     else
@@ -79,6 +88,42 @@
 
 @if (!_isLoading && _rangeItems is not null && _mode == "range")
 {
+    @if (_rangeItems.Items.Any())
+    {
+        <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Weight Over Time</RadzenText>
+        <RadzenChart Style="height: 300px;" class="rz-mb-4">
+            <RadzenLineSeries Data="@GetRangeWeightData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="Weight (kg)" Smooth="true" />
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis>
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+
+        <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">BMI Over Time</RadzenText>
+        <RadzenChart Style="height: 300px;" class="rz-mb-4">
+            <RadzenLineSeries Data="@GetRangeBmiData()" CategoryProperty="Date" ValueProperty="Value"
+                Title="BMI" Smooth="true" />
+            <RadzenCategoryAxis Padding="20" />
+            <RadzenValueAxis>
+                <RadzenGridLines Visible="true" />
+            </RadzenValueAxis>
+        </RadzenChart>
+
+        @if (GetRangeBodyFatData().Any())
+        {
+            <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Body Fat % Over Time</RadzenText>
+            <RadzenChart Style="height: 300px;" class="rz-mb-4">
+                <RadzenLineSeries Data="@GetRangeBodyFatData()" CategoryProperty="Date" ValueProperty="Value"
+                    Title="Body Fat %" Smooth="true" />
+                <RadzenCategoryAxis Padding="20" />
+                <RadzenValueAxis>
+                    <RadzenGridLines Visible="true" />
+                </RadzenValueAxis>
+            </RadzenChart>
+        }
+    }
+
     <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Weight Records</RadzenText>
     <RadzenDataGrid Data="@_rangeItems.Items" TItem="WeightItem" Density="Density.Compact"
                     AllowPaging="true" PageSize="10" Count="@_rangeItems.TotalCount" LoadData="@OnLoadData" class="rz-mb-4">
@@ -203,4 +248,28 @@
         if (bmi < 30.0) return "Overweight";
         return "Obese";
     }
+
+    private record BodyCompositionItem(string Component, double Mass);
+
+    private List<BodyCompositionItem> GetBodyCompositionData()
+    {
+        var w = _singleItem!.Weight;
+        var items = new List<BodyCompositionItem>();
+        if (w.FatMassKg is not null) items.Add(new("Fat", w.FatMassKg.Value));
+        if (w.MuscleMassKg is not null) items.Add(new("Muscle", w.MuscleMassKg.Value));
+        if (w.BoneMassKg is not null) items.Add(new("Bone", w.BoneMassKg.Value));
+        if (w.WaterMassKg is not null) items.Add(new("Water", w.WaterMassKg.Value));
+        return items;
+    }
+
+    private record ChartDataPoint(string Date, double Value);
+
+    private List<ChartDataPoint> GetRangeWeightData() =>
+        _rangeItems!.Items.Where(w => w.Weight.Weight > 0).Select(w => new ChartDataPoint(w.Date, w.Weight.Weight)).ToList();
+
+    private List<ChartDataPoint> GetRangeBmiData() =>
+        _rangeItems!.Items.Where(w => w.Weight.Bmi > 0).Select(w => new ChartDataPoint(w.Date, Math.Round(w.Weight.Bmi, 1))).ToList();
+
+    private List<ChartDataPoint> GetRangeBodyFatData() =>
+        _rangeItems!.Items.Where(w => w.Weight.Fat > 0).Select(w => new ChartDataPoint(w.Date, Math.Round(w.Weight.Fat, 1))).ToList();
 }

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Weight.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Pages/Weight.razor
@@ -88,6 +88,9 @@
 
 @if (!_isLoading && _rangeItems is not null && _mode == "range")
 {
+    <RadzenTabs>
+        <Tabs>
+            <RadzenTabsItem Text="Charts">
     @if (_rangeItems.Items.Any())
     {
         <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Weight Over Time</RadzenText>
@@ -123,7 +126,8 @@
             </RadzenChart>
         }
     }
-
+            </RadzenTabsItem>
+            <RadzenTabsItem Text="Table">
     <RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Weight Records</RadzenText>
     <RadzenDataGrid Data="@_rangeItems.Items" TItem="WeightItem" Density="Density.Compact"
                     AllowPaging="true" PageSize="10" Count="@_rangeItems.TotalCount" LoadData="@OnLoadData" class="rz-mb-4">
@@ -155,6 +159,9 @@
             </RadzenDataGridColumn>
         </Columns>
     </RadzenDataGrid>
+            </RadzenTabsItem>
+        </Tabs>
+    </RadzenTabs>
 }
 
 @if (!_isLoading && _singleItem is null && _mode == "date" && _errorMessage is null)

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Shared/TrendCard.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Shared/TrendCard.razor
@@ -19,6 +19,14 @@
                 <RadzenCategoryAxis Visible="false" Padding="-20" />
             </RadzenSparkline>
         }
+        @if (GaugeMax > 0)
+        {
+            <RadzenArcGauge Style="width: 100%; height: 60px;">
+                <RadzenArcGaugeScale Min="0" Max="@GaugeMax">
+                    <RadzenArcGaugeScaleValue Value="@GaugeValue" ShowValue="false" />
+                </RadzenArcGaugeScale>
+            </RadzenArcGauge>
+        }
     </RadzenStack>
 </RadzenCard>
 
@@ -29,4 +37,6 @@
     [Parameter] public string? CardClass { get; set; }
     [Parameter] public RenderFragment? IconContent { get; set; }
     [Parameter] public IEnumerable<TrendDataPoint>? TrendData { get; set; }
+    [Parameter] public double GaugeValue { get; set; }
+    [Parameter] public double GaugeMax { get; set; }
 }

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Shared/TrendCard.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Shared/TrendCard.razor
@@ -1,0 +1,32 @@
+<RadzenCard class="@($"rz-h-100 summary-card {CardClass}")">
+    <RadzenStack Orientation="Orientation.Vertical"
+                 AlignItems="AlignItems.Center" Gap="0.25rem">
+        @if (IconContent is not null)
+        {
+            <div class="card-icon">@IconContent</div>
+        }
+        <RadzenText TextStyle="TextStyle.Overline" class="rz-color-secondary">@Title</RadzenText>
+        <RadzenText TextStyle="TextStyle.H5" class="rz-mb-0">@Value</RadzenText>
+        @if (!string.IsNullOrEmpty(Subtitle))
+        {
+            <RadzenText TextStyle="TextStyle.Caption" class="rz-color-secondary">@Subtitle</RadzenText>
+        }
+        @if (TrendData is not null && TrendData.Any())
+        {
+            <RadzenSparkline Style="width: 100%; height: 40px;">
+                <RadzenAreaSeries Smooth="true" Data="@TrendData"
+                    CategoryProperty="Date" ValueProperty="Value" />
+                <RadzenCategoryAxis Visible="false" Padding="-20" />
+            </RadzenSparkline>
+        }
+    </RadzenStack>
+</RadzenCard>
+
+@code {
+    [Parameter] public string Title { get; set; } = "";
+    [Parameter] public string Value { get; set; } = "";
+    [Parameter] public string? Subtitle { get; set; }
+    [Parameter] public string? CardClass { get; set; }
+    [Parameter] public RenderFragment? IconContent { get; set; }
+    [Parameter] public IEnumerable<TrendDataPoint>? TrendData { get; set; }
+}

--- a/src/Biotrackr.UI/Biotrackr.UI/Components/Shared/TrendCard.razor
+++ b/src/Biotrackr.UI/Biotrackr.UI/Components/Shared/TrendCard.razor
@@ -21,11 +21,9 @@
         }
         @if (GaugeMax > 0)
         {
-            <RadzenArcGauge Style="width: 100%; height: 60px;">
-                <RadzenArcGaugeScale Min="0" Max="@GaugeMax">
-                    <RadzenArcGaugeScaleValue Value="@GaugeValue" ShowValue="false" />
-                </RadzenArcGaugeScale>
-            </RadzenArcGauge>
+            <RadzenProgressBar Value="@(Math.Min(GaugeValue / GaugeMax * 100, 100))"
+                               ShowValue="true" Mode="ProgressBarMode.Determinate"
+                               Style="width: 100%; height: 8px;" class="rz-mt-1" />
         }
     </RadzenStack>
 </RadzenCard>

--- a/src/Biotrackr.UI/Biotrackr.UI/Models/TrendDataPoint.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI/Models/TrendDataPoint.cs
@@ -1,0 +1,7 @@
+namespace Biotrackr.UI.Models;
+
+public class TrendDataPoint
+{
+    public string Date { get; set; } = "";
+    public double Value { get; set; }
+}

--- a/src/Biotrackr.UI/Biotrackr.UI/Models/UserInfo.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI/Models/UserInfo.cs
@@ -1,0 +1,9 @@
+namespace Biotrackr.UI.Models;
+
+public class UserInfo
+{
+    public string DisplayName { get; set; } = "User";
+    public string Email { get; set; } = "";
+    public string UserId { get; set; } = "";
+    public string IdentityProvider { get; set; } = "";
+}

--- a/src/Biotrackr.UI/Biotrackr.UI/Program.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI/Program.cs
@@ -32,6 +32,13 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddRadzenComponents();
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<IUserInfoService, UserInfoService>();
+builder.Services.AddRadzenCookieThemeService(options =>
+{
+    options.Name = "BiotrackrTheme";
+    options.Duration = TimeSpan.FromDays(365);
+});
 
 var appInsightsConnectionString = builder.Configuration["applicationinsightsconnectionstring"];
 

--- a/src/Biotrackr.UI/Biotrackr.UI/Services/IUserInfoService.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI/Services/IUserInfoService.cs
@@ -1,0 +1,9 @@
+using Biotrackr.UI.Models;
+using Microsoft.AspNetCore.Http;
+
+namespace Biotrackr.UI.Services;
+
+public interface IUserInfoService
+{
+    UserInfo GetUserInfo(HttpContext httpContext);
+}

--- a/src/Biotrackr.UI/Biotrackr.UI/Services/UserInfoService.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI/Services/UserInfoService.cs
@@ -1,0 +1,74 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Biotrackr.UI.Models;
+using Microsoft.AspNetCore.Http;
+
+namespace Biotrackr.UI.Services;
+
+public class UserInfoService(ILogger<UserInfoService> logger) : IUserInfoService
+{
+    public UserInfo GetUserInfo(HttpContext httpContext)
+    {
+        var userInfo = new UserInfo();
+
+        try
+        {
+            var principalHeader = httpContext.Request.Headers["X-MS-CLIENT-PRINCIPAL"].FirstOrDefault();
+
+            if (!string.IsNullOrEmpty(principalHeader))
+            {
+                var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(principalHeader));
+                var principal = JsonSerializer.Deserialize<ClientPrincipal>(decoded);
+
+                if (principal?.Claims is not null)
+                {
+                    userInfo.DisplayName = GetClaimValue(principal.Claims, "name") ?? "User";
+                    userInfo.Email = GetClaimValue(principal.Claims, "preferred_username")
+                        ?? GetClaimValue(principal.Claims, "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")
+                        ?? "";
+                    userInfo.UserId = GetClaimValue(principal.Claims, "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier") ?? "";
+                    userInfo.IdentityProvider = principal.AuthType ?? "";
+
+                    return userInfo;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to parse X-MS-CLIENT-PRINCIPAL header");
+        }
+
+        // Fallback to X-MS-CLIENT-PRINCIPAL-NAME
+        var principalName = httpContext.Request.Headers["X-MS-CLIENT-PRINCIPAL-NAME"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(principalName))
+        {
+            userInfo.DisplayName = principalName;
+        }
+
+        return userInfo;
+    }
+
+    private static string? GetClaimValue(List<ClientPrincipalClaim> claims, string claimType)
+    {
+        return claims.FirstOrDefault(c => c.Type == claimType)?.Value;
+    }
+
+    private sealed record ClientPrincipal
+    {
+        [JsonPropertyName("auth_typ")]
+        public string? AuthType { get; init; }
+
+        [JsonPropertyName("claims")]
+        public List<ClientPrincipalClaim>? Claims { get; init; }
+    }
+
+    private sealed record ClientPrincipalClaim
+    {
+        [JsonPropertyName("typ")]
+        public string? Type { get; init; }
+
+        [JsonPropertyName("val")]
+        public string? Value { get; init; }
+    }
+}

--- a/src/Biotrackr.UI/Biotrackr.UI/wwwroot/app.css
+++ b/src/Biotrackr.UI/Biotrackr.UI/wwwroot/app.css
@@ -338,4 +338,57 @@
         max-width: 85%;
     }
 }
+
+/* Dark mode overrides */
+.rz-material-dark .chat-main {
+    background-color: #1e1e1e;
+}
+
+.rz-material-dark .message-agent {
+    background-color: #2d2d2d;
+    color: #e0e0e0;
+}
+
+.rz-material-dark .chat-input-area {
+    background-color: #2d2d2d;
+    border-top-color: #444;
+}
+
+.rz-material-dark .chat-empty-state {
+    color: #999;
+}
+
+.rz-material-dark .markdown-body th,
+.rz-material-dark .markdown-body td {
+    border-color: #444;
+}
+
+.rz-material-dark .markdown-body th {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.rz-material-dark .markdown-body code {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.rz-material-dark .markdown-body pre {
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.rz-material-dark .markdown-body blockquote {
+    border-left-color: #555;
+    color: #999;
+}
+
+.rz-material-dark .markdown-body hr {
+    border-top-color: #444;
+}
+
+.rz-material-dark .chat-sidebar-item-date {
+    color: #aaa;
+}
+
+.rz-material-dark .summary-card:hover {
+    box-shadow: 0 4px 12px rgba(255, 255, 255, 0.1);
+}
 /* trigger rebuild */


### PR DESCRIPTION
## Summary

Enhance the Biotrackr Blazor Server UI with dashboard trend sparklines, per-domain data visualizations, responsive sidebar overlay, user profile menu, and light/dark mode toggle using Radzen Blazor components.

## Changes

### Dashboard Trends
- Replaced 2×4 SummaryCard grid on Home page with 4 domain-grouped sections (Activity, Sleep, Weight, Food)
- Each section uses new `TrendCard` component with embedded `RadzenSparkline` showing 7-day trends
- Fetches date range data via 4 parallel API calls with silent degradation on failure

### Domain Page Charts
- **Activity**: Arc gauges (Steps/Calories vs Goal), HR zones bar chart, active minutes bar (single day); steps, resting HR, and active minutes line/area charts (range)
- **Sleep**: Sleep stages donut, efficiency gauge (single day); duration, efficiency, and stages line/stacked area charts (range)
- **Weight**: Body composition donut — conditional on data availability (single day); weight, BMI, and body fat line charts (range)
- **Food**: Macronutrient donut, calorie gauge (single day); calories line with goal reference, macro stacked area (range)

### Responsive Layout
- Replaced push sidebar with overlay pattern (`position: absolute; z-index: 3`)
- Added click-to-dismiss mask when sidebar is open
- Sidebar starts collapsed

### User Profile
- Created `UserInfoService` to parse Azure EasyAuth `X-MS-CLIENT-PRINCIPAL` header with fallback to `X-MS-CLIENT-PRINCIPAL-NAME`
- Added `RadzenProfileMenu` in header with Gravatar and display name
- Moved Sign Out from nav menu to profile dropdown

### Light/Dark Mode
- Added `RadzenAppearanceToggle` in header (auto-maps material ↔ material-dark)
- Registered `RadzenCookieThemeService` for cross-session persistence
- SSR theme cookie reading in `App.razor` to prevent flash of wrong theme
- Dark-mode gradient overrides for header/sidebar

## Files Changed

**8 added, 14 modified** — all scoped to `src/Biotrackr.UI/`

### New Files
| File | Purpose |
|------|---------|
| `Models/UserInfo.cs` | User identity model |
| `Models/TrendDataPoint.cs` | Sparkline data binding model |
| `Services/IUserInfoService.cs` | Interface |
| `Services/UserInfoService.cs` | EasyAuth header parser |
| `Components/Shared/TrendCard.razor` | SummaryCard + RadzenSparkline |
| `UnitTests/Helpers/RadzenJsInteropHelper.cs` | bUnit JS mock for Radzen charts |
| `UnitTests/Services/UserInfoServiceShould.cs` | 5 service tests |
| `UnitTests/Components/Shared/TrendCardShould.cs` | 7 component tests |

### Modified Files
- `Program.cs` — 3 service registrations
- `MainLayout.razor` — Full overhaul (overlay sidebar + profile menu + theme toggle)
- `MainLayout.razor.css` — Overlay mask + dark-mode gradients
- `NavMenu.razor` — Removed Sign Out
- `App.razor` — SSR theme cookie
- `Home.razor` — Domain-grouped TrendCards with 7-day data
- `Activity.razor`, `Sleep.razor`, `Weight.razor`, `Food.razor` — Chart additions
- 6 test files updated with chart rendering tests + Radzen JS mock setup

## Testing

- **171 tests pass**, 0 failures, 0 skipped
- `dotnet build` — 0 errors, 0 warnings
- New: 12 tests (5 UserInfoService + 7 TrendCard)
- Updated: 16 chart rendering tests across domain pages + NavMenu assertion fix

## Dependencies

No new NuGet packages — uses existing Radzen.Blazor v9.1.0. No backend API changes.