### PR TITLE
feat: add historical sleep data backfill via env vars

### DIFF
--- a/infra/apps/sleep-service/main.bicep
+++ b/infra/apps/sleep-service/main.bicep
@@ -82,6 +82,14 @@ module sleepService '../../modules/host/container-app-jobs.bicep' = {
         name: 'cosmosdbendpoint'
         value: cosmosDbAccount.properties.documentEndpoint
       }
+      {
+        name: 'BackfillStartDate'
+        value: '2017-02-20'
+      }
+      {
+        name: 'BackfillEndDate'
+        value: '2024-12-14'
+      }
     ]
     imageName: imageName 
     uaiName: uai.name

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/ServiceTests/FitbitServiceShould.cs
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/ServiceTests/FitbitServiceShould.cs
@@ -154,5 +154,54 @@ namespace Biotrackr.Sleep.Svc.UnitTests.ServiceTests
             await act.Should().ThrowAsync<Exception>();
             _mockLogger.VerifyLog(logger => logger.LogError($"Exception thrown in GetSleepResponse: {exceptionMessage}"));
         }
+
+        [Fact]
+        public async Task GetSleepResponseByDateRange_ShouldReturnSleepResponse_WhenSuccessful()
+        {
+            // Arrange
+            var startDate = "2023-10-01";
+            var endDate = "2023-10-31";
+            var accessToken = "testAccessToken";
+            var fixture = new Fixture();
+            var expectedResponse = fixture.Create<SleepResponse>();
+
+            _mockSecretClient.Setup(s => s.GetSecretAsync("AccessToken", null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Response.FromValue(new KeyVaultSecret("AccessToken", accessToken), Mock.Of<Response>()));
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(JsonSerializer.Serialize(expectedResponse))
+                });
+
+            // Act
+            var result = await _fitbitService.GetSleepResponseByDateRange(startDate, endDate);
+
+            // Assert
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Fact]
+        public async Task GetSleepResponseByDateRange_ShouldLogErrorAndThrow_WhenExceptionOccurs()
+        {
+            // Arrange
+            var startDate = "2023-10-01";
+            var endDate = "2023-10-31";
+            var exceptionMessage = "Test exception";
+
+            _mockSecretClient.Setup(s => s.GetSecretAsync("AccessToken", null, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception(exceptionMessage));
+
+            // Act
+            Func<Task> act = async () => await _fitbitService.GetSleepResponseByDateRange(startDate, endDate);
+
+            // Assert
+            await act.Should().ThrowAsync<Exception>();
+            _mockLogger.VerifyLog(logger => logger.LogError($"Exception thrown in GetSleepResponseByDateRange: {exceptionMessage}"));
+        }
     }
 }

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/WorkerTests/SleepWorkerShould.cs
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc.UnitTests/WorkerTests/SleepWorkerShould.cs
@@ -145,5 +145,161 @@ namespace Biotrackr.Sleep.Svc.UnitTests.WorkerTests
                 x => x.StopApplication(),
                 Times.Once);
         }
+
+        [Fact]
+        public async Task ExecuteAsync_ShouldRunBackfill_WhenEnvVarsAreSet()
+        {
+            try
+            {
+                // Arrange
+                Environment.SetEnvironmentVariable("BackfillStartDate", "2024-01-01");
+                Environment.SetEnvironmentVariable("BackfillEndDate", "2024-01-10");
+
+                var sleepResponse = new SleepResponse
+                {
+                    Sleep = new List<Biotrackr.Sleep.Svc.Models.FitbitEntities.Sleep>
+                    {
+                        new Biotrackr.Sleep.Svc.Models.FitbitEntities.Sleep { DateOfSleep = "2024-01-01" },
+                        new Biotrackr.Sleep.Svc.Models.FitbitEntities.Sleep { DateOfSleep = "2024-01-02" },
+                        new Biotrackr.Sleep.Svc.Models.FitbitEntities.Sleep { DateOfSleep = "2024-01-03" }
+                    }
+                };
+
+                _mockFitbitService
+                    .Setup(x => x.GetSleepResponseByDateRange(It.IsAny<string>(), It.IsAny<string>()))
+                    .ReturnsAsync(sleepResponse);
+
+                _mockSleepService
+                    .Setup(x => x.MapAndSaveDocument(It.IsAny<string>(), It.IsAny<SleepResponse>()))
+                    .Returns(Task.CompletedTask);
+
+                var worker = new SleepWorker(
+                    _mockFitbitService.Object,
+                    _mockSleepService.Object,
+                    _mockLogger.Object,
+                    _mockAppLifetime.Object);
+
+                var cancellationTokenSource = new CancellationTokenSource();
+
+                // Act
+                await worker.StartAsync(cancellationTokenSource.Token);
+                await Task.Delay(200);
+
+                // Assert
+                _mockFitbitService.Verify(
+                    x => x.GetSleepResponseByDateRange(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+
+                _mockFitbitService.Verify(
+                    x => x.GetSleepResponse(It.IsAny<string>()),
+                    Times.Never);
+
+                _mockSleepService.Verify(
+                    x => x.MapAndSaveDocument(It.IsAny<string>(), It.IsAny<SleepResponse>()),
+                    Times.Exactly(3));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("BackfillStartDate", null);
+                Environment.SetEnvironmentVariable("BackfillEndDate", null);
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ShouldRunSingleDay_WhenNoEnvVars()
+        {
+            try
+            {
+                // Arrange
+                Environment.SetEnvironmentVariable("BackfillStartDate", null);
+                Environment.SetEnvironmentVariable("BackfillEndDate", null);
+
+                var expectedDate = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd");
+                var sleepResponse = _fixture.Create<SleepResponse>();
+
+                _mockFitbitService
+                    .Setup(x => x.GetSleepResponse(expectedDate))
+                    .ReturnsAsync(sleepResponse);
+
+                _mockSleepService
+                    .Setup(x => x.MapAndSaveDocument(expectedDate, sleepResponse))
+                    .Returns(Task.CompletedTask);
+
+                var worker = new SleepWorker(
+                    _mockFitbitService.Object,
+                    _mockSleepService.Object,
+                    _mockLogger.Object,
+                    _mockAppLifetime.Object);
+
+                var cancellationTokenSource = new CancellationTokenSource();
+
+                // Act
+                await worker.StartAsync(cancellationTokenSource.Token);
+                await Task.Delay(100);
+
+                // Assert
+                _mockFitbitService.Verify(
+                    x => x.GetSleepResponse(It.Is<string>(d => d == expectedDate)),
+                    Times.Once);
+
+                _mockFitbitService.Verify(
+                    x => x.GetSleepResponseByDateRange(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Never);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("BackfillStartDate", null);
+                Environment.SetEnvironmentVariable("BackfillEndDate", null);
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ShouldProcessMultipleChunks_WhenDateRangeExceeds100Days()
+        {
+            try
+            {
+                // Arrange — 150-day range requires 2 chunks
+                Environment.SetEnvironmentVariable("BackfillStartDate", "2024-01-01");
+                Environment.SetEnvironmentVariable("BackfillEndDate", "2024-05-30");
+
+                var sleepResponse = new SleepResponse
+                {
+                    Sleep = new List<Biotrackr.Sleep.Svc.Models.FitbitEntities.Sleep>
+                    {
+                        new Biotrackr.Sleep.Svc.Models.FitbitEntities.Sleep { DateOfSleep = "2024-01-15" }
+                    }
+                };
+
+                _mockFitbitService
+                    .Setup(x => x.GetSleepResponseByDateRange(It.IsAny<string>(), It.IsAny<string>()))
+                    .ReturnsAsync(sleepResponse);
+
+                _mockSleepService
+                    .Setup(x => x.MapAndSaveDocument(It.IsAny<string>(), It.IsAny<SleepResponse>()))
+                    .Returns(Task.CompletedTask);
+
+                var worker = new SleepWorker(
+                    _mockFitbitService.Object,
+                    _mockSleepService.Object,
+                    _mockLogger.Object,
+                    _mockAppLifetime.Object);
+
+                var cancellationTokenSource = new CancellationTokenSource();
+
+                // Act
+                await worker.StartAsync(cancellationTokenSource.Token);
+                await Task.Delay(1500); // Allow time for 500ms delay between chunks
+
+                // Assert — 150 days = 2 chunks (100 + 50)
+                _mockFitbitService.Verify(
+                    x => x.GetSleepResponseByDateRange(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Exactly(2));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("BackfillStartDate", null);
+                Environment.SetEnvironmentVariable("BackfillEndDate", null);
+            }
+        }
     }
 }

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Services/FitbitService.cs
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Services/FitbitService.cs
@@ -44,5 +44,31 @@ namespace Biotrackr.Sleep.Svc.Services
                 throw;
             }
         }
+
+        public async Task<SleepResponse> GetSleepResponseByDateRange(string startDate, string endDate)
+        {
+            try
+            {
+                KeyVaultSecret fitbitAccessToken = await _secretClient.GetSecretAsync("AccessToken");
+                _httpClient.DefaultRequestHeaders.Clear();
+                Uri getSleepByDateRangeUri = new Uri($"https://api.fitbit.com/1.2/user/-/sleep/date/{startDate}/{endDate}.json");
+                var request = new HttpRequestMessage(HttpMethod.Get, getSleepByDateRangeUri);
+                request.Content = new StringContent("");
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", fitbitAccessToken.Value);
+
+                var response = await _httpClient.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+
+                var responseAsString = await response.Content.ReadAsStringAsync();
+                var sleepResponse = JsonSerializer.Deserialize<SleepResponse>(responseAsString);
+
+                return sleepResponse;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Exception thrown in {nameof(GetSleepResponseByDateRange)}: {ex.Message}");
+                throw;
+            }
+        }
     }
 }

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Services/Interfaces/IFitbitService.cs
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Services/Interfaces/IFitbitService.cs
@@ -5,5 +5,6 @@ namespace Biotrackr.Sleep.Svc.Services.Interfaces
     public interface IFitbitService
     {
         Task<SleepResponse> GetSleepResponse(string date);
+        Task<SleepResponse> GetSleepResponseByDateRange(string startDate, string endDate);
     }
 }

--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Worker/SleepWorker.cs
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Worker/SleepWorker.cs
@@ -1,4 +1,6 @@
-﻿using Biotrackr.Sleep.Svc.Services.Interfaces;
+﻿using Biotrackr.Sleep.Svc.Models.FitbitEntities;
+using Biotrackr.Sleep.Svc.Services.Interfaces;
+using System.Globalization;
 
 namespace Biotrackr.Sleep.Svc.Worker
 {
@@ -23,13 +25,23 @@ namespace Biotrackr.Sleep.Svc.Worker
             {
                 _logger.LogInformation($"{nameof(SleepWorker)} executed at: {DateTime.Now}");
 
-                var date = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd");
+                var backfillStartDate = Environment.GetEnvironmentVariable("BackfillStartDate");
+                var backfillEndDate = Environment.GetEnvironmentVariable("BackfillEndDate");
 
-                _logger.LogInformation($"Getting sleep data for {date}");
-                var sleepResponse = await _fitbitService.GetSleepResponse(date);
+                if (!string.IsNullOrEmpty(backfillStartDate) && !string.IsNullOrEmpty(backfillEndDate))
+                {
+                    await ExecuteBackfill(backfillStartDate, backfillEndDate, stoppingToken);
+                }
+                else
+                {
+                    var date = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd");
 
-                _logger.LogInformation($"Mapping and saving document for {date}");
-                await _sleepService.MapAndSaveDocument(date, sleepResponse);
+                    _logger.LogInformation($"Getting sleep data for {date}");
+                    var sleepResponse = await _fitbitService.GetSleepResponse(date);
+
+                    _logger.LogInformation($"Mapping and saving document for {date}");
+                    await _sleepService.MapAndSaveDocument(date, sleepResponse);
+                }
 
                 return 0;
             }
@@ -42,6 +54,77 @@ namespace Biotrackr.Sleep.Svc.Worker
             {
                 _appLifetime.StopApplication();
             }
+        }
+
+        private async Task ExecuteBackfill(string startDateStr, string endDateStr, CancellationToken stoppingToken)
+        {
+            var start = DateTime.ParseExact(startDateStr, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+            var end = DateTime.ParseExact(endDateStr, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+            var chunkSize = 100;
+            var chunkNumber = 0;
+            var totalChunks = (int)Math.Ceiling((end - start).TotalDays / chunkSize);
+
+            _logger.LogInformation("Starting backfill from {StartDate} to {EndDate} ({TotalChunks} chunks)",
+                startDateStr, endDateStr, totalChunks);
+
+            var current = start;
+            while (current <= end)
+            {
+                stoppingToken.ThrowIfCancellationRequested();
+
+                var chunkEnd = current.AddDays(chunkSize - 1);
+                if (chunkEnd > end) chunkEnd = end;
+                chunkNumber++;
+
+                var chunkStartStr = current.ToString("yyyy-MM-dd");
+                var chunkEndStr = chunkEnd.ToString("yyyy-MM-dd");
+
+                _logger.LogInformation("Processing chunk {ChunkNumber}/{TotalChunks}: {Start} to {End}",
+                    chunkNumber, totalChunks, chunkStartStr, chunkEndStr);
+
+                var sleepResponse = await _fitbitService.GetSleepResponseByDateRange(chunkStartStr, chunkEndStr);
+
+                if (sleepResponse?.Sleep != null)
+                {
+                    var groupedByDate = sleepResponse.Sleep
+                        .GroupBy(s => s.DateOfSleep)
+                        .ToList();
+
+                    foreach (var group in groupedByDate)
+                    {
+                        try
+                        {
+                            _logger.LogInformation("Saving sleep data for {Date} ({EntryCount} entries)",
+                                group.Key, group.Count());
+
+                            var dateResponse = new SleepResponse
+                            {
+                                Sleep = group.ToList(),
+                                Summary = null
+                            };
+                            await _sleepService.MapAndSaveDocument(group.Key, dateResponse);
+
+                            _logger.LogInformation("Successfully saved sleep data for {Date}", group.Key);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError("Failed to save sleep data for {Date}: {Error}", group.Key, ex.Message);
+                        }
+                    }
+
+                    _logger.LogInformation("Saved {Count} dates for chunk {ChunkNumber}",
+                        groupedByDate.Count, chunkNumber);
+                }
+
+                current = chunkEnd.AddDays(1);
+
+                if (current <= end)
+                {
+                    await Task.Delay(500, stoppingToken);
+                }
+            }
+
+            _logger.LogInformation("Backfill complete. Processed {TotalChunks} chunks.", totalChunks);
         }
     }
 }


### PR DESCRIPTION
## Summary

One-time backfill modification to `Biotrackr.Sleep.Svc` enabling retrieval of all historical Fitbit sleep data (2017-02-20 to 2024-12-14) via environment variables and the Fitbit date-range API with 100-day chunking. **Code should be reverted after the backfill completes.**

## Changes

### Source (3 files)
- **IFitbitService.cs** — Added `GetSleepResponseByDateRange(string startDate, string endDate)` method to interface
- **FitbitService.cs** — Implemented date-range endpoint call (`/1.2/user/-/sleep/date/{start}/{end}.json`)
- **SleepWorker.cs** — Added backfill mode: reads `BackfillStartDate`/`BackfillEndDate` env vars, iterates 100-day chunks, groups by date, saves per-date documents with per-date logging and error isolation

### Infrastructure (1 file)
- **infra/apps/sleep-service/main.bicep** — Added `BackfillStartDate=2017-02-20` and `BackfillEndDate=2024-12-14` env vars

### Tests (2 files)
- **FitbitServiceShould.cs** — Added 2 tests (happy path + error path for date-range method)
- **SleepWorkerShould.cs** — Added 3 tests (backfill mode, single-day fallback, multi-chunk processing)

## How it works

1. Worker reads `BackfillStartDate` and `BackfillEndDate` environment variables at startup
2. When both are set, iterates through the date range in 100-day chunks (Fitbit API max) — 29 API calls total
3. Groups sleep entries by `DateOfSleep` and saves one `SleepDocument` per date using existing `MapAndSaveDocument`
4. Per-date logging enables identifying and retrying specific failed dates
5. When env vars are absent, existing single-day behavior (yesterday's date) is preserved

## Post-merge steps

1. Deploy to trigger the backfill
2. Verify Cosmos DB documents are populated for the date range
3. **Remove the `BackfillStartDate` and `BackfillEndDate` env vars from the Bicep file**
4. **Revert the source code changes** (IFitbitService, FitbitService, SleepWorker) back to their original state
5. Redeploy with clean code

## Validation

- `dotnet build` succeeds (22 pre-existing warnings, 0 errors)
- `dotnet test` passes 18/18 tests (13 existing + 5 new)