### PR TITLE
fix: rebuild sleep service to restore daily sync after backfill

### DIFF
--- a/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Worker/SleepWorker.cs
+++ b/src/Biotrackr.Sleep.Svc/Biotrackr.Sleep.Svc/Worker/SleepWorker.cs
@@ -1,5 +1,7 @@
 ﻿using Biotrackr.Sleep.Svc.Services.Interfaces;
 
+// Rebuild to restore daily sync container image after backfill
+
 namespace Biotrackr.Sleep.Svc.Worker
 {
     public class SleepWorker : BackgroundService


### PR DESCRIPTION
Triggers a rebuild of the Sleep Service container image from clean `main` code to restore daily sync behavior after the historical backfill deployment.

The backfill code was already reverted from `main` via force-push. This PR exists solely to trigger CI/CD to build and deploy a fresh container image without the backfill environment variables or code.