### PR TITLE
feat: add report status proxy endpoint and structured JSON tool return

### DIFF
--- a/infra/apps/chat-api/main.bicep
+++ b/infra/apps/chat-api/main.bicep
@@ -261,6 +261,25 @@ resource chatApiDeleteConversation 'Microsoft.ApiManagement/service/apis/operati
   }
 }
 
+resource chatApiGetReportStatus 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  name: 'chat-getreportstatus'
+  parent: chatApimApi
+  properties: {
+    displayName: 'GetReportStatus'
+    method: 'GET'
+    urlTemplate: '/reports/{jobId}/status'
+    description: 'Get the status of a report generation job (proxied to Reporting.Api)'
+    templateParameters: [
+      {
+        name: 'jobId'
+        description: 'The report job ID'
+        type: 'string'
+        required: true
+      }
+    ]
+  }
+}
+
 resource chatApiHealthCheck 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
   name: 'chat-healthcheck'
   parent: chatApimApi

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Handlers/ChatHandlersShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Handlers/ChatHandlersShould.cs
@@ -4,7 +4,11 @@ using Biotrackr.Chat.Api.Models;
 using Biotrackr.Chat.Api.Services;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
 using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Net.Http.Json;
 
 namespace Biotrackr.Chat.Api.UnitTests.Handlers
 {
@@ -115,6 +119,84 @@ namespace Biotrackr.Chat.Api.UnitTests.Handlers
             // Assert
             result.Should().BeOfType<NoContent>();
             _repositoryMock.Verify(x => x.DeleteConversationAsync(sessionId), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetReportStatus_ShouldReturnOk_WhenReportExists()
+        {
+            // Arrange
+            var jobId = "test-job-123";
+            var responseJson = System.Text.Json.JsonSerializer.Serialize(new
+            {
+                metadata = new { jobId, status = "generating" },
+                artifactUrls = new Dictionary<string, string>()
+            });
+            var httpClientFactory = CreateMockHttpClientFactory(HttpStatusCode.OK, responseJson);
+
+            // Act
+            var result = await ChatHandlers.GetReportStatus(httpClientFactory, jobId, new LoggerFactory());
+
+            // Assert
+            result.Result.Should().BeOfType<Ok<ReportStatusProxyResponse>>();
+            var okResult = (Ok<ReportStatusProxyResponse>)result.Result;
+            okResult.Value!.JobId.Should().Be(jobId);
+            okResult.Value.Status.Should().Be("generating");
+        }
+
+        [Fact]
+        public async Task GetReportStatus_ShouldReturnNotFound_WhenReportDoesNotExist()
+        {
+            // Arrange
+            var httpClientFactory = CreateMockHttpClientFactory(HttpStatusCode.NotFound, """{"error":"not found"}""");
+
+            // Act
+            var result = await ChatHandlers.GetReportStatus(httpClientFactory, "nonexistent", new LoggerFactory());
+
+            // Assert
+            result.Result.Should().BeOfType<NotFound>();
+        }
+
+        [Fact]
+        public async Task GetReportStatus_ShouldReturn502_WhenUpstreamFails()
+        {
+            // Arrange
+            var mockFactory = new Mock<IHttpClientFactory>();
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ThrowsAsync(new HttpRequestException("Connection refused"));
+
+            var client = new HttpClient(mockHandler.Object) { BaseAddress = new Uri("https://localhost") };
+            mockFactory.Setup(f => f.CreateClient("ReportingApi")).Returns(client);
+
+            // Act
+            var result = await ChatHandlers.GetReportStatus(mockFactory.Object, "job-123", new LoggerFactory());
+
+            // Assert
+            result.Result.Should().BeOfType<StatusCodeHttpResult>();
+            var statusResult = (StatusCodeHttpResult)result.Result;
+            statusResult.StatusCode.Should().Be(502);
+        }
+
+        private static IHttpClientFactory CreateMockHttpClientFactory(HttpStatusCode statusCode, string responseBody)
+        {
+            var mockFactory = new Mock<IHttpClientFactory>();
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = statusCode,
+                    Content = new StringContent(responseBody, System.Text.Encoding.UTF8, "application/json")
+                });
+
+            var client = new HttpClient(mockHandler.Object) { BaseAddress = new Uri("https://localhost") };
+            mockFactory.Setup(f => f.CreateClient("ReportingApi")).Returns(client);
+            return mockFactory.Object;
         }
     }
 }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/RequestReportToolShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/RequestReportToolShould.cs
@@ -38,6 +38,21 @@ namespace Biotrackr.Chat.Api.UnitTests.Tools
         }
 
         [Fact]
+        public async Task ReturnStructuredJsonOnSuccessfulRequest()
+        {
+            var responseBody = JsonSerializer.Serialize(new { jobId = "job-456", status = "generating", message = "Started" });
+            var handler = CreateMockHandler(HttpStatusCode.Accepted, responseBody);
+            var sut = CreateTool(handler);
+
+            var result = await sut.RequestReport("weekly_summary", "2026-03-01", "2026-03-07", "Generate a report", SampleSnapshot);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("jobId").GetString().Should().Be("job-456");
+            doc.RootElement.GetProperty("status").GetString().Should().Be("generating");
+            doc.RootElement.GetProperty("message").GetString().Should().Contain("Job ID: job-456");
+        }
+
+        [Fact]
         public async Task ReturnErrorMessageOnFailedRequest()
         {
             var handler = CreateMockHandler(HttpStatusCode.BadRequest, "{\"error\":\"Invalid report type\"}");

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Extensions/EndpointRouteBuilderExtensions.cs
@@ -27,6 +27,14 @@ namespace Biotrackr.Chat.Api.Extensions
                 .WithOpenApi()
                 .WithSummary("Delete a conversation")
                 .WithDescription("Permanently deletes a conversation and all its messages.");
+
+            var reportEndpoints = endpointRouteBuilder.MapGroup("/reports");
+
+            reportEndpoints.MapGet("/{jobId}/status", ChatHandlers.GetReportStatus)
+                .WithName("GetReportStatus")
+                .WithOpenApi()
+                .WithSummary("Get report generation status")
+                .WithDescription("Proxies to Reporting.Api to get the current status of a report generation job.");
         }
 
         public static void RegisterHealthCheckEndpoints(this IEndpointRouteBuilder endpointRouteBuilder)

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Handlers/ChatHandlers.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Handlers/ChatHandlers.cs
@@ -1,5 +1,6 @@
 using Biotrackr.Chat.Api.Models;
 using Biotrackr.Chat.Api.Services;
+using System.Net.Http.Json;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Biotrackr.Chat.Api.Handlers
@@ -40,5 +41,54 @@ namespace Biotrackr.Chat.Api.Handlers
             await repository.DeleteConversationAsync(sessionId);
             return TypedResults.NoContent();
         }
+
+        public static async Task<Results<NotFound, StatusCodeHttpResult, Ok<ReportStatusProxyResponse>>> GetReportStatus(
+            IHttpClientFactory httpClientFactory,
+            string jobId,
+            ILoggerFactory loggerFactory)
+        {
+            try
+            {
+                var client = httpClientFactory.CreateClient("ReportingApi");
+                var response = await client.GetAsync($"/api/reports/{jobId}");
+
+                if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    return TypedResults.NotFound();
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                var content = await response.Content.ReadFromJsonAsync<ReportingApiResponse>();
+                return TypedResults.Ok(new ReportStatusProxyResponse
+                {
+                    JobId = content?.Metadata?.JobId ?? jobId,
+                    Status = content?.Metadata?.Status ?? "unknown"
+                });
+            }
+            catch (HttpRequestException ex)
+            {
+                var logger = loggerFactory.CreateLogger("ChatHandlers.GetReportStatus");
+                logger.LogWarning(ex, "Failed to get report status for job {JobId}", jobId);
+                return TypedResults.StatusCode(502);
+            }
+        }
+    }
+
+    public sealed class ReportStatusProxyResponse
+    {
+        public string JobId { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+    }
+
+    internal sealed class ReportingApiResponse
+    {
+        public ReportingApiMetadata? Metadata { get; set; }
+    }
+
+    internal sealed class ReportingApiMetadata
+    {
+        public string? JobId { get; set; }
+        public string? Status { get; set; }
     }
 }

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/RequestReportTool.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Tools/RequestReportTool.cs
@@ -67,7 +67,12 @@ namespace Biotrackr.Chat.Api.Tools
             var result = await response.Content.ReadFromJsonAsync<GenerateResponse>();
             _logger.LogInformation("Report job {JobId} started for {ReportType}", result?.JobId, reportType);
 
-            return $"Report generation started. Job ID: {result?.JobId}. You can ask me to check on the status of this report.";
+            return JsonSerializer.Serialize(new
+            {
+                jobId = result?.JobId,
+                status = "generating",
+                message = $"Report generation started. Job ID: {result?.JobId}. You can ask me to check on the status of this report."
+            });
         }
 
         public AIFunction AsAIFunction()


### PR DESCRIPTION
## Summary

Add a Chat.Api proxy endpoint for report status polling and change `RequestReportTool` to return structured JSON for reliable job ID extraction. This is Phase 1 of Approach B (#245) — the backend + infrastructure changes that enable the UI to poll for report generation status independently of the AGUI SSE stream.

**Phase 1 of 2 PRs** for #245. Phase 2 (UI polling + progress indicator) will be a separate PR after this merges.

## Changes

### Chat.Api — Proxy Endpoint

- **New handler**: `ChatHandlers.GetReportStatus` — proxies `GET /reports/{jobId}/status` to Reporting.Api's `GET /api/reports/{jobId}` using the existing `"ReportingApi"` named HttpClient (already has agent identity auth + resilience)
- **Returns**: Simplified `{ jobId, status }` response (strips large fields like `SourceDataSnapshot` and SAS URLs that are inappropriate for 10-second polling)
- **Error handling**: Returns `NotFound` for 404, `502 Bad Gateway` for upstream failures
- **New DTOs**: `ReportStatusProxyResponse`, `ReportingApiResponse`, `ReportingApiMetadata` in `ChatHandlers.cs`

### Chat.Api — Endpoint Registration

- **New route group**: `MapGroup("/reports")` in `EndpointRouteBuilderExtensions.cs`
- **Endpoint**: `GET /reports/{jobId}/status` with OpenAPI metadata

### Chat.Api — RequestReportTool Structured JSON

- **Before**: `"Report generation started. Job ID: {jobId}. You can ask me to check on the status of this report."`
- **After**: `{ "jobId": "...", "status": "generating", "message": "Report generation started. Job ID: ..." }`
- Claude reads the JSON naturally via the `message` field (system prompt does not reference output format — verified safe to change)
- UI can parse `jobId` via `JsonSerializer.Deserialize` instead of fragile regex

### Infrastructure — APIM

- **New APIM operation**: `chatApiGetReportStatus` in `infra/apps/chat-api/main.bicep`
- `GET /reports/{jobId}/status` with `templateParameters` for `jobId`
- API-level JWT/subscription-key policy auto-applies (no additional policy changes)

## Test Results

- **146/146 tests passed** (4 new + 142 existing)
- New tests:
  - `GetReportStatus_ShouldReturnOk_WhenReportExists`
  - `GetReportStatus_ShouldReturnNotFound_WhenReportDoesNotExist`
  - `GetReportStatus_ShouldReturn502_WhenUpstreamFails`
  - `ReturnStructuredJsonOnSuccessfulRequest`
- 0 errors, warnings are pre-existing

## Files Changed

| File | Change |
|------|--------|
| `src/Biotrackr.Chat.Api/.../Tools/RequestReportTool.cs` | Structured JSON return on success |
| `src/Biotrackr.Chat.Api/.../Handlers/ChatHandlers.cs` | New `GetReportStatus` handler + DTOs |
| `src/Biotrackr.Chat.Api/.../Extensions/EndpointRouteBuilderExtensions.cs` | New `/reports` route group |
| `infra/apps/chat-api/main.bicep` | New APIM operation |
| `src/Biotrackr.Chat.Api/.../UnitTests/Handlers/ChatHandlersShould.cs` | 3 new handler tests |
| `src/Biotrackr.Chat.Api/.../UnitTests/Tools/RequestReportToolShould.cs` | 1 new structured JSON test |

## Related Issues

Part of #245 (Phase 1 — Chat.Api + Infrastructure)
Part of #243 (Epic — Report generation progress indicator)

## References

- Research: `.copilot-tracking/research/2026-04-06/approach-b-report-status-polling-research.md`
- Plan: `.copilot-tracking/plans/2026-04-06/approach-b-report-status-polling-plan.instructions.md`