### PR TITLE
chore: trigger Chat.Api and UI redeploy after Approach B revert

### DIFF
--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Program.cs
@@ -25,6 +25,7 @@ var resourceAttributes = new Dictionary<string, object>
 };
 var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
 
+// Approach B reverted — redeploy with original RequestReportTool plain text return
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Configuration.AddEnvironmentVariables();

--- a/src/Biotrackr.UI/Biotrackr.UI/Program.cs
+++ b/src/Biotrackr.UI/Biotrackr.UI/Program.cs
@@ -17,6 +17,7 @@ var resourceAttributes = new Dictionary<string, object>
 };
 var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
 
+// Approach B reverted — redeploy with Approach A progress indicator only
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Configuration.AddEnvironmentVariables();


### PR DESCRIPTION
## Summary

Trigger redeploy of Chat.Api and UI after reverting Approach B (PR #249).

The revert commit (`666f237`) was pushed directly to main. This PR triggers the CI/CD pipelines for both Chat.Api and UI to redeploy with:
- **Chat.Api**: Original `RequestReportTool` plain text return (structured JSON reverted)
- **UI**: Approach A progress indicator only (polling removed)

## Changes

- Added build-trigger comments to `Program.cs` in both projects

## Related

- Reverts #249 (Chat.Api proxy + structured JSON)
- Closes #250 (UI polling — closed without merge)