### PR TITLE
fix: correct Withings visceral fat measure type from 123 to 170

### DIFF
--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/AdapterTests/WithingsWeightAdapterShould.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/AdapterTests/WithingsWeightAdapterShould.cs
@@ -67,7 +67,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         [Fact]
         public void DecodeVisceralFatCorrectly()
         {
-            var grp = CreateMeasureGroup(new Measure { Value = 10, Type = 123, Unit = 0 });
+            var grp = CreateMeasureGroup(new Measure { Value = 10, Type = 170, Unit = 0 });
             var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
             result.VisceralFatIndex.Should().Be(10);
         }
@@ -129,7 +129,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         [Fact]
         public void HandleZeroExponent()
         {
-            var grp = CreateMeasureGroup(new Measure { Value = 10, Type = 123, Unit = 0 });
+            var grp = CreateMeasureGroup(new Measure { Value = 10, Type = 170, Unit = 0 });
             var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
             result.VisceralFatIndex.Should().Be(10);
         }

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/ServiceTests/WithingsServiceShould.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/ServiceTests/WithingsServiceShould.cs
@@ -186,6 +186,42 @@ namespace Biotrackr.Vitals.Svc.UnitTests.ServiceTests
                 Times.Once);
         }
 
+        [Fact]
+        public async Task GetMeasurements_ShouldRequestVisceralFatMeasureType()
+        {
+            // Arrange
+            SetupSecretClient("test-access-token");
+            string? capturedBody = null;
+
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+                {
+                    capturedBody = req.Content!.ReadAsStringAsync().Result;
+                    var response = CreateSuccessfulResponse(1);
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(JsonSerializer.Serialize(response))
+                    };
+                });
+
+            // Act
+            await _sut.GetMeasurements("2026-02-04", "2026-04-02");
+
+            // Assert
+            capturedBody.Should().NotBeNull();
+            capturedBody.Should().Contain("meastypes=");
+
+            // Extract the meastypes value from URL-encoded form body
+            var parsed = System.Web.HttpUtility.ParseQueryString(capturedBody!);
+            var meastypes = parsed["meastypes"]!;
+
+            // Type 170 = Visceral Fat (correct)
+            meastypes.Split(',').Should().Contain("170");
+            // Type 123 = VO2 Max (should NOT be requested as visceral fat)
+            meastypes.Split(',').Should().NotContain("123");
+        }
+
         private void SetupSecretClient(string accessToken)
         {
             _mockSecretClient.Setup(x => x.GetSecretAsync("WithingsAccessToken", null, It.IsAny<CancellationToken>()))

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Adapters/WithingsWeightAdapter.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Adapters/WithingsWeightAdapter.cs
@@ -26,7 +26,7 @@ namespace Biotrackr.Vitals.Svc.Adapters
                 MuscleMassKg = GetNullableValue(measures, 76),
                 BoneMassKg = GetNullableValue(measures, 88),
                 WaterMassKg = GetNullableValue(measures, 77),
-                VisceralFatIndex = GetNullableIntValue(measures, 123)
+                VisceralFatIndex = GetNullableIntValue(measures, 170)
             };
         }
 

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Services/WithingsService.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Services/WithingsService.cs
@@ -77,7 +77,7 @@ namespace Biotrackr.Vitals.Svc.Services
             var formContent = new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 ["action"] = "getmeas",
-                ["meastypes"] = "1,5,6,8,9,10,11,76,77,88,123",
+                ["meastypes"] = "1,5,6,8,9,10,11,76,77,88,170",
                 ["category"] = "1",
                 ["startdate"] = startUnix.ToString(),
                 ["enddate"] = endUnix.ToString(),


### PR DESCRIPTION
## Summary

Fixes a double bug where the Withings API `meastypes` parameter requested type 123 (VO2 Max) instead of type 170 (Visceral Fat), and the adapter mapped type 123 to `VisceralFatIndex`. This caused `VisceralFatIndex` to always be `null` in Cosmos DB.

## Root Cause

Two bugs working together:

1. **`WithingsService.cs`**: The `meastypes` server-side filter requested type `123` (VO2 Max) instead of `170` (Visceral Fat). Since Withings only returns data for requested types, visceral fat data was **never returned** by the API.
2. **`WithingsWeightAdapter.cs`**: The adapter mapped type `123` to `VisceralFatIndex`, but type 123 is actually VO2 Max per Withings documentation.

Confirmed by 4 independent sources: Withings official `llms.md`, `vangorra/python_withings_api`, `joostlek/python-withings` (aiowithings), and the Home Assistant Withings integration.

## Changes

| File | Change |
|------|--------|
| `WithingsService.cs` | Replace type `123` with `170` in `meastypes` API parameter |
| `WithingsWeightAdapter.cs` | Change adapter lookup from type `123` to `170` for `VisceralFatIndex` |
| `WithingsWeightAdapterShould.cs` | Update `DecodeVisceralFatCorrectly` and `HandleZeroExponent` test data to type `170` |
| `WithingsServiceShould.cs` | Add `GetMeasurements_ShouldRequestVisceralFatMeasureType` regression test |

## Data Type

`int?` is confirmed correct for visceral fat — it is a dimensionless rating (scale 1–59, whole numbers).

## Follow-Up

Historical visceral fat data needs a one-time backfill after this fix is deployed. Tracked in #257.

## Testing

- All 51 unit tests pass
- New meastypes verification test prevents regression
