### PR TITLE
feat: add configurable LookbackDays to VitalsWorker (#257)

### DIFF
--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/WorkerTests/VitalsWorkerShould.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/WorkerTests/VitalsWorkerShould.cs
@@ -342,6 +342,33 @@ namespace Biotrackr.Vitals.Svc.UnitTests.WorkerTests
             capturedDoc.Weight!.WeightKg.Should().BeApproximately(81.0, 0.001);
         }
 
+        [Fact]
+        public async Task ExecuteAsync_Should_UseConfiguredLookbackDays()
+        {
+            var customSettings = Options.Create(new Settings { DatabaseName = "TestDb", ContainerName = "TestContainer", UserHeight = 1.88, LookbackDays = 30 });
+            var measureResponse = CreateWeightMeasureResponse(0);
+            string? capturedStartDate = null;
+
+            _withingsServiceMock
+                .Setup(w => w.GetMeasurements(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback<string, string>((start, end) => capturedStartDate = start)
+                .ReturnsAsync(measureResponse);
+
+            var worker = new VitalsWorker(
+                _withingsServiceMock.Object,
+                _vitalsServiceMock.Object,
+                _loggerMock.Object,
+                _appLifetimeMock.Object,
+                customSettings);
+
+            await worker.StartAsync(CancellationToken.None);
+            await Task.Delay(200);
+
+            capturedStartDate.Should().NotBeNull();
+            var expectedStart = DateTime.Now.AddDays(-30).ToString("yyyy-MM-dd");
+            capturedStartDate.Should().Be(expectedStart);
+        }
+
         private static WithingsMeasureResponse CreateWeightMeasureResponse(int groupCount)
         {
             var groups = Enumerable.Range(0, groupCount).Select(i => new MeasureGroup
@@ -361,7 +388,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.WorkerTests
                     new Measure { Value = 45200, Type = 76, Unit = -3 },
                     new Measure { Value = 3100, Type = 88, Unit = -3 },
                     new Measure { Value = 48900, Type = 77, Unit = -3 },
-                    new Measure { Value = 10, Type = 123, Unit = 0 }
+                    new Measure { Value = 10, Type = 170, Unit = 0 }
                 ]
             }).ToList();
 

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Configuration/Settings.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Configuration/Settings.cs
@@ -5,5 +5,6 @@
         public string DatabaseName { get; set; }
         public string ContainerName { get; set; }
         public double UserHeight { get; set; } = 1.88;
+        public int LookbackDays { get; set; } = 2;
     }
 }

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Workers/VitalsWorker.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Workers/VitalsWorker.cs
@@ -29,7 +29,7 @@ namespace Biotrackr.Vitals.Svc.Workers
             {
                 _logger.LogInformation($"{nameof(VitalsWorker)} executed at: {DateTime.Now}");
 
-                var startDate = DateTime.Now.AddDays(-2).ToString("yyyy-MM-dd");
+                var startDate = DateTime.Now.AddDays(-_settings.LookbackDays).ToString("yyyy-MM-dd");
                 var endDate = DateTime.Now.ToString("yyyy-MM-dd");
 
                 var measureResponse = await _withingsService.GetMeasurements(startDate, endDate);


### PR DESCRIPTION
## Summary

Adds a configurable `LookbackDays` setting to VitalsWorker, replacing the hardcoded 2-day lookback window. This enables backfilling historical data by temporarily increasing the lookback via Azure App Configuration.

Closes #257 (Tasks 1 and 2)

## Changes

| File | Change |
|------|--------|
| `Settings.cs` | Added `LookbackDays` property (default `2`) |
| `VitalsWorker.cs` | Replaced `AddDays(-2)` with `_settings.LookbackDays` |
| `VitalsWorkerShould.cs` | Added `ExecuteAsync_Should_UseConfiguredLookbackDays` test; fixed stale type 123→170 in test data |

## Backfill Procedure

After merging and deploying:
1. Set `Biotrackr:LookbackDays` to `365` in Azure App Configuration
2. Trigger the VitalsWorker Container Apps Job manually
3. Verify visceral fat data populated in Vitals documents
4. Reset `Biotrackr:LookbackDays` to `2`

## Testing

- 52/52 unit tests pass (was 51; +1 new test)
- Default behavior unchanged (still 2-day lookback)
