### PR TITLE
ops: add LookbackDays App Configuration setting for Vitals Service

### DIFF
--- a/infra/apps/vitals-service/main.bicep
+++ b/infra/apps/vitals-service/main.bicep
@@ -95,3 +95,11 @@ resource userHeightSetting 'Microsoft.AppConfiguration/configurationStores/keyVa
     value: '1.88'
   }
 }
+
+resource lookbackDaysSetting 'Microsoft.AppConfiguration/configurationStores/keyValues@2025-02-01-preview' = {
+  name: 'Biotrackr:LookbackDays'
+  parent: appConfig
+  properties: {
+    value: '2'
+  }
+}

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/WorkerTests/VitalsWorkerShould.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/WorkerTests/VitalsWorkerShould.cs
@@ -342,6 +342,33 @@ namespace Biotrackr.Vitals.Svc.UnitTests.WorkerTests
             capturedDoc.Weight!.WeightKg.Should().BeApproximately(81.0, 0.001);
         }
 
+        [Fact]
+        public async Task ExecuteAsync_Should_UseConfiguredLookbackDays()
+        {
+            var customSettings = Options.Create(new Settings { DatabaseName = "TestDb", ContainerName = "TestContainer", UserHeight = 1.88, LookbackDays = 30 });
+            var measureResponse = CreateWeightMeasureResponse(0);
+            string? capturedStartDate = null;
+
+            _withingsServiceMock
+                .Setup(w => w.GetMeasurements(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback<string, string>((start, end) => capturedStartDate = start)
+                .ReturnsAsync(measureResponse);
+
+            var worker = new VitalsWorker(
+                _withingsServiceMock.Object,
+                _vitalsServiceMock.Object,
+                _loggerMock.Object,
+                _appLifetimeMock.Object,
+                customSettings);
+
+            await worker.StartAsync(CancellationToken.None);
+            await Task.Delay(200);
+
+            capturedStartDate.Should().NotBeNull();
+            var expectedStart = DateTime.Now.AddDays(-30).ToString("yyyy-MM-dd");
+            capturedStartDate.Should().Be(expectedStart);
+        }
+
         private static WithingsMeasureResponse CreateWeightMeasureResponse(int groupCount)
         {
             var groups = Enumerable.Range(0, groupCount).Select(i => new MeasureGroup
@@ -361,7 +388,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.WorkerTests
                     new Measure { Value = 45200, Type = 76, Unit = -3 },
                     new Measure { Value = 3100, Type = 88, Unit = -3 },
                     new Measure { Value = 48900, Type = 77, Unit = -3 },
-                    new Measure { Value = 10, Type = 123, Unit = 0 }
+                    new Measure { Value = 10, Type = 170, Unit = 0 }
                 ]
             }).ToList();
 

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Configuration/Settings.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Configuration/Settings.cs
@@ -5,5 +5,6 @@
         public string DatabaseName { get; set; }
         public string ContainerName { get; set; }
         public double UserHeight { get; set; } = 1.88;
+        public int LookbackDays { get; set; } = 2;
     }
 }

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Workers/VitalsWorker.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Workers/VitalsWorker.cs
@@ -29,7 +29,7 @@ namespace Biotrackr.Vitals.Svc.Workers
             {
                 _logger.LogInformation($"{nameof(VitalsWorker)} executed at: {DateTime.Now}");
 
-                var startDate = DateTime.Now.AddDays(-2).ToString("yyyy-MM-dd");
+                var startDate = DateTime.Now.AddDays(-_settings.LookbackDays).ToString("yyyy-MM-dd");
                 var endDate = DateTime.Now.ToString("yyyy-MM-dd");
 
                 var measureResponse = await _withingsService.GetMeasurements(startDate, endDate);


### PR DESCRIPTION
## Summary

Adds the `Biotrackr:LookbackDays` App Configuration setting to the Vitals Service Bicep deployment with a default value of `2`.

This setting is consumed by the `LookbackDays` property added in PR #259. To run a backfill, change this value to `365` in Azure App Configuration and trigger the VitalsWorker job.

## Changes

| File | Change |
|------|--------|
| `infra/apps/vitals-service/main.bicep` | Added `Biotrackr:LookbackDays` App Config key-value resource (default `2`) |
