### PR TITLE
feat: rename WeightTools to VitalsTools and add blood pressure model

### DIFF
--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server.IntegrationTests/Contract/McpTransportShould.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server.IntegrationTests/Contract/McpTransportShould.cs
@@ -183,7 +183,7 @@ namespace Biotrackr.Mcp.Server.IntegrationTests.Contract
                 "get_activity_by_date", "get_activity_by_date_range", "get_activity_records",
                 "get_food_by_date", "get_food_by_date_range", "get_food_records",
                 "get_sleep_by_date", "get_sleep_by_date_range", "get_sleep_records",
-                "get_weight_by_date", "get_weight_by_date_range", "get_weight_records"
+                "get_vitals_by_date", "get_vitals_by_date_range", "get_vitals_records"
             };
             toolNames.Should().BeEquivalentTo(expectedToolNames);
         }

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server.UnitTests/Tools/VitalsToolsShould.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server.UnitTests/Tools/VitalsToolsShould.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Text.Json;
 using Biotrackr.Mcp.Server.Models;
-using Biotrackr.Mcp.Server.Models.Weight;
+using Biotrackr.Mcp.Server.Models.Vitals;
 using Biotrackr.Mcp.Server.Tools;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -9,27 +9,27 @@ using Moq;
 
 namespace Biotrackr.Mcp.Server.UnitTests.Tools
 {
-    public class WeightToolsShould
+    public class VitalsToolsShould
     {
-        private readonly Mock<ILogger<WeightTools>> _loggerMock;
+        private readonly Mock<ILogger<VitalsTools>> _loggerMock;
 
-        public WeightToolsShould()
+        public VitalsToolsShould()
         {
-            _loggerMock = new Mock<ILogger<WeightTools>>();
+            _loggerMock = new Mock<ILogger<VitalsTools>>();
         }
 
-        private WeightTools CreateSut(HttpResponseMessage response)
+        private VitalsTools CreateSut(HttpResponseMessage response)
         {
             var handler = new MockHttpMessageHandler(response);
             var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test.api.com") };
-            return new WeightTools(httpClient, _loggerMock.Object);
+            return new VitalsTools(httpClient, _loggerMock.Object);
         }
 
-        private WeightTools CreateSut(Exception exception)
+        private VitalsTools CreateSut(Exception exception)
         {
             var handler = new MockHttpMessageHandler(exception);
             var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test.api.com") };
-            return new WeightTools(httpClient, _loggerMock.Object);
+            return new VitalsTools(httpClient, _loggerMock.Object);
         }
 
         private static HttpResponseMessage CreateSuccessResponse<T>(T data)
@@ -41,17 +41,17 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
             };
         }
 
-        #region GetWeightByDate Tests
+        #region GetVitalsByDate Tests
 
         [Fact]
-        public async Task GetWeightByDate_ShouldReturnData_WhenDateIsValid()
+        public async Task GetVitalsByDate_ShouldReturnData_WhenDateIsValid()
         {
             // Arrange
-            var weightItem = new WeightItem { Date = "2025-01-15" };
-            var sut = CreateSut(CreateSuccessResponse(weightItem));
+            var vitalsItem = new VitalsItem { Date = "2025-01-15" };
+            var sut = CreateSut(CreateSuccessResponse(vitalsItem));
 
             // Act
-            var result = await sut.GetWeightByDate("2025-01-15");
+            var result = await sut.GetVitalsByDate("2025-01-15");
 
             // Assert
             var parsed = JsonSerializer.Deserialize<JsonElement>(result);
@@ -63,13 +63,13 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
         [InlineData("01-15-2025")]
         [InlineData("2025/01/15")]
         [InlineData("")]
-        public async Task GetWeightByDate_ShouldReturnError_WhenDateIsInvalid(string date)
+        public async Task GetVitalsByDate_ShouldReturnError_WhenDateIsInvalid(string date)
         {
             // Arrange
             var sut = CreateSut(new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var result = await sut.GetWeightByDate(date);
+            var result = await sut.GetVitalsByDate(date);
 
             // Assert
             var error = JsonSerializer.Deserialize<JsonElement>(result);
@@ -77,13 +77,13 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
         }
 
         [Fact]
-        public async Task GetWeightByDate_ShouldReturnError_WhenApiReturns404()
+        public async Task GetVitalsByDate_ShouldReturnError_WhenApiReturns404()
         {
             // Arrange
             var sut = CreateSut(new HttpResponseMessage(HttpStatusCode.NotFound));
 
             // Act
-            var result = await sut.GetWeightByDate("2025-01-15");
+            var result = await sut.GetVitalsByDate("2025-01-15");
 
             // Assert
             var error = JsonSerializer.Deserialize<JsonElement>(result);
@@ -91,13 +91,13 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
         }
 
         [Fact]
-        public async Task GetWeightByDate_ShouldReturnError_WhenNetworkFails()
+        public async Task GetVitalsByDate_ShouldReturnError_WhenNetworkFails()
         {
             // Arrange
             var sut = CreateSut(new HttpRequestException("Connection refused"));
 
             // Act
-            var result = await sut.GetWeightByDate("2025-01-15");
+            var result = await sut.GetVitalsByDate("2025-01-15");
 
             // Assert
             var error = JsonSerializer.Deserialize<JsonElement>(result);
@@ -106,15 +106,15 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
 
         #endregion
 
-        #region GetWeightByDateRange Tests
+        #region GetVitalsByDateRange Tests
 
         [Fact]
-        public async Task GetWeightByDateRange_ShouldReturnData_WhenDatesAreValid()
+        public async Task GetVitalsByDateRange_ShouldReturnData_WhenDatesAreValid()
         {
             // Arrange
-            var paginatedResponse = new PaginatedResponse<WeightItem>
+            var paginatedResponse = new PaginatedResponse<VitalsItem>
             {
-                Items = [new WeightItem { Date = "2025-01-15" }],
+                Items = [new VitalsItem { Date = "2025-01-15" }],
                 TotalCount = 1,
                 PageNumber = 1,
                 PageSize = 20
@@ -122,7 +122,7 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
             var sut = CreateSut(CreateSuccessResponse(paginatedResponse));
 
             // Act
-            var result = await sut.GetWeightByDateRange("2025-01-01", "2025-01-31");
+            var result = await sut.GetVitalsByDateRange("2025-01-01", "2025-01-31");
 
             // Assert
             var parsed = JsonSerializer.Deserialize<JsonElement>(result);
@@ -130,13 +130,13 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
         }
 
         [Fact]
-        public async Task GetWeightByDateRange_ShouldReturnError_WhenStartDateIsInvalid()
+        public async Task GetVitalsByDateRange_ShouldReturnError_WhenStartDateIsInvalid()
         {
             // Arrange
             var sut = CreateSut(new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var result = await sut.GetWeightByDateRange("invalid", "2025-01-31");
+            var result = await sut.GetVitalsByDateRange("invalid", "2025-01-31");
 
             // Assert
             var error = JsonSerializer.Deserialize<JsonElement>(result);
@@ -144,13 +144,13 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
         }
 
         [Fact]
-        public async Task GetWeightByDateRange_ShouldReturnError_WhenEndDateIsInvalid()
+        public async Task GetVitalsByDateRange_ShouldReturnError_WhenEndDateIsInvalid()
         {
             // Arrange
             var sut = CreateSut(new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var result = await sut.GetWeightByDateRange("2025-01-01", "invalid");
+            var result = await sut.GetVitalsByDateRange("2025-01-01", "invalid");
 
             // Assert
             var error = JsonSerializer.Deserialize<JsonElement>(result);
@@ -158,13 +158,13 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
         }
 
         [Fact]
-        public async Task GetWeightByDateRange_ShouldReturnError_WhenStartDateIsAfterEndDate()
+        public async Task GetVitalsByDateRange_ShouldReturnError_WhenStartDateIsAfterEndDate()
         {
             // Arrange
             var sut = CreateSut(new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var result = await sut.GetWeightByDateRange("2025-02-01", "2025-01-01");
+            var result = await sut.GetVitalsByDateRange("2025-02-01", "2025-01-01");
 
             // Assert
             var error = JsonSerializer.Deserialize<JsonElement>(result);
@@ -172,10 +172,10 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
         }
 
         [Fact]
-        public async Task GetWeightByDateRange_ShouldAcceptCustomPagination()
+        public async Task GetVitalsByDateRange_ShouldAcceptCustomPagination()
         {
             // Arrange
-            var paginatedResponse = new PaginatedResponse<WeightItem>
+            var paginatedResponse = new PaginatedResponse<VitalsItem>
             {
                 Items = [],
                 TotalCount = 0,
@@ -185,7 +185,7 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
             var sut = CreateSut(CreateSuccessResponse(paginatedResponse));
 
             // Act
-            var result = await sut.GetWeightByDateRange("2025-01-01", "2025-01-31", 3, 50);
+            var result = await sut.GetVitalsByDateRange("2025-01-01", "2025-01-31", 3, 50);
 
             // Assert
             var parsed = JsonSerializer.Deserialize<JsonElement>(result);
@@ -194,13 +194,13 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
         }
 
         [Fact]
-        public async Task GetWeightByDateRange_ShouldReturnError_WhenApiReturns500()
+        public async Task GetVitalsByDateRange_ShouldReturnError_WhenApiReturns500()
         {
             // Arrange
             var sut = CreateSut(new HttpResponseMessage(HttpStatusCode.InternalServerError));
 
             // Act
-            var result = await sut.GetWeightByDateRange("2025-01-01", "2025-01-31");
+            var result = await sut.GetVitalsByDateRange("2025-01-01", "2025-01-31");
 
             // Assert
             var error = JsonSerializer.Deserialize<JsonElement>(result);
@@ -209,15 +209,15 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
 
         #endregion
 
-        #region GetWeightRecords Tests
+        #region GetVitalsRecords Tests
 
         [Fact]
-        public async Task GetWeightRecords_ShouldReturnData_WithDefaultPagination()
+        public async Task GetVitalsRecords_ShouldReturnData_WithDefaultPagination()
         {
             // Arrange
-            var paginatedResponse = new PaginatedResponse<WeightItem>
+            var paginatedResponse = new PaginatedResponse<VitalsItem>
             {
-                Items = [new WeightItem { Date = "2025-01-15" }],
+                Items = [new VitalsItem { Date = "2025-01-15" }],
                 TotalCount = 1,
                 PageNumber = 1,
                 PageSize = 20
@@ -225,7 +225,7 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
             var sut = CreateSut(CreateSuccessResponse(paginatedResponse));
 
             // Act
-            var result = await sut.GetWeightRecords();
+            var result = await sut.GetVitalsRecords();
 
             // Assert
             var parsed = JsonSerializer.Deserialize<JsonElement>(result);
@@ -234,10 +234,10 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
         }
 
         [Fact]
-        public async Task GetWeightRecords_ShouldReturnData_WithCustomPagination()
+        public async Task GetVitalsRecords_ShouldReturnData_WithCustomPagination()
         {
             // Arrange
-            var paginatedResponse = new PaginatedResponse<WeightItem>
+            var paginatedResponse = new PaginatedResponse<VitalsItem>
             {
                 Items = [],
                 TotalCount = 100,
@@ -247,7 +247,7 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
             var sut = CreateSut(CreateSuccessResponse(paginatedResponse));
 
             // Act
-            var result = await sut.GetWeightRecords(5, 10);
+            var result = await sut.GetVitalsRecords(5, 10);
 
             // Assert
             var parsed = JsonSerializer.Deserialize<JsonElement>(result);
@@ -256,13 +256,13 @@ namespace Biotrackr.Mcp.Server.UnitTests.Tools
         }
 
         [Fact]
-        public async Task GetWeightRecords_ShouldReturnError_WhenApiReturnsUnauthorized()
+        public async Task GetVitalsRecords_ShouldReturnError_WhenApiReturnsUnauthorized()
         {
             // Arrange
             var sut = CreateSut(new HttpResponseMessage(HttpStatusCode.Unauthorized));
 
             // Act
-            var result = await sut.GetWeightRecords();
+            var result = await sut.GetVitalsRecords();
 
             // Assert
             var error = JsonSerializer.Deserialize<JsonElement>(result);

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Vitals/BloodPressureReadingData.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Vitals/BloodPressureReadingData.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+
+namespace Biotrackr.Mcp.Server.Models.Vitals
+{
+    public class BloodPressureReadingData
+    {
+        [JsonPropertyName("systolic")]
+        public int Systolic { get; set; }
+
+        [JsonPropertyName("diastolic")]
+        public int Diastolic { get; set; }
+
+        [JsonPropertyName("heartRate")]
+        public int HeartRate { get; set; }
+
+        [JsonPropertyName("timestamp")]
+        public string Timestamp { get; set; } = string.Empty;
+
+        [JsonPropertyName("time")]
+        public string Time { get; set; } = string.Empty;
+
+        [JsonPropertyName("source")]
+        public string Source { get; set; } = "Withings";
+
+        [JsonPropertyName("logId")]
+        public long LogId { get; set; }
+
+        [JsonPropertyName("deviceId")]
+        public string? DeviceId { get; set; }
+    }
+}

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Vitals/VitalsData.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Vitals/VitalsData.cs
@@ -1,17 +1,17 @@
 using System.Text.Json.Serialization;
 
-namespace Biotrackr.Mcp.Server.Models.Weight
+namespace Biotrackr.Mcp.Server.Models.Vitals
 {
-    public class WeightData
+    public class VitalsData
     {
         [JsonPropertyName("bmi")]
-        public double Bmi { get; set; }
+        public double? Bmi { get; set; }
 
         [JsonPropertyName("date")]
         public string Date { get; set; } = string.Empty;
 
         [JsonPropertyName("fat")]
-        public double Fat { get; set; }
+        public double? Fat { get; set; }
 
         [JsonIgnore]
         [JsonPropertyName("logId")]
@@ -25,7 +25,7 @@ namespace Biotrackr.Mcp.Server.Models.Weight
         public string Time { get; set; } = string.Empty;
 
         [JsonPropertyName("weight")]
-        public double Weight { get; set; }
+        public double? Weight { get; set; }
 
         [JsonPropertyName("fatMassKg")]
         public double? FatMassKg { get; set; }

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Vitals/VitalsItem.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Models/Vitals/VitalsItem.cs
@@ -1,15 +1,18 @@
 using System.Text.Json.Serialization;
 
-namespace Biotrackr.Mcp.Server.Models.Weight
+namespace Biotrackr.Mcp.Server.Models.Vitals
 {
-    public class WeightItem
+    public class VitalsItem
     {
         [JsonIgnore]
         [JsonPropertyName("id")]
         public string Id { get; set; } = string.Empty;
 
         [JsonPropertyName("weight")]
-        public WeightData Weight { get; set; } = new();
+        public VitalsData? Weight { get; set; }
+
+        [JsonPropertyName("bloodPressureReadings")]
+        public List<BloodPressureReadingData>? BloodPressureReadings { get; set; }
 
         [JsonPropertyName("date")]
         public string Date { get; set; } = string.Empty;

--- a/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Tools/VitalsTools.cs
+++ b/src/Biotrackr.Mcp.Server/Biotrackr.Mcp.Server/Tools/VitalsTools.cs
@@ -1,5 +1,5 @@
 using Biotrackr.Mcp.Server.Models;
-using Biotrackr.Mcp.Server.Models.Weight;
+using Biotrackr.Mcp.Server.Models.Vitals;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
@@ -8,14 +8,14 @@ using System.Text.Json;
 namespace Biotrackr.Mcp.Server.Tools
 {
     [McpServerToolType]
-    public class WeightTools : BaseTool
+    public class VitalsTools : BaseTool
     {
-        public WeightTools(HttpClient httpClient, ILogger<WeightTools> logger) : base(httpClient, logger)
+        public VitalsTools(HttpClient httpClient, ILogger<VitalsTools> logger) : base(httpClient, logger)
         {
         }
 
-        [McpServerTool, Description("Gets Weight Records between two specified dates. Dates must be in yyyy-MM-dd format. Supports pagination.")]
-        public async Task<string> GetWeightByDateRange(
+        [McpServerTool, Description("Gets Vitals Records between two specified dates. Dates must be in yyyy-MM-dd format. Supports pagination.")]
+        public async Task<string> GetVitalsByDateRange(
             [Description("Start date in yyyy-MM-dd format")] string startDate,
             [Description("End date in yyyy-MM-dd format")] string endDate,
             [Description("Page number (default: 1)")] int pageNumber = 1,
@@ -30,28 +30,28 @@ namespace Biotrackr.Mcp.Server.Tools
             if (!IsValidDateRange(startDate, endDate))
                 return JsonSerializer.Serialize(new { error = "startDate must be on or before endDate." });
 
-            var endpoint = BuildPaginatedEndpoint($"/weight/range/{startDate}/{endDate}", pageNumber, pageSize);
-            return await GetAsync<PaginatedResponse<WeightItem>>(endpoint, "GetWeightByDateRange");
+            var endpoint = BuildPaginatedEndpoint($"/vitals/range/{startDate}/{endDate}", pageNumber, pageSize);
+            return await GetAsync<PaginatedResponse<VitalsItem>>(endpoint, "GetVitalsByDateRange");
         }
 
-        [McpServerTool, Description("Gets a Weight Record for a specified date. Date must be in yyyy-MM-dd format.")]
-        public async Task<string> GetWeightByDate(
+        [McpServerTool, Description("Gets a Vitals Record for a specified date. Date must be in yyyy-MM-dd format.")]
+        public async Task<string> GetVitalsByDate(
             [Description("Date in yyyy-MM-dd format")] string date)
         {
             if (!IsValidDate(date))
                 return JsonSerializer.Serialize(new { error = "Invalid date format. Use yyyy-MM-dd." });
 
-            var endpoint = $"/weight/{date}";
-            return await GetAsync<WeightItem>(endpoint, "GetWeightByDate");
+            var endpoint = $"/vitals/{date}";
+            return await GetAsync<VitalsItem>(endpoint, "GetVitalsByDate");
         }
 
-        [McpServerTool, Description("Retrieves paginated Weight Records.")]
-        public async Task<string> GetWeightRecords(
+        [McpServerTool, Description("Retrieves paginated Vitals Records.")]
+        public async Task<string> GetVitalsRecords(
             [Description("Page number (default: 1)")] int pageNumber = 1,
             [Description("Page size between 1-100 (default: 20)")] int pageSize = 20)
         {
-            var endpoint = BuildPaginatedEndpoint("/weight", pageNumber, pageSize);
-            return await GetAsync<PaginatedResponse<WeightItem>>(endpoint, "GetWeightRecords");
+            var endpoint = BuildPaginatedEndpoint("/vitals", pageNumber, pageSize);
+            return await GetAsync<PaginatedResponse<VitalsItem>>(endpoint, "GetVitalsRecords");
         }
     }
 }


### PR DESCRIPTION
## Summary

Rename the MCP Server's weight tools and models to the vitals domain. This is PR 3 of 6 in the Weight-to-Vitals migration.

## Changes

### Renamed
- `WeightTools` → `VitalsTools` — class, methods (`GetVitalsByDate`, `GetVitalsByDateRange`, `GetVitalsRecords`), HTTP endpoints `/weight/` → `/vitals/`
- `Models/Weight/` → `Models/Vitals/` — `WeightItem` → `VitalsItem`, `WeightData` → `VitalsData`
- `WeightToolsShould` → `VitalsToolsShould` — unit test class

### Added
- `BloodPressureReadingData` model — systolic, diastolic, heartRate, timestamp, time, source, logId, deviceId
- `VitalsItem.BloodPressureReadings` — nullable list at document level (sibling of weight data)

### Modified
- `VitalsData` — weight properties (`Bmi`, `Fat`, `WeightKg`) made nullable (`double?`) for BP-only days
- `McpTransportShould.cs` — tool name assertions updated to `get_vitals_*` (count stays 12)

### Auto-generated tool names
- `get_vitals_by_date`, `get_vitals_by_date_range`, `get_vitals_records`

## Validation

- **Build:** 0 errors, 0 warnings
- **Unit tests:** 115 passed, 0 failed

## Related

- Depends on PR #255 (Vitals.Svc) and PR #256 (Vitals.Api) — both merged
- Part of the Blood Pressure Integration & Weight-to-Vitals Migration