### PR TITLE
feat: update Chat API tool allowlist and prompts for vitals domain

### DIFF
--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ToolPolicyMiddlewareShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Middleware/ToolPolicyMiddlewareShould.cs
@@ -31,7 +31,7 @@ namespace Biotrackr.Chat.Api.UnitTests.Middleware
                 [
                     "GetActivityByDate", "GetActivityByDateRange", "GetActivityRecords",
                     "GetSleepByDate", "GetSleepByDateRange", "GetSleepRecords",
-                    "GetWeightByDate", "GetWeightByDateRange", "GetWeightRecords",
+                    "GetVitalsByDate", "GetVitalsByDateRange", "GetVitalsRecords",
                     "GetFoodByDate", "GetFoodByDateRange", "GetFoodRecords"
                 ]
             };

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/CachingMcpToolWrapperShould.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.UnitTests/Tools/CachingMcpToolWrapperShould.cs
@@ -12,7 +12,7 @@ namespace Biotrackr.Chat.Api.UnitTests.Tools
         [Theory]
         [InlineData("get_activity_by_date", "2026-03-20", "get_activity_by_date:2026-03-20")]
         [InlineData("get_sleep_by_date", "2025-01-01", "get_sleep_by_date:2025-01-01")]
-        [InlineData("get_weight_by_date", "2026-12-31", "get_weight_by_date:2026-12-31")]
+        [InlineData("get_vitals_by_date", "2026-12-31", "get_vitals_by_date:2026-12-31")]
         [InlineData("get_food_by_date", "2026-06-15", "get_food_by_date:2026-06-15")]
         public void DeriveCacheKeyForByDateTools(string toolName, string date, string expectedKey)
         {
@@ -96,7 +96,7 @@ namespace Biotrackr.Chat.Api.UnitTests.Tools
         [Theory]
         [InlineData("get_activity_by_date_range")]
         [InlineData("get_sleep_by_date_range")]
-        [InlineData("get_weight_by_date_range")]
+        [InlineData("get_vitals_by_date_range")]
         [InlineData("get_food_by_date_range")]
         public void DetermineTtlForDateRangeToolReturnsThirtyMinutes(string toolName)
         {
@@ -114,7 +114,7 @@ namespace Biotrackr.Chat.Api.UnitTests.Tools
         [Theory]
         [InlineData("get_activity_records")]
         [InlineData("get_sleep_records")]
-        [InlineData("get_weight_records")]
+        [InlineData("get_vitals_records")]
         [InlineData("get_food_records")]
         public void DetermineTtlForRecordsToolReturnsFifteenMinutes(string toolName)
         {

--- a/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/ToolPolicyOptions.cs
+++ b/src/Biotrackr.Chat.Api/Biotrackr.Chat.Api/Configuration/ToolPolicyOptions.cs
@@ -7,7 +7,7 @@ namespace Biotrackr.Chat.Api.Configuration
         [
             "get_activity_by_date", "get_activity_by_date_range", "get_activity_records",
             "get_sleep_by_date", "get_sleep_by_date_range", "get_sleep_records",
-            "get_weight_by_date", "get_weight_by_date_range", "get_weight_records",
+            "get_vitals_by_date", "get_vitals_by_date_range", "get_vitals_records",
             "get_food_by_date", "get_food_by_date_range", "get_food_records",
             "GenerateReport", "CheckReportStatus"
         ];


### PR DESCRIPTION
## Summary

Update Chat API tool allowlist, system prompts, and unit tests for the vitals domain. This is PR 5 of 6 in the Weight-to-Vitals migration.

## Changes

### Modified — Source
- `ToolPolicyOptions.cs` — tool allowlist: `get_weight_*` → `get_vitals_*`

### Modified — Tests
- `CachingMcpToolWrapperShould.cs` — cache key and TTL test data updated to `get_vitals_*`
- `ToolPolicyMiddlewareShould.cs` — tool allowlist test data updated to `GetVitals*`

### Updated — Key Vault Secrets (not in code)
- `ChatSystemPrompt` — "activity, sleep, weight, food" → "activity, sleep, vitals (weight, blood pressure, and body composition), food" in 3 domain-list references
- `ReportGeneratorPrompt` — updated data domain description and report type descriptions to include blood pressure

### Not changed
- Eval dataset (`chat-agent-eval.jsonl`) — natural language "weight" queries remain valid since users will still say "weight trend" etc. The vitals tools return weight data.

## Validation

- **Build:** 0 errors
- **Unit tests:** 152 passed, 0 failed

## Related

- Depends on PRs #255 (Svc), #256 (Api), #261 (MCP), #262 (UI) — all merged
- Part of the Blood Pressure Integration & Weight-to-Vitals Migration