### PR TITLE
fix: convert Withings vitals timestamps from UTC to user local timezone

### DIFF
--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/AdapterTests/WithingsBloodPressureAdapterShould.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/AdapterTests/WithingsBloodPressureAdapterShould.cs
@@ -14,7 +14,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
                 diastolicValue: 80, diastolicUnit: 0,
                 heartRateValue: 72, heartRateUnit: 0);
 
-            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp);
+            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp, TimeZoneInfo.Utc);
 
             result.Systolic.Should().Be(120);
             result.Diastolic.Should().Be(80);
@@ -33,7 +33,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
                 Measures = [new Measure { Value = 120, Type = 10, Unit = 0 }]
             };
 
-            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp);
+            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp, TimeZoneInfo.Utc);
 
             result.Systolic.Should().Be(120);
             result.Diastolic.Should().Be(0);
@@ -49,7 +49,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
                 diastolicValue: 8000, diastolicUnit: -2,
                 heartRateValue: 7200, heartRateUnit: -2);
 
-            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp);
+            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp, TimeZoneInfo.Utc);
 
             result.Systolic.Should().Be(120);
             result.Diastolic.Should().Be(80);
@@ -65,7 +65,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
                 heartRateValue: 72, heartRateUnit: 0);
             grp.Date = new DateTimeOffset(2024, 4, 1, 8, 30, 0, TimeSpan.Zero).ToUnixTimeSeconds();
 
-            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp);
+            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp, TimeZoneInfo.Utc);
 
             result.Timestamp.Should().Contain("2024-04-01");
             result.Time.Should().Be("08:30:00");
@@ -79,7 +79,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
                 diastolicValue: 80, diastolicUnit: 0,
                 heartRateValue: 72, heartRateUnit: 0);
 
-            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp);
+            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp, TimeZoneInfo.Utc);
 
             result.Source.Should().Be("Withings");
         }
@@ -93,7 +93,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
                 heartRateValue: 72, heartRateUnit: 0);
             grp.GrpId = 987654321;
 
-            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp);
+            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp, TimeZoneInfo.Utc);
 
             result.LogId.Should().Be(987654321L);
         }
@@ -107,7 +107,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
                 heartRateValue: 72, heartRateUnit: 0);
             grp.DeviceId = "bpm-connect-123";
 
-            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp);
+            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp, TimeZoneInfo.Utc);
 
             result.DeviceId.Should().Be("bpm-connect-123");
         }
@@ -121,9 +121,60 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
                 heartRateValue: 72, heartRateUnit: 0);
             grp.DeviceId = "";
 
-            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp);
+            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp, TimeZoneInfo.Utc);
 
             result.DeviceId.Should().BeNull();
+        }
+
+        [Fact]
+        public void ConvertTimestampToLocalTimezone_AEST()
+        {
+            // UTC 2026-04-09 20:07:59 → AEST (UTC+10) = 2026-04-10 06:07:59
+            // April is after DST ends in Australia, so AEST (+10:00) applies
+            var grp = CreateBpMeasureGroup(
+                systolicValue: 120, systolicUnit: 0,
+                diastolicValue: 80, diastolicUnit: 0,
+                heartRateValue: 72, heartRateUnit: 0);
+            grp.Date = new DateTimeOffset(2026, 4, 9, 20, 7, 59, TimeSpan.Zero).ToUnixTimeSeconds();
+
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("AUS Eastern Standard Time");
+            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp, tz);
+
+            result.Time.Should().Be("06:07:59");
+            result.Timestamp.Should().Contain("+10:00");
+        }
+
+        [Fact]
+        public void ConvertTimestampToLocalTimezone_AEDT()
+        {
+            // UTC 2026-12-09 20:07:59 → AEDT (UTC+11) = 2026-12-10 07:07:59
+            // December is during daylight saving in Australia, so AEDT (+11:00) applies
+            var grp = CreateBpMeasureGroup(
+                systolicValue: 120, systolicUnit: 0,
+                diastolicValue: 80, diastolicUnit: 0,
+                heartRateValue: 72, heartRateUnit: 0);
+            grp.Date = new DateTimeOffset(2026, 12, 9, 20, 7, 59, TimeSpan.Zero).ToUnixTimeSeconds();
+
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("AUS Eastern Standard Time");
+            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp, tz);
+
+            result.Time.Should().Be("07:07:59");
+            result.Timestamp.Should().Contain("+11:00");
+        }
+
+        [Fact]
+        public void HandleUtcFallback_WhenUtcTimezoneProvided()
+        {
+            var grp = CreateBpMeasureGroup(
+                systolicValue: 120, systolicUnit: 0,
+                diastolicValue: 80, diastolicUnit: 0,
+                heartRateValue: 72, heartRateUnit: 0);
+            grp.Date = new DateTimeOffset(2026, 4, 9, 20, 7, 59, TimeSpan.Zero).ToUnixTimeSeconds();
+
+            var result = WithingsBloodPressureAdapter.FromMeasureGroup(grp, TimeZoneInfo.Utc);
+
+            result.Time.Should().Be("20:07:59");
+            result.Timestamp.Should().Contain("+00:00");
         }
 
         private static MeasureGroup CreateBpMeasureGroup(

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/AdapterTests/WithingsWeightAdapterShould.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/AdapterTests/WithingsWeightAdapterShould.cs
@@ -12,7 +12,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void DecodeWeightCorrectly()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 80250, Type = 1, Unit = -3 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.WeightKg.Should().BeApproximately(80.25, 0.001);
         }
 
@@ -20,7 +20,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void DecodeFatPercentCorrectly()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 2050, Type = 6, Unit = -2 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.Fat.Should().BeApproximately(20.50, 0.01);
         }
 
@@ -28,7 +28,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void DecodeFatMassCorrectly()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 15230, Type = 8, Unit = -3 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.FatMassKg.Should().BeApproximately(15.23, 0.001);
         }
 
@@ -36,7 +36,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void DecodeFatFreeMassCorrectly()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 65020, Type = 5, Unit = -3 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.FatFreeMassKg.Should().BeApproximately(65.02, 0.001);
         }
 
@@ -44,7 +44,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void DecodeMuscleMassCorrectly()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 45200, Type = 76, Unit = -3 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.MuscleMassKg.Should().BeApproximately(45.2, 0.001);
         }
 
@@ -52,7 +52,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void DecodeBoneMassCorrectly()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 3100, Type = 88, Unit = -3 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.BoneMassKg.Should().BeApproximately(3.1, 0.001);
         }
 
@@ -60,7 +60,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void DecodeWaterMassCorrectly()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 48900, Type = 77, Unit = -3 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.WaterMassKg.Should().BeApproximately(48.9, 0.001);
         }
 
@@ -68,7 +68,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void DecodeVisceralFatCorrectly()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 10, Type = 170, Unit = 0 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.VisceralFatIndex.Should().Be(10);
         }
 
@@ -78,7 +78,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
             var grp = CreateMeasureGroup(new Measure { Value = 80250, Type = 1, Unit = -3 });
             grp.Date = new DateTimeOffset(2024, 4, 1, 7, 30, 0, TimeSpan.Zero).ToUnixTimeSeconds();
 
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.Date.Should().Be("2024-04-01");
         }
 
@@ -88,7 +88,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
             var grp = CreateMeasureGroup(new Measure { Value = 80250, Type = 1, Unit = -3 });
             grp.Date = new DateTimeOffset(2024, 4, 1, 7, 30, 0, TimeSpan.Zero).ToUnixTimeSeconds();
 
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.Time.Should().Be("07:30:00");
         }
 
@@ -96,7 +96,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void SetSourceToWithings()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 80250, Type = 1, Unit = -3 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.Source.Should().Be("Withings");
         }
 
@@ -106,7 +106,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
             var grp = CreateMeasureGroup(new Measure { Value = 80250, Type = 1, Unit = -3 });
             grp.GrpId = 123456789;
 
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.LogId.Should().Be(123456789L);
         }
 
@@ -116,7 +116,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
             // Only weight (type=1) present — body comp fields should be null
             var grp = CreateMeasureGroup(new Measure { Value = 80250, Type = 1, Unit = -3 });
 
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.WeightKg.Should().BeApproximately(80.25, 0.001);
             result.FatMassKg.Should().BeNull();
             result.FatFreeMassKg.Should().BeNull();
@@ -130,7 +130,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void HandleZeroExponent()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 10, Type = 170, Unit = 0 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.VisceralFatIndex.Should().Be(10);
         }
 
@@ -138,7 +138,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void HandlePositiveExponent()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 8, Type = 1, Unit = 1 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.WeightKg.Should().BeApproximately(80.0, 0.001);
         }
 
@@ -146,7 +146,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void HandleLargeNegativeExponent()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 802500, Type = 1, Unit = -4 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.WeightKg.Should().BeApproximately(80.25, 0.001);
         }
 
@@ -160,7 +160,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
                 Measures = []
             };
 
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
             result.WeightKg.Should().Be(0);
             result.Fat.Should().Be(0);
             result.FatMassKg.Should().BeNull();
@@ -170,7 +170,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void CalculateBmiFromHeightAndWeight()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 80250, Type = 1, Unit = -3 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, TimeZoneInfo.Utc);
 
             // BMI = 80.25 / (1.88 * 1.88) = 80.25 / 3.5344 = 22.7
             result.Bmi.Should().BeApproximately(22.7, 0.1);
@@ -180,8 +180,50 @@ namespace Biotrackr.Vitals.Svc.UnitTests.AdapterTests
         public void SetBmiToZeroWhenHeightIsZero()
         {
             var grp = CreateMeasureGroup(new Measure { Value = 80250, Type = 1, Unit = -3 });
-            var result = WithingsWeightAdapter.FromMeasureGroup(grp, 0);
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, 0, TimeZoneInfo.Utc);
             result.Bmi.Should().Be(0);
+        }
+
+        [Fact]
+        public void ConvertDateAndTimeToLocalTimezone_AEST()
+        {
+            // UTC 20:01:08 on 2026-04-09 → AEST (+10) = 06:01:08 on 2026-04-10
+            var grp = CreateMeasureGroup(new Measure { Value = 80250, Type = 1, Unit = -3 });
+            grp.Date = new DateTimeOffset(2026, 4, 9, 20, 1, 8, TimeSpan.Zero).ToUnixTimeSeconds();
+
+            var melbourne = TimeZoneInfo.FindSystemTimeZoneById("Australia/Melbourne");
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, melbourne);
+
+            result.Date.Should().Be("2026-04-10");
+            result.Time.Should().Be("06:01:08");
+        }
+
+        [Fact]
+        public void ConvertDateAndTimeToLocalTimezone_AEDT()
+        {
+            // UTC 20:01:08 on 2025-12-09 → AEDT (+11) = 07:01:08 on 2025-12-10
+            var grp = CreateMeasureGroup(new Measure { Value = 80250, Type = 1, Unit = -3 });
+            grp.Date = new DateTimeOffset(2025, 12, 9, 20, 1, 8, TimeSpan.Zero).ToUnixTimeSeconds();
+
+            var melbourne = TimeZoneInfo.FindSystemTimeZoneById("Australia/Melbourne");
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, melbourne);
+
+            result.Date.Should().Be("2025-12-10");
+            result.Time.Should().Be("07:01:08");
+        }
+
+        [Fact]
+        public void DateDoesNotChange_WhenLocalTimeIsSameDay()
+        {
+            // UTC 02:00:00 on 2026-04-10 → AEST (+10) = 12:00:00 on 2026-04-10
+            var grp = CreateMeasureGroup(new Measure { Value = 80250, Type = 1, Unit = -3 });
+            grp.Date = new DateTimeOffset(2026, 4, 10, 2, 0, 0, TimeSpan.Zero).ToUnixTimeSeconds();
+
+            var melbourne = TimeZoneInfo.FindSystemTimeZoneById("Australia/Melbourne");
+            var result = WithingsWeightAdapter.FromMeasureGroup(grp, UserHeight, melbourne);
+
+            result.Date.Should().Be("2026-04-10");
+            result.Time.Should().Be("12:00:00");
         }
 
         private static MeasureGroup CreateMeasureGroup(params Measure[] measures)

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/ServiceTests/WithingsServiceShould.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/ServiceTests/WithingsServiceShould.cs
@@ -57,6 +57,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.ServiceTests
                 Status = 0,
                 Body = new WithingsMeasureBody
                 {
+                    Timezone = "Australia/Melbourne",
                     MeasureGroups = [new MeasureGroup { GrpId = 1, Date = 1711929600, Measures = [new Measure { Value = 80250, Type = 1, Unit = -3 }] }],
                     More = 1,
                     Offset = 50
@@ -68,6 +69,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.ServiceTests
                 Status = 0,
                 Body = new WithingsMeasureBody
                 {
+                    Timezone = "Australia/Melbourne",
                     MeasureGroups = [new MeasureGroup { GrpId = 2, Date = 1711929700, Measures = [new Measure { Value = 81000, Type = 1, Unit = -3 }] }],
                     More = 0,
                     Offset = 0
@@ -222,6 +224,72 @@ namespace Biotrackr.Vitals.Svc.UnitTests.ServiceTests
             meastypes.Split(',').Should().NotContain("123");
         }
 
+        [Fact]
+        public async Task GetMeasurements_ShouldPreserveTimezoneFromResponse()
+        {
+            // Arrange
+            SetupSecretClient("test-access-token");
+            var expectedResponse = CreateSuccessfulResponse(1);
+            SetupHttpResponse(expectedResponse);
+
+            // Act
+            var result = await _sut.GetMeasurements("2026-02-04", "2026-04-02");
+
+            // Assert
+            result.Body!.Timezone.Should().Be("Australia/Melbourne");
+        }
+
+        [Fact]
+        public async Task GetMeasurements_ShouldPreserveTimezoneFromFirstPage_WhenPaginated()
+        {
+            // Arrange
+            SetupSecretClient("test-access-token");
+
+            var page1 = new WithingsMeasureResponse
+            {
+                Status = 0,
+                Body = new WithingsMeasureBody
+                {
+                    Timezone = "Australia/Melbourne",
+                    MeasureGroups = [new MeasureGroup { GrpId = 1, Date = 1711929600, Measures = [new Measure { Value = 80250, Type = 1, Unit = -3 }] }],
+                    More = 1,
+                    Offset = 50
+                }
+            };
+
+            var page2 = new WithingsMeasureResponse
+            {
+                Status = 0,
+                Body = new WithingsMeasureBody
+                {
+                    Timezone = "Europe/Paris",
+                    MeasureGroups = [new MeasureGroup { GrpId = 2, Date = 1711929700, Measures = [new Measure { Value = 81000, Type = 1, Unit = -3 }] }],
+                    More = 0,
+                    Offset = 0
+                }
+            };
+
+            var callCount = 0;
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() =>
+                {
+                    callCount++;
+                    var response = callCount == 1 ? page1 : page2;
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(JsonSerializer.Serialize(response))
+                    };
+                });
+
+            // Act
+            var result = await _sut.GetMeasurements("2026-02-04", "2026-04-02");
+
+            // Assert
+            result.Body!.Timezone.Should().Be("Australia/Melbourne");
+            result.Body.MeasureGroups.Should().HaveCount(2);
+        }
+
         private void SetupSecretClient(string accessToken)
         {
             _mockSecretClient.Setup(x => x.GetSecretAsync("WithingsAccessToken", null, It.IsAny<CancellationToken>()))
@@ -252,6 +320,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.ServiceTests
                 Status = 0,
                 Body = new WithingsMeasureBody
                 {
+                    Timezone = "Australia/Melbourne",
                     MeasureGroups = groups,
                     More = 0,
                     Offset = 0

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/WorkerTests/VitalsWorkerShould.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc.UnitTests/WorkerTests/VitalsWorkerShould.cs
@@ -292,8 +292,8 @@ namespace Biotrackr.Vitals.Svc.UnitTests.WorkerTests
                 {
                     GrpId = 100001,
                     Attrib = 0,
-                    Date = baseDate.AddHours(7).ToUnixTimeSeconds(),
-                    Created = baseDate.AddHours(7).AddSeconds(50).ToUnixTimeSeconds(),
+                    Date = baseDate.AddHours(2).ToUnixTimeSeconds(),
+                    Created = baseDate.AddHours(2).AddSeconds(50).ToUnixTimeSeconds(),
                     Category = 1,
                     DeviceId = "test-device",
                     Measures = [new Measure { Value = 80000, Type = 1, Unit = -3 }]
@@ -302,8 +302,8 @@ namespace Biotrackr.Vitals.Svc.UnitTests.WorkerTests
                 {
                     GrpId = 100002,
                     Attrib = 0,
-                    Date = baseDate.AddHours(19).ToUnixTimeSeconds(),
-                    Created = baseDate.AddHours(19).AddSeconds(50).ToUnixTimeSeconds(),
+                    Date = baseDate.AddHours(4).ToUnixTimeSeconds(),
+                    Created = baseDate.AddHours(4).AddSeconds(50).ToUnixTimeSeconds(),
                     Category = 1,
                     DeviceId = "test-device",
                     Measures = [new Measure { Value = 81000, Type = 1, Unit = -3 }]
@@ -313,7 +313,7 @@ namespace Biotrackr.Vitals.Svc.UnitTests.WorkerTests
             var measureResponse = new WithingsMeasureResponse
             {
                 Status = 0,
-                Body = new WithingsMeasureBody { MeasureGroups = groups, More = 0, Offset = 0 }
+                Body = new WithingsMeasureBody { MeasureGroups = groups, More = 0, Offset = 0, Timezone = "Australia/Melbourne" }
             };
 
             VitalsDocument? capturedDoc = null;
@@ -369,6 +369,246 @@ namespace Biotrackr.Vitals.Svc.UnitTests.WorkerTests
             capturedStartDate.Should().Be(expectedStart);
         }
 
+        [Fact]
+        public async Task ExecuteAsync_Should_GroupByLocalDate_WhenTimezoneProvided()
+        {
+            // UTC 08:00 Apr 1 → AEST 18:00 Apr 1 (same day)
+            // UTC 14:00 Apr 1 → AEST 00:00 Apr 2 (next day)
+            var groups = new List<MeasureGroup>
+            {
+                new MeasureGroup
+                {
+                    GrpId = 400001,
+                    Attrib = 0,
+                    Date = new DateTimeOffset(2024, 4, 1, 8, 0, 0, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Created = new DateTimeOffset(2024, 4, 1, 8, 0, 50, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Category = 1,
+                    DeviceId = "test-device",
+                    Measures = [new Measure { Value = 80000, Type = 1, Unit = -3 }]
+                },
+                new MeasureGroup
+                {
+                    GrpId = 400002,
+                    Attrib = 0,
+                    Date = new DateTimeOffset(2024, 4, 1, 14, 0, 0, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Created = new DateTimeOffset(2024, 4, 1, 14, 0, 50, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Category = 1,
+                    DeviceId = "test-device",
+                    Measures = [new Measure { Value = 81000, Type = 1, Unit = -3 }]
+                }
+            };
+
+            var measureResponse = new WithingsMeasureResponse
+            {
+                Status = 0,
+                Body = new WithingsMeasureBody { MeasureGroups = groups, More = 0, Offset = 0, Timezone = "Australia/Melbourne" }
+            };
+
+            var capturedDocs = new List<VitalsDocument>();
+
+            _withingsServiceMock
+                .Setup(w => w.GetMeasurements(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(measureResponse);
+
+            _vitalsServiceMock
+                .Setup(w => w.UpsertVitalsDocument(It.IsAny<VitalsDocument>()))
+                .Callback<VitalsDocument>(doc => capturedDocs.Add(doc))
+                .Returns(Task.CompletedTask);
+
+            var worker = new VitalsWorker(
+                _withingsServiceMock.Object,
+                _vitalsServiceMock.Object,
+                _loggerMock.Object,
+                _appLifetimeMock.Object,
+                _settings);
+
+            await worker.StartAsync(CancellationToken.None);
+            await Task.Delay(200);
+
+            capturedDocs.Should().HaveCount(2);
+            capturedDocs.Select(d => d.Date).Should().Contain("2024-04-01");
+            capturedDocs.Select(d => d.Date).Should().Contain("2024-04-02");
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Should_FallbackToUtc_WhenTimezoneIsEmpty()
+        {
+            // UTC 14:00 Apr 1 — with UTC grouping stays on Apr 1
+            var groups = new List<MeasureGroup>
+            {
+                new MeasureGroup
+                {
+                    GrpId = 500001,
+                    Attrib = 0,
+                    Date = new DateTimeOffset(2024, 4, 1, 14, 0, 0, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Created = new DateTimeOffset(2024, 4, 1, 14, 0, 50, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Category = 1,
+                    DeviceId = "test-device",
+                    Measures = [new Measure { Value = 80000, Type = 1, Unit = -3 }]
+                }
+            };
+
+            var measureResponse = new WithingsMeasureResponse
+            {
+                Status = 0,
+                Body = new WithingsMeasureBody { MeasureGroups = groups, More = 0, Offset = 0, Timezone = "" }
+            };
+
+            VitalsDocument? capturedDoc = null;
+
+            _withingsServiceMock
+                .Setup(w => w.GetMeasurements(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(measureResponse);
+
+            _vitalsServiceMock
+                .Setup(w => w.UpsertVitalsDocument(It.IsAny<VitalsDocument>()))
+                .Callback<VitalsDocument>(doc => capturedDoc = doc)
+                .Returns(Task.CompletedTask);
+
+            var worker = new VitalsWorker(
+                _withingsServiceMock.Object,
+                _vitalsServiceMock.Object,
+                _loggerMock.Object,
+                _appLifetimeMock.Object,
+                _settings);
+
+            await worker.StartAsync(CancellationToken.None);
+            await Task.Delay(200);
+
+            capturedDoc.Should().NotBeNull();
+            capturedDoc!.Date.Should().Be("2024-04-01");
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Should_FallbackToUtc_WhenTimezoneIsInvalid()
+        {
+            // UTC 14:00 Apr 1 — with UTC fallback stays on Apr 1
+            var groups = new List<MeasureGroup>
+            {
+                new MeasureGroup
+                {
+                    GrpId = 600001,
+                    Attrib = 0,
+                    Date = new DateTimeOffset(2024, 4, 1, 14, 0, 0, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Created = new DateTimeOffset(2024, 4, 1, 14, 0, 50, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Category = 1,
+                    DeviceId = "test-device",
+                    Measures = [new Measure { Value = 80000, Type = 1, Unit = -3 }]
+                }
+            };
+
+            var measureResponse = new WithingsMeasureResponse
+            {
+                Status = 0,
+                Body = new WithingsMeasureBody { MeasureGroups = groups, More = 0, Offset = 0, Timezone = "Invalid/Zone" }
+            };
+
+            VitalsDocument? capturedDoc = null;
+
+            _withingsServiceMock
+                .Setup(w => w.GetMeasurements(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(measureResponse);
+
+            _vitalsServiceMock
+                .Setup(w => w.UpsertVitalsDocument(It.IsAny<VitalsDocument>()))
+                .Callback<VitalsDocument>(doc => capturedDoc = doc)
+                .Returns(Task.CompletedTask);
+
+            var worker = new VitalsWorker(
+                _withingsServiceMock.Object,
+                _vitalsServiceMock.Object,
+                _loggerMock.Object,
+                _appLifetimeMock.Object,
+                _settings);
+
+            await worker.StartAsync(CancellationToken.None);
+            await Task.Delay(200);
+
+            capturedDoc.Should().NotBeNull();
+            capturedDoc!.Date.Should().Be("2024-04-01");
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Unknown timezone")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Should_PassTimezoneToAdapters()
+        {
+            // Use July (AEST, UTC+10 — no daylight saving): UTC 02:00 Jul 1 → AEST 12:00 Jul 1
+            var groups = new List<MeasureGroup>
+            {
+                new MeasureGroup
+                {
+                    GrpId = 700001,
+                    Attrib = 0,
+                    Date = new DateTimeOffset(2024, 7, 1, 2, 0, 0, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Created = new DateTimeOffset(2024, 7, 1, 2, 0, 50, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Category = 1,
+                    DeviceId = "test-device",
+                    Measures =
+                    [
+                        new Measure { Value = 80000, Type = 1, Unit = -3 },
+                        new Measure { Value = 2050, Type = 6, Unit = -2 }
+                    ]
+                },
+                new MeasureGroup
+                {
+                    GrpId = 700002,
+                    Attrib = 0,
+                    Date = new DateTimeOffset(2024, 7, 1, 2, 30, 0, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Created = new DateTimeOffset(2024, 7, 1, 2, 30, 50, TimeSpan.Zero).ToUnixTimeSeconds(),
+                    Category = 1,
+                    DeviceId = "bp-device",
+                    Measures =
+                    [
+                        new Measure { Value = 120, Type = 10, Unit = 0 },
+                        new Measure { Value = 80, Type = 9, Unit = 0 },
+                        new Measure { Value = 72, Type = 11, Unit = 0 }
+                    ]
+                }
+            };
+
+            var measureResponse = new WithingsMeasureResponse
+            {
+                Status = 0,
+                Body = new WithingsMeasureBody { MeasureGroups = groups, More = 0, Offset = 0, Timezone = "Australia/Melbourne" }
+            };
+
+            VitalsDocument? capturedDoc = null;
+
+            _withingsServiceMock
+                .Setup(w => w.GetMeasurements(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(measureResponse);
+
+            _vitalsServiceMock
+                .Setup(w => w.UpsertVitalsDocument(It.IsAny<VitalsDocument>()))
+                .Callback<VitalsDocument>(doc => capturedDoc = doc)
+                .Returns(Task.CompletedTask);
+
+            var worker = new VitalsWorker(
+                _withingsServiceMock.Object,
+                _vitalsServiceMock.Object,
+                _loggerMock.Object,
+                _appLifetimeMock.Object,
+                _settings);
+
+            await worker.StartAsync(CancellationToken.None);
+            await Task.Delay(200);
+
+            capturedDoc.Should().NotBeNull();
+            // Weight time should reflect AEST (UTC+10), so 02:00 UTC → 12:00 AEST
+            capturedDoc!.Weight.Should().NotBeNull();
+            capturedDoc.Weight!.Time.Should().Be("12:00:00");
+            // BP time should also reflect AEST, so 02:30 UTC → 12:30 AEST
+            capturedDoc.BloodPressureReadings.Should().NotBeNull();
+            capturedDoc.BloodPressureReadings![0].Time.Should().Be("12:30:00");
+        }
+
         private static WithingsMeasureResponse CreateWeightMeasureResponse(int groupCount)
         {
             var groups = Enumerable.Range(0, groupCount).Select(i => new MeasureGroup
@@ -399,7 +639,8 @@ namespace Biotrackr.Vitals.Svc.UnitTests.WorkerTests
                 {
                     MeasureGroups = groups,
                     More = 0,
-                    Offset = 0
+                    Offset = 0,
+                    Timezone = "Australia/Melbourne"
                 }
             };
         }
@@ -429,7 +670,8 @@ namespace Biotrackr.Vitals.Svc.UnitTests.WorkerTests
                 {
                     MeasureGroups = groups,
                     More = 0,
-                    Offset = 0
+                    Offset = 0,
+                    Timezone = "Australia/Melbourne"
                 }
             };
         }
@@ -476,7 +718,8 @@ namespace Biotrackr.Vitals.Svc.UnitTests.WorkerTests
                 {
                     MeasureGroups = groups,
                     More = 0,
-                    Offset = 0
+                    Offset = 0,
+                    Timezone = "Australia/Melbourne"
                 }
             };
         }

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Adapters/WithingsBloodPressureAdapter.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Adapters/WithingsBloodPressureAdapter.cs
@@ -5,17 +5,19 @@ namespace Biotrackr.Vitals.Svc.Adapters
 {
     public static class WithingsBloodPressureAdapter
     {
-        public static BloodPressureReading FromMeasureGroup(MeasureGroup grp)
+        public static BloodPressureReading FromMeasureGroup(MeasureGroup grp, TimeZoneInfo userTimezone)
         {
             var measures = grp.Measures.ToDictionary(m => m.Type, m => m);
+            var utc = DateTimeOffset.FromUnixTimeSeconds(grp.Date);
+            var local = TimeZoneInfo.ConvertTime(utc, userTimezone);
 
             return new BloodPressureReading
             {
                 Systolic = GetIntValue(measures, 10),
                 Diastolic = GetIntValue(measures, 9),
                 HeartRate = GetIntValue(measures, 11),
-                Timestamp = DateTimeOffset.FromUnixTimeSeconds(grp.Date).ToString("o"),
-                Time = DateTimeOffset.FromUnixTimeSeconds(grp.Date).ToString("HH:mm:ss"),
+                Timestamp = local.ToString("o"),
+                Time = local.ToString("HH:mm:ss"),
                 Source = "Withings",
                 LogId = grp.GrpId,
                 DeviceId = string.IsNullOrEmpty(grp.DeviceId) ? null : grp.DeviceId

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Adapters/WithingsWeightAdapter.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Adapters/WithingsWeightAdapter.cs
@@ -5,9 +5,11 @@ namespace Biotrackr.Vitals.Svc.Adapters
 {
     public static class WithingsWeightAdapter
     {
-        public static WeightMeasurement FromMeasureGroup(MeasureGroup grp, double userHeight)
+        public static WeightMeasurement FromMeasureGroup(MeasureGroup grp, double userHeight, TimeZoneInfo userTimezone)
         {
             var measures = grp.Measures.ToDictionary(m => m.Type, m => m);
+            var utc = DateTimeOffset.FromUnixTimeSeconds(grp.Date);
+            var local = TimeZoneInfo.ConvertTime(utc, userTimezone);
 
             double weightKg = GetValue(measures, 1);
             double bmi = userHeight > 0 ? Math.Round(weightKg / (userHeight * userHeight), 1) : 0;
@@ -17,8 +19,8 @@ namespace Biotrackr.Vitals.Svc.Adapters
                 WeightKg = weightKg,
                 Bmi = bmi,
                 Fat = GetValue(measures, 6),
-                Date = DateTimeOffset.FromUnixTimeSeconds(grp.Date).ToString("yyyy-MM-dd"),
-                Time = DateTimeOffset.FromUnixTimeSeconds(grp.Date).ToString("HH:mm:ss"),
+                Date = local.ToString("yyyy-MM-dd"),
+                Time = local.ToString("HH:mm:ss"),
                 Source = "Withings",
                 LogId = grp.GrpId,
                 FatMassKg = GetNullableValue(measures, 8),

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Services/WithingsService.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Services/WithingsService.cs
@@ -33,6 +33,7 @@ namespace Biotrackr.Vitals.Svc.Services
                 var allMeasureGroups = new List<MeasureGroup>();
                 int offset = 0;
                 bool hasMore = true;
+                string timezone = string.Empty;
 
                 while (hasMore)
                 {
@@ -41,6 +42,11 @@ namespace Biotrackr.Vitals.Svc.Services
                     if (response.Body?.MeasureGroups != null)
                     {
                         allMeasureGroups.AddRange(response.Body.MeasureGroups);
+                    }
+
+                    if (string.IsNullOrEmpty(timezone) && !string.IsNullOrEmpty(response.Body?.Timezone))
+                    {
+                        timezone = response.Body.Timezone;
                     }
 
                     hasMore = response.Body?.More == 1;
@@ -54,6 +60,7 @@ namespace Biotrackr.Vitals.Svc.Services
                     Status = 0,
                     Body = new WithingsMeasureBody
                     {
+                        Timezone = timezone,
                         MeasureGroups = allMeasureGroups,
                         More = 0,
                         Offset = 0

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Workers/VitalsWorker.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Workers/VitalsWorker.cs
@@ -34,8 +34,26 @@ namespace Biotrackr.Vitals.Svc.Workers
 
                 var measureResponse = await _withingsService.GetMeasurements(startDate, endDate);
 
+                var timezoneId = measureResponse.Body?.Timezone;
+                TimeZoneInfo userTimezone;
+                try
+                {
+                    userTimezone = !string.IsNullOrEmpty(timezoneId)
+                        ? TimeZoneInfo.FindSystemTimeZoneById(timezoneId)
+                        : TimeZoneInfo.Utc;
+                }
+                catch (TimeZoneNotFoundException)
+                {
+                    _logger.LogWarning($"Unknown timezone '{timezoneId}' from Withings API. Falling back to UTC.");
+                    userTimezone = TimeZoneInfo.Utc;
+                }
+
                 var dateGroups = measureResponse.Body!.MeasureGroups
-                    .GroupBy(mg => DateTimeOffset.FromUnixTimeSeconds(mg.Date).ToString("yyyy-MM-dd"));
+                    .GroupBy(mg =>
+                    {
+                        var utc = DateTimeOffset.FromUnixTimeSeconds(mg.Date);
+                        return TimeZoneInfo.ConvertTime(utc, userTimezone).ToString("yyyy-MM-dd");
+                    });
 
                 foreach (var dateGroup in dateGroups)
                 {
@@ -48,13 +66,13 @@ namespace Biotrackr.Vitals.Svc.Workers
                     if (weightGroups.Count > 0)
                     {
                         var mostRecentWeightGroup = weightGroups.OrderByDescending(mg => mg.Date).First();
-                        weight = WithingsWeightAdapter.FromMeasureGroup(mostRecentWeightGroup, _settings.UserHeight);
+                        weight = WithingsWeightAdapter.FromMeasureGroup(mostRecentWeightGroup, _settings.UserHeight, userTimezone);
                     }
 
                     List<BloodPressureReading>? bpReadings = null;
                     if (bpGroups.Count > 0)
                     {
-                        bpReadings = bpGroups.Select(WithingsBloodPressureAdapter.FromMeasureGroup).ToList();
+                        bpReadings = bpGroups.Select(g => WithingsBloodPressureAdapter.FromMeasureGroup(g, userTimezone)).ToList();
                     }
 
                     var vitalsDocument = new VitalsDocument


### PR DESCRIPTION
Blood pressure readings and weight measurements from the Withings API were stored with UTC timestamps, causing morning readings to display as evening and vice versa. For users in Australia/Melbourne (UTC+10), a 6 AM local reading appeared as 8 PM the previous day — and landed in the wrong daily document.

## Changes

### Timezone preservation in WithingsService

The Withings API returns a `body.timezone` IANA string (e.g., `"Australia/Melbourne"`) in every response, but *WithingsService.cs* discarded it during pagination aggregation. The aggregated response now preserves the **timezone field** from the first API page for downstream use.

### Timestamp conversion in adapters

*WithingsBloodPressureAdapter.cs* and *WithingsWeightAdapter.cs* now accept a `TimeZoneInfo` parameter and convert UTC `DateTimeOffset` values to local time before formatting. Blood pressure `Timestamp` and `Time` fields, and weight `Date` and `Time` fields, all reflect the user's local timezone.

### Local-date grouping in VitalsWorker

*VitalsWorker.cs* resolves `TimeZoneInfo` from the Withings API response's IANA timezone string and uses it for date grouping. Measurements now land in the correct local-date document — a 6 AM Melbourne reading on April 10 no longer gets grouped under April 9. Includes graceful fallback to UTC with a warning log when the timezone is missing or invalid.

### Test coverage

All existing adapter and worker tests updated to pass `TimeZoneInfo.Utc` (preserving backward compatibility). New tests added covering:
- AEST (+10) and AEDT (+11) timezone conversion
- Cross-date grouping scenarios
- UTC fallback for missing/invalid timezone
- Adapter timezone passthrough verification

## Related Issues

None

## Notes

- Historical Cosmos DB documents were migrated separately using a one-time .NET console app (not included in this PR)
- The fix is isolated to `Biotrackr.Vitals.Svc` — Sleep, Activity, and Food services use the Fitbit API with date strings and are unaffected
- No external libraries needed — .NET 6+ `TimeZoneInfo.FindSystemTimeZoneById` supports IANA timezone IDs natively