### PR TITLE
fix(vitals-svc): reduce lookback days from 2 to 1

### DIFF
--- a/infra/apps/vitals-service/main.bicep
+++ b/infra/apps/vitals-service/main.bicep
@@ -100,6 +100,6 @@ resource lookbackDaysSetting 'Microsoft.AppConfiguration/configurationStores/key
   name: 'Biotrackr:LookbackDays'
   parent: appConfig
   properties: {
-    value: '2'
+    value: '1'
   }
 }

--- a/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Configuration/Settings.cs
+++ b/src/Biotrackr.Vitals.Svc/Biotrackr.Vitals.Svc/Configuration/Settings.cs
@@ -5,6 +5,6 @@
         public string DatabaseName { get; set; }
         public string ContainerName { get; set; }
         public double UserHeight { get; set; } = 1.88;
-        public int LookbackDays { get; set; } = 2;
+        public int LookbackDays { get; set; } = 1;
     }
 }


### PR DESCRIPTION
Reduced the Withings API lookback window in `Biotrackr.Vitals.Svc` from 2 days to 1 day, so the service fetches yesterday's and today's data instead of re-processing measurements from 2 days ago. This aligns with the `AddDays(-1)` pattern used by all three Fitbit ingestion services (Activity, Food, Sleep).

## Changes

- Updated **`LookbackDays`** default from `2` to `1` in *Settings.cs*, reducing the compile-time default to match the new behavior
- Updated **`Biotrackr:LookbackDays`** App Configuration value from `'2'` to `'1'` in *main.bicep*, ensuring the deployed configuration matches

> The Withings API was researched to determine whether a "today-only" (`LookbackDays=0`) query was feasible. It is not — the current `WithingsService` parses date strings to midnight timestamps, so `startUnix == endUnix` when both dates are the same day, producing a zero-width range with no results. `LookbackDays=1` is the simplest change that eliminates re-processing 2-day-old data while maintaining a full 24-hour query window.

The upsert pattern in `VitalsService` ensures this change carries no data corruption risk — any date that is queried will still be safely upserted regardless of overlap.

## Related Issues

None

## Notes

- All existing unit tests use `It.IsAny<string>()` for date parameters, so no test changes are needed
- The `ExecuteAsync_Should_UseConfiguredLookbackDays` test explicitly sets `LookbackDays = 30` and is unaffected by the default change

## Follow-up Tasks

- Fix `endDate` midnight truncation in *WithingsService.cs* — today's measurements taken after midnight are never captured (pre-existing issue, tracked as WI-01)
- Evaluate `lastupdate` sync pattern — Withings API supports incremental sync via `lastupdate` parameter to eliminate all redundant API calls (tracked as WI-02)