### PR TITLE
feat(reporting-api): accept multiple agent identity callers

### DIFF
--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Contract/AuthorizationPolicyShould.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Contract/AuthorizationPolicyShould.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using Biotrackr.Reporting.Api.IntegrationTests.Fixtures;
+using FluentAssertions;
+
+namespace Biotrackr.Reporting.Api.IntegrationTests.Contract;
+
+/// <summary>
+/// Contract tests verifying the ChatApiAgent authorization policy accepts
+/// multiple authorized caller identities (Chat.Api and Reporting.Svc).
+/// Each test creates its own factory to isolate configuration.
+/// Serialized via collection to avoid static ConfigurableAuthHandler race conditions.
+/// </summary>
+[Collection("AuthorizationPolicyTests")]
+public class AuthorizationPolicyShould
+{
+    [Fact]
+    public async Task RequireAuthentication_ShouldRejectUnauthenticatedRequests()
+    {
+        // Arrange
+        await using var factory = new AuthorizationTestWebApplicationFactory
+        {
+            ChatApiAgentIdentityId = "chat-api-identity",
+            ReportingSvcAgentIdentityId = "reporting-svc-identity"
+        };
+        var client = factory.CreateClient();
+        ConfigurableAuthHandler.AzpClaimValue = string.Empty;
+
+        // Act — request with no azp claim should be rejected by policy
+        var response = await client.GetAsync("/api/reports");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task AcceptChatApiIdentity_ShouldReturn200_WhenBothIdentitiesConfigured()
+    {
+        // Arrange
+        await using var factory = new AuthorizationTestWebApplicationFactory
+        {
+            ChatApiAgentIdentityId = "chat-api-identity",
+            ReportingSvcAgentIdentityId = "reporting-svc-identity"
+        };
+        var client = factory.CreateClient();
+        ConfigurableAuthHandler.AzpClaimValue = "chat-api-identity";
+
+        // Act
+        var response = await client.GetAsync("/api/reports");
+
+        // Assert
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task AcceptReportingSvcIdentity_ShouldReturn200_WhenBothIdentitiesConfigured()
+    {
+        // Arrange
+        await using var factory = new AuthorizationTestWebApplicationFactory
+        {
+            ChatApiAgentIdentityId = "chat-api-identity",
+            ReportingSvcAgentIdentityId = "reporting-svc-identity"
+        };
+        var client = factory.CreateClient();
+        ConfigurableAuthHandler.AzpClaimValue = "reporting-svc-identity";
+
+        // Act
+        var response = await client.GetAsync("/api/reports");
+
+        // Assert
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task AcceptChatApiIdentity_ShouldReturn200_WhenOnlyChatApiIdentityConfigured()
+    {
+        // Arrange
+        await using var factory = new AuthorizationTestWebApplicationFactory
+        {
+            ChatApiAgentIdentityId = "chat-api-identity",
+            ReportingSvcAgentIdentityId = null
+        };
+        var client = factory.CreateClient();
+        ConfigurableAuthHandler.AzpClaimValue = "chat-api-identity";
+
+        // Act
+        var response = await client.GetAsync("/api/reports");
+
+        // Assert
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task RejectUnknownIdentity_ShouldReturn403_WhenAzpDoesNotMatch()
+    {
+        // Arrange
+        await using var factory = new AuthorizationTestWebApplicationFactory
+        {
+            ChatApiAgentIdentityId = "chat-api-identity",
+            ReportingSvcAgentIdentityId = "reporting-svc-identity"
+        };
+        var client = factory.CreateClient();
+        ConfigurableAuthHandler.AzpClaimValue = "unknown-identity";
+
+        // Act
+        var response = await client.GetAsync("/api/reports");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Fixtures/AuthorizationTestWebApplicationFactory.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Fixtures/AuthorizationTestWebApplicationFactory.cs
@@ -1,0 +1,73 @@
+using Biotrackr.Reporting.Api.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Biotrackr.Reporting.Api.IntegrationTests.Fixtures;
+
+/// <summary>
+/// WebApplicationFactory variant for testing authorization policy configuration.
+/// Unlike <see cref="ReportingApiWebApplicationFactory"/>, this preserves the real
+/// ChatApiAgent authorization policy from Program.cs so azp claim requirements
+/// can be verified against the actual policy wiring.
+/// </summary>
+public class AuthorizationTestWebApplicationFactory : WebApplicationFactory<Program>
+{
+    public string? ChatApiAgentIdentityId { get; set; }
+    public string? ReportingSvcAgentIdentityId { get; set; }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // Skip Azure App Configuration and Application Insights
+        Environment.SetEnvironmentVariable("azureappconfigendpoint", string.Empty);
+        Environment.SetEnvironmentVariable("managedidentityclientid", string.Empty);
+        Environment.SetEnvironmentVariable("applicationinsightsconnectionstring", string.Empty);
+
+        // Provide minimal AzureAd config
+        Environment.SetEnvironmentVariable("AzureAd:Instance", "https://login.microsoftonline.com/");
+        Environment.SetEnvironmentVariable("AzureAd:TenantId", "test-tenant-id");
+        Environment.SetEnvironmentVariable("AzureAd:ClientId", "test-client-id");
+
+        // Settings
+        Environment.SetEnvironmentVariable("Biotrackr:CopilotCliUrl", "http://localhost:4321");
+        Environment.SetEnvironmentVariable("Biotrackr:ReportingBlobStorageEndpoint", "https://teststorage.blob.core.windows.net");
+        Environment.SetEnvironmentVariable("Biotrackr:ReportGenerationEnabled", "true");
+
+        // Configure authorized caller identity IDs
+        Environment.SetEnvironmentVariable("Biotrackr:ChatApiAgentIdentityId", ChatApiAgentIdentityId ?? string.Empty);
+        Environment.SetEnvironmentVariable("Biotrackr:ReportingSvcAgentIdentityId", ReportingSvcAgentIdentityId ?? string.Empty);
+
+        builder.UseEnvironment("Test");
+
+        builder.ConfigureServices(services =>
+        {
+            // Replace real services with mocks
+            var mockBlobStorage = new Mock<IBlobStorageService>();
+            var mockCopilot = new Mock<ICopilotService>();
+            var mockReportGeneration = new Mock<IReportGenerationService>();
+            var mockChatClient = new Mock<IChatClient>();
+
+            ReplaceService<IBlobStorageService>(services, mockBlobStorage.Object);
+            ReplaceService<ICopilotService>(services, mockCopilot.Object);
+            ReplaceService<IReportGenerationService>(services, mockReportGeneration.Object);
+            ReplaceService<IChatClient>(services, mockChatClient.Object);
+
+            // Replace authentication with a configurable test scheme but preserve the real authorization policy
+            services.AddAuthentication("TestScheme")
+                .AddScheme<AuthenticationSchemeOptions, ConfigurableAuthHandler>("TestScheme", _ => { });
+        });
+    }
+
+    private static void ReplaceService<T>(IServiceCollection services, T instance) where T : class
+    {
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(T));
+        if (descriptor != null)
+        {
+            services.Remove(descriptor);
+        }
+        services.AddSingleton(instance);
+    }
+}

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Fixtures/ConfigurableAuthHandler.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Fixtures/ConfigurableAuthHandler.cs
@@ -1,0 +1,49 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Biotrackr.Reporting.Api.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Authentication handler for authorization policy tests that allows
+/// configuring the azp claim value per request via a static property.
+/// </summary>
+public class ConfigurableAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    /// <summary>
+    /// The azp claim value to include in the authenticated identity.
+    /// Set before making a request to control which caller identity is simulated.
+    /// </summary>
+    public static string AzpClaimValue { get; set; } = string.Empty;
+
+    public ConfigurableAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Name, "test-agent"),
+            new("oid", "00000000-0000-0000-0000-000000000001"),
+            new("tid", "test-tenant-id"),
+        };
+
+        if (!string.IsNullOrWhiteSpace(AzpClaimValue))
+        {
+            claims.Add(new Claim("azp", AzpClaimValue));
+        }
+
+        var identity = new ClaimsIdentity(claims, "TestScheme");
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, "TestScheme");
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Program.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Program.cs
@@ -63,15 +63,22 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         };
     });
 
-// Authorization policy: restrict to Chat.Api's agent identity (ASI07 — mutual A2A auth)
+// Authorization policy: restrict to authorized agent identities (ASI07 — mutual A2A auth)
+var authorizedCallerIds = new List<string>();
 var chatApiAgentIdentityId = builder.Configuration.GetValue<string>("Biotrackr:ChatApiAgentIdentityId") ?? string.Empty;
+if (!string.IsNullOrWhiteSpace(chatApiAgentIdentityId))
+    authorizedCallerIds.Add(chatApiAgentIdentityId);
+var reportingSvcAgentIdentityId = builder.Configuration.GetValue<string>("Biotrackr:ReportingSvcAgentIdentityId") ?? string.Empty;
+if (!string.IsNullOrWhiteSpace(reportingSvcAgentIdentityId))
+    authorizedCallerIds.Add(reportingSvcAgentIdentityId);
+
 builder.Services.AddAuthorizationBuilder()
     .AddPolicy("ChatApiAgent", policy =>
     {
         policy.RequireAuthenticatedUser();
-        if (!string.IsNullOrWhiteSpace(chatApiAgentIdentityId))
+        if (authorizedCallerIds.Count > 0)
         {
-            policy.RequireClaim("azp", chatApiAgentIdentityId);
+            policy.RequireClaim("azp", [.. authorizedCallerIds]);
         }
     });
 


### PR DESCRIPTION
## Summary

Extend the `ChatApiAgent` authorization policy in Reporting.Api to accept multiple authorized agent identity callers. This enables both Chat.Api (existing) and the upcoming Reporting.Svc to authenticate via JWT `azp` claims.

## Changes

### Modified

- **`src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Program.cs`** — replaced single `azp` claim check with multi-caller support. Reads both `Biotrackr:ChatApiAgentIdentityId` and `Biotrackr:ReportingSvcAgentIdentityId` from configuration, collecting configured values into a list passed to `RequireClaim("azp", ...)`.

### Added

- **`AuthorizationPolicyShould.cs`** — 5 contract tests verifying multi-caller authorization:
  - Rejects unauthenticated requests
  - Accepts Chat.Api identity when both configured
  - Accepts Reporting.Svc identity when both configured
  - Backward compatibility — works with only Chat.Api identity
  - Rejects unknown identity values
- **`AuthorizationTestWebApplicationFactory.cs`** — dedicated test factory that preserves the real authorization policy (unlike existing fixture which overrides auth)
- **`ConfigurableAuthHandler.cs`** — auth handler with configurable `azp` claim for policy testing

## Backward Compatibility

This change is fully backward-compatible. If `Biotrackr:ReportingSvcAgentIdentityId` is not configured (which it won't be until Reporting.Svc is deployed), the policy behaves identically to the current single-caller implementation.

## Validation

- **Build**: Succeeded (1 pre-existing CS0618 warning)
- **Tests**: 187 total, 187 passed, 0 failed
- **Coverage**: 75.8% line coverage (threshold: 70%)

## Related

Part of the Scheduled Health Summaries feature — PR #1 of 3 (Reporting.Api auth extension).
