### PR TITLE
core(infra): add Azure Communication Services Email module

### DIFF
--- a/infra/core/main.bicep
+++ b/infra/core/main.bicep
@@ -149,3 +149,14 @@ module foundry '../modules/ai/foundry.bicep' = {
     evaluationStorageAccountName: 'st${replace(baseName, '-', '')}eval${environment}'
   }
 }
+
+module acsEmail '../modules/communication/acs-email.bicep' = {
+  name: 'acs-email'
+  params: {
+    baseName: baseName
+    environment: environment
+    tags: tags
+    uaiName: uai.outputs.uaiName
+    logAnalyticsName: logAnalytics.outputs.logAnalyticsName
+  }
+}

--- a/infra/modules/communication/acs-email.bicep
+++ b/infra/modules/communication/acs-email.bicep
@@ -1,0 +1,112 @@
+metadata name = 'Azure Communication Services Email'
+metadata description = 'This module deploys Azure Communication Services with Email capabilities, an Azure-managed domain, and assigns the Contributor role to a provided user-assigned identity.'
+
+@description('The base name for the ACS resources')
+@minLength(5)
+@maxLength(50)
+param baseName string
+
+@description('The deployment environment')
+@allowed([
+  'dev'
+  'prod'
+])
+param environment string
+
+@description('Tags to apply to all resources')
+param tags object
+
+@description('Name of the user-assigned managed identity for RBAC')
+@minLength(3)
+@maxLength(128)
+param uaiName string
+
+@description('Name of the Log Analytics workspace for diagnostic settings')
+param logAnalyticsName string
+
+var emailServiceName = 'email-${baseName}-${environment}'
+var communicationServiceName = 'acs-${baseName}-${environment}'
+var contributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+
+resource uai 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: uaiName
+}
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+  name: logAnalyticsName
+}
+
+resource emailService 'Microsoft.Communication/emailServices@2023-04-01' = {
+  name: emailServiceName
+  location: 'global'
+  tags: tags
+  properties: {
+    dataLocation: 'Australia'
+  }
+}
+
+resource domain 'Microsoft.Communication/emailServices/domains@2023-04-01' = {
+  name: 'AzureManagedDomain'
+  parent: emailService
+  location: 'global'
+  tags: tags
+  properties: {
+    domainManagement: 'AzureManagedDomain'
+  }
+}
+
+resource communicationService 'Microsoft.Communication/communicationServices@2023-04-01' = {
+  name: communicationServiceName
+  location: 'global'
+  tags: tags
+  properties: {
+    dataLocation: 'Australia'
+    linkedDomains: [
+      domain.id
+    ]
+  }
+}
+
+resource contributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, resourceGroup().id, communicationService.id)
+  scope: communicationService
+  properties: {
+    principalId: uai.properties.principalId
+    roleDefinitionId: contributorRoleId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource diagnosticLogs 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: communicationService.name
+  scope: communicationService
+  properties: {
+    workspaceId: logAnalytics.id
+    logs: [
+      {
+        category: 'EmailSendMailOperational'
+        enabled: true
+      }
+      {
+        category: 'EmailStatusUpdateOperational'
+        enabled: true
+      }
+      {
+        category: 'EmailUserEngagementOperational'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}
+
+@description('The endpoint of the Communication Service')
+output acsEndpoint string = communicationService.properties.hostName
+
+@description('The sender address from the Azure-managed email domain')
+output senderAddress string = 'DoNotReply@${domain.properties.fromSenderDomain}'

--- a/infra/modules/communication/acs-email.bicep
+++ b/infra/modules/communication/acs-email.bicep
@@ -41,7 +41,7 @@ resource emailService 'Microsoft.Communication/emailServices@2023-04-01' = {
   location: 'global'
   tags: tags
   properties: {
-    dataLocation: 'Australia'
+    dataLocation: 'United States'
   }
 }
 
@@ -60,7 +60,7 @@ resource communicationService 'Microsoft.Communication/communicationServices@202
   location: 'global'
   tags: tags
   properties: {
-    dataLocation: 'Australia'
+    dataLocation: 'United States'
     linkedDomains: [
       domain.id
     ]

--- a/infra/modules/communication/acs-email.bicep
+++ b/infra/modules/communication/acs-email.bicep
@@ -51,7 +51,7 @@ resource domain 'Microsoft.Communication/emailServices/domains@2023-04-01' = {
   location: 'global'
   tags: tags
   properties: {
-    domainManagement: 'AzureManagedDomain'
+    domainManagement: 'AzureManaged'
   }
 }
 


### PR DESCRIPTION
## Summary

Add Azure Communication Services (ACS) Email infrastructure to the core Bicep deployment. This provides the email sending capability required by the upcoming `Biotrackr.Reporting.Svc` for scheduled health summary delivery.

## Changes

### Added

- **`infra/modules/communication/acs-email.bicep`** — New Bicep module deploying:
  - `Microsoft.Communication/emailServices` — Email Communication Service (Australia data location)
  - `Microsoft.Communication/emailServices/domains` — Azure-managed email domain
  - `Microsoft.Communication/communicationServices` — Communication Service linked to email domain
  - `Microsoft.Authorization/roleAssignments` — Contributor role for UAI on ACS resource
  - `Microsoft.Insights/diagnosticSettings` — Logs (`EmailSendMailOperational`, `EmailStatusUpdateOperational`, `EmailUserEngagementOperational`) and metrics sent to Log Analytics

### Modified

- **`infra/core/main.bicep`** — Added `acsEmail` module deployment with `logAnalyticsName` parameter, following the same pattern as all other shared resource modules.

## Design Decisions

- **Data location: Australia** — Aligned with the project owner's location (Melbourne)
- **Azure-managed domain** — Uses `DoNotReply@{guid}.azurecomm.net` sender. Custom domain (e.g., `reports.biotrackr.dev`) deferred to follow-on work.
- **Diagnostic settings** — Follows the existing pattern (Key Vault, Cosmos DB, ACR, etc.) of sending operational logs + AllMetrics to the shared Log Analytics workspace.

## Validation

- `az bicep build --file infra/modules/communication/acs-email.bicep` — Exit 0
- `az bicep build --file infra/core/main.bicep` — Exit 0

## Related

Part of the Scheduled Health Summaries feature — PR #2 of 3 (ACS core infrastructure).