### PR TITLE
docs: add presentation-notes to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,5 +416,8 @@ scripts/chat-system-prompt/reviewer-prompt.txt
 # researcher files
 .copilot-tracking/*
 
+# Presentation notes — working files, not published
+docs/presentation-notes/*
+
 # Auto-generated ARM templates from Bicep compilation
 infra/apps/*/main.json


### PR DESCRIPTION
## Summary

Adds `docs/presentation-notes/*` to `.gitignore` to exclude working presentation files from version control.

## Changes

- Added `docs/presentation-notes/*` entry to `.gitignore`

## Context

Presentation materials for the "Applying the OWASP Top 10 for Agentic Applications to Your AI Agents" talk are stored in `docs/presentation-notes/` as working files (outlines, speaker notes, FAQ, slide decks). These are personal preparation materials and should not be committed to the repository.