### PR TITLE
docs(ai-bom): add transparency and security documents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -585,6 +585,8 @@ Do not modify decision records — they are append-only historical documents.
 
 * `AGENTS.md` — Standalone agent guide (9 sections, cross-tool compatible)
 * `CLAUDE.md` — Claude Code import file (`@AGENTS.md`)
+* `AI-TRANSPARENCY.md` — Public AI transparency statement (models, data categories, safety approach, ethical considerations)
+* `SECURITY.md` — Security vulnerability reporting policy (GitHub Private Advisory, AI-specific concerns)
 * `.github/instructions/csharp-conventions.instructions.md` — C# coding conventions (auto-loaded for `**/*.cs`)
 * `.github/instructions/css-conventions.instructions.md` — CSS isolation conventions (auto-loaded for `**/*.razor.css`)
 * `.github/instructions/razor-components.instructions.md` — Razor component conventions (auto-loaded for `**/*.razor`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,8 @@ Full standard: `docs/standards/commit-standards.md`
 
 Full OWASP Agentic Security (ASI01-ASI10) details are in `.github/copilot-instructions.md`.
 
+For public AI transparency documentation, see `AI-TRANSPARENCY.md`. For security vulnerability reporting, see `SECURITY.md`.
+
 ## Boundary Rules
 
 ### NEVER

--- a/AI-TRANSPARENCY.md
+++ b/AI-TRANSPARENCY.md
@@ -1,0 +1,259 @@
+---
+title: AI Transparency Statement
+description: Public transparency document describing how Biotrackr uses AI components, data handling practices, safety controls, and ethical considerations
+ms.date: 2026-04-16
+---
+
+# AI Transparency Statement
+
+> Biotrackr AI System Disclosure — Public Transparency Document
+
+**Last Updated:** April 2026
+
+---
+
+## Table of Contents
+
+* [System Overview](#system-overview)
+* [AI Models](#ai-models)
+* [Frameworks and Protocols](#frameworks-and-protocols)
+* [Data Categories Processed by AI](#data-categories-processed-by-ai)
+* [Safety and Security](#safety-and-security)
+* [Human Oversight](#human-oversight)
+* [Ethical Considerations](#ethical-considerations)
+* [Health Data and AI Disclaimer](#health-data-and-ai-disclaimer)
+* [Data Privacy](#data-privacy)
+* [Known Limitations](#known-limitations)
+* [AI Dependencies](#ai-dependencies)
+* [Licensing](#licensing)
+* [Responsible AI Contact](#responsible-ai-contact)
+* [Technical Documentation](#technical-documentation)
+
+---
+
+## System Overview
+
+Biotrackr is a personal health and fitness tracking platform that integrates with Fitbit and Withings wearable devices to collect, store, and analyze health data across four domains: physical activity, sleep, nutrition, and vitals.
+
+The platform includes AI-powered features for:
+
+* **Conversational health data querying** — Users interact with an AI assistant to ask natural language questions about their health data (e.g., "How did I sleep last week?" or "Show my step trends this month").
+* **Automated health report generation** — The AI generates PDF reports with charts and analysis summarizing health trends over configurable time periods.
+* **Independent report validation** — A separate AI reviewer validates generated reports against source data before delivery to the user.
+
+AI features are supplementary to the platform's core functionality. All health data is accessible through the dashboard without AI involvement. AI capabilities can be disabled independently of the rest of the platform.
+
+## AI Models
+
+| Attribute | Details |
+|-----------|---------|
+| **Provider** | Anthropic |
+| **Model Family** | Claude |
+| **Access Method** | API-consumed (cloud-hosted by provider) |
+| **Self-hosted** | No — models are not deployed or fine-tuned locally |
+
+### How Models Are Used
+
+* **Conversational Agent:** Interprets user questions about health data, determines which data to retrieve, and formulates natural language responses.
+* **Report Generation:** Generates analysis narratives and code to produce charts and PDF reports from health data.
+* **Report Review:** An independent model instance reviews generated reports for accuracy, consistency with source data, and appropriate disclaimers.
+
+Biotrackr does not fine-tune, retrain, or modify the underlying models. All AI interactions use the provider's standard API.
+
+## Frameworks and Protocols
+
+Biotrackr uses the following AI and agent frameworks:
+
+| Framework / Protocol | Purpose |
+|---------------------|---------|
+| **Microsoft Agent Framework** | Agent orchestration — manages AI agent lifecycle, tool integration, and session management |
+| **Model Context Protocol (MCP)** | Standardized tool integration — exposes health data query capabilities as structured tools for AI consumption |
+| **AGUI Protocol** | Streaming conversational responses — delivers real-time AI responses to the user interface |
+| **Agent-to-Agent (A2A) Protocol** | Inter-service agent communication — enables structured communication between AI services |
+| **GitHub Copilot SDK** | Code generation for report building — generates data analysis and visualization code for health reports |
+
+## Data Categories Processed by AI
+
+The following categories of personal health data may be processed by AI components:
+
+| Category | Examples |
+|----------|----------|
+| **Physical Activity** | Daily steps, distance walked/run, calories burned, active minutes, exercise sessions |
+| **Sleep** | Sleep duration, sleep stages (light, deep, REM), sleep efficiency, time asleep/awake |
+| **Nutrition** | Daily calorie intake, macronutrient breakdown (protein, carbohydrates, fat), food log entries |
+| **Vitals** | Body weight, body composition (muscle mass, bone mass, water mass, fat mass, fat-free mass), visceral fat index, blood pressure |
+
+### Data Flow
+
+* Health data originates from Fitbit and Withings devices and is stored in the user's own database.
+* When a user asks a question or requests a report, relevant data is retrieved from the database and sent to the AI provider's API for processing.
+* AI responses are streamed back to the user in real time.
+* Conversation history is stored in the user's database and can be deleted by the user at any time.
+
+> **Important:** All data categories listed above are considered **personal and sensitive health data**. See [Data Privacy](#data-privacy) for how this data is handled.
+
+## Safety and Security
+
+Biotrackr's AI safety approach is aligned with the **OWASP Agentic Security Top 10** (ASI01–ASI10), a comprehensive framework for securing AI agent systems. The following safety categories are addressed:
+
+| Safety Category | Description |
+|----------------|-------------|
+| **Prompt Injection Defense** | Protections against attempts to manipulate AI behavior through crafted inputs |
+| **Tool Access Policies** | Controls governing which tools the AI can invoke and usage budgets per session |
+| **Identity Verification** | Authentication and authorization for inter-service AI communication |
+| **Code Execution Validation** | Automated scanning of AI-generated code before execution |
+| **Conversation Safeguards** | Limits on conversation length and content to prevent context manipulation |
+| **Independent Report Review** | Separate AI reviewer validates report accuracy against source data |
+| **Graceful Degradation** | Controlled fallback behavior when AI services are unavailable |
+| **Kill Switch** | Administrative ability to disable AI features without affecting core platform functionality |
+| **Supply Chain Security** | Dependency scanning and version management for AI-related packages |
+
+> **Note:** Specific implementation details, thresholds, and configurations for these safety controls are intentionally omitted from this public document. Security auditors and compliance reviewers may request the full technical AI Bill of Materials (AI-BOM) — see [Technical Documentation](#technical-documentation).
+
+For reporting security vulnerabilities, see [SECURITY.md](SECURITY.md).
+
+## Human Oversight
+
+Biotrackr incorporates multiple layers of human oversight over AI behavior:
+
+* **User-initiated interactions:** All AI conversations are initiated by the user. The AI does not autonomously reach out, collect data, or take actions without a user request.
+* **Transparent tool usage:** The user interface displays which data tools the AI invoked during a conversation, providing visibility into the AI's reasoning process.
+* **Report review pipeline:** All AI-generated reports pass through an independent AI reviewer before delivery. If concerns are identified, they are flagged to the user alongside the report.
+* **Conversation management:** Users can view, export, and permanently delete their conversation history at any time.
+* **Feature control:** AI report generation can be administratively disabled via a configuration flag without affecting the rest of the platform.
+* **Mandatory disclaimers:** All AI-generated content carries clear disclaimers about its nature and limitations.
+
+## Ethical Considerations
+
+### Intended Use
+
+Biotrackr's AI features are designed for **personal health awareness and trend exploration** — helping users understand patterns in their own health data through natural language conversation and visual reports.
+
+### Not Intended For
+
+* **Medical diagnosis, treatment, or prevention** of any health condition
+* **Clinical decision support** for healthcare providers
+* **Emergency health monitoring** or real-time alerting
+* **Comparison with population health data** or normative benchmarks
+* **Predictions about future health outcomes** beyond simple trend observation
+
+### Bias and Fairness
+
+* The AI models are provided by Anthropic and may carry biases present in their training data. Biotrackr does not fine-tune or modify these models.
+* Health data interpretation may not account for individual medical conditions, medications, or physiological differences.
+* Report analysis is based solely on the data available from connected devices and may not represent a complete picture of the user's health.
+
+### Transparency Commitment
+
+This document is part of Biotrackr's commitment to transparent AI practices. The project maintains:
+
+* This public AI Transparency Statement
+* A detailed internal AI Bill of Materials (AI-BOM) available to security auditors
+* Alignment with OWASP Agentic Security standards
+* Open-source codebase for community review
+
+## Health Data and AI Disclaimer
+
+> **This platform does not provide medical advice.**
+>
+> AI-generated insights, reports, charts, and conversational responses about your health data are for **informational and personal awareness purposes only**. They are not intended to be a substitute for professional medical advice, diagnosis, or treatment.
+>
+> **Always seek the advice of your physician or other qualified health provider** with any questions you may have regarding a medical condition. Never disregard professional medical advice or delay in seeking it because of something generated by this platform's AI features.
+>
+> AI-generated content may contain inaccuracies. While reports undergo automated review for consistency with source data, the AI may misinterpret trends, draw incorrect conclusions, or present data in misleading ways. **Always verify AI-generated insights against your raw health data** available in the platform dashboard.
+>
+> If you think you may have a medical emergency, call your doctor or emergency services immediately.
+
+## Data Privacy
+
+### Health Data Sent to External AI Providers
+
+When you use Biotrackr's AI features (conversational queries or report generation), relevant portions of your health data are transmitted to Anthropic's API for processing. The following applies:
+
+* **Data transmitted:** Only the health data relevant to your specific query or report request is sent. Bulk data exports are not transmitted.
+* **Provider data usage:** Per Anthropic's commercial terms of service, data sent through the API is not used to train or improve their models.
+* **Encryption:** All data transmitted to the AI provider is encrypted in transit.
+* **No PII beyond health metrics:** The platform does not send your name, email, device identifiers, or account credentials to the AI provider. Only anonymized health metric values are transmitted.
+* **Local storage:** Your conversation history and generated reports are stored in your own database instance. They are not stored by the AI provider beyond the duration needed to process your request.
+
+### Your Controls
+
+* You can use all platform features (dashboard, data viewing) without using AI features.
+* You can delete individual conversations or your entire conversation history.
+* AI features can be administratively disabled.
+* Generated reports are stored in your own storage and can be deleted.
+
+## Known Limitations
+
+| Limitation | Description |
+|-----------|-------------|
+| **External AI dependency** | AI features require connectivity to Anthropic's API. If the provider experiences downtime, AI features will be temporarily unavailable while core platform functionality continues normally. |
+| **Data completeness** | AI analysis is limited to data collected by connected Fitbit and Withings devices. Gaps in device wear, syncing issues, or unsupported metrics may lead to incomplete analysis. |
+| **Temporal context** | The AI's conversational context is limited per session. Very long conversations may lose earlier context, potentially affecting response quality. |
+| **Report accuracy** | While reports undergo automated review, AI-generated charts and narratives may occasionally misrepresent data trends. Users should verify against raw data. |
+| **Language support** | The conversational AI primarily supports English. Responses in other languages may have reduced quality. |
+| **No real-time data** | The AI works with synced historical data. It does not have access to real-time sensor readings from wearable devices. |
+| **Single-user design** | The platform is designed for individual personal use. It does not support multi-user comparisons or household health tracking. |
+
+## AI Dependencies
+
+### AI-Related NuGet Packages (.NET)
+
+| Package | Major Version | Purpose |
+|---------|--------------|---------|
+| Microsoft.Agents.AI | 1.x | Agent framework for AI orchestration |
+| Microsoft.Extensions.AI | 10.x | AI service abstractions and integration |
+| ModelContextProtocol | 1.x | MCP client and server implementation |
+| GitHub.Copilot.SDK | 0.x | Copilot integration for report code generation |
+
+### Python Dependencies (Report Generation)
+
+| Package | Purpose |
+|---------|---------|
+| pandas | Health data analysis and transformation |
+| matplotlib | Chart and visualization generation |
+| seaborn | Statistical visualization |
+| reportlab | PDF report generation |
+| numpy | Numerical computation |
+
+### Infrastructure
+
+| Component | Purpose |
+|-----------|---------|
+| .NET 10 / C# 14 | Application runtime |
+| Azure Container Apps | Service hosting |
+| Azure Cosmos DB | Health data and conversation storage |
+| Azure API Management | API gateway and access control |
+| Azure Key Vault | Secure configuration storage |
+
+## Licensing
+
+Biotrackr is licensed under the **Apache License 2.0**. See [LICENSE](LICENSE) for full terms.
+
+The AI models consumed via API are subject to Anthropic's terms of service and usage policies.
+
+## Responsible AI Contact
+
+For questions, concerns, or feedback about Biotrackr's AI features and this transparency statement:
+
+* **GitHub Issues:** Open an issue in this repository with the label `responsible-ai`
+* **Security Vulnerabilities:** See [SECURITY.md](SECURITY.md) for responsible disclosure
+
+## Technical Documentation
+
+This public transparency statement provides a high-level overview of Biotrackr's AI system. A comprehensive **AI Bill of Materials (AI-BOM)** is maintained internally with full technical details including:
+
+* Complete dependency inventory with exact versions
+* Detailed data flow diagrams
+* Security control specifications
+* Model configuration parameters
+* Tool schemas and integration details
+* Evaluation results and safety test outcomes
+
+The full technical AI-BOM is **available on request** for:
+
+* Security auditors conducting assessments
+* Compliance reviewers evaluating data handling practices
+* Regulatory bodies with appropriate jurisdiction
+
+To request access, open a GitHub issue with the label `ai-bom-request` or contact the repository maintainers.

--- a/AI-TRANSPARENCY.md
+++ b/AI-TRANSPARENCY.md
@@ -173,7 +173,7 @@ When you use Biotrackr's AI features (conversational queries or report generatio
 * **Data transmitted:** Only the health data relevant to your specific query or report request is sent. Bulk data exports are not transmitted.
 * **Provider data usage:** Per Anthropic's commercial terms of service, data sent through the API is not used to train or improve their models.
 * **Encryption:** All data transmitted to the AI provider is encrypted in transit.
-* **No PII beyond health metrics:** The platform does not send your name, email, device identifiers, or account credentials to the AI provider. Only anonymized health metric values are transmitted.
+* **Account identifiers not sent:** The platform does not intentionally send your name, email, device identifiers, or account credentials to the AI provider. However, health metrics with dates and timestamps are personal data, and user-provided chat messages are forwarded without redaction — users should avoid including sensitive personal information in their queries.
 * **Local storage:** Your conversation history and generated reports are stored in your own database instance. They are not stored by the AI provider beyond the duration needed to process your request.
 
 ### Your Controls

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ HTTP-based Container Apps serving data from Cosmos DB via Azure API Management:
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
 
+## AI Transparency and Security
+
+* [AI-TRANSPARENCY.md](AI-TRANSPARENCY.md) — How Biotrackr uses AI, data handling practices, safety controls, and ethical considerations
+* [SECURITY.md](SECURITY.md) — Security vulnerability reporting policy
+
 ---
 
 **Author**: [willvelida](https://github.com/willvelida)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,112 @@
+---
+title: Security Policy
+description: Security vulnerability reporting policy for the Biotrackr project
+ms.date: 2026-04-16
+---
+
+# Security Policy
+
+## Supported Versions
+
+Biotrackr follows a rolling release model. Only the latest deployed version receives security updates.
+
+| Branch | Supported |
+|--------|-----------|
+| `main` | Yes |
+| Feature branches | No |
+| Previous releases | No |
+
+## Reporting a Vulnerability
+
+**Please do not open public GitHub issues for security vulnerabilities.**
+
+### Preferred: GitHub Private Security Advisory
+
+Report vulnerabilities through [GitHub Private Security Advisories](https://github.com/willvelida/biotrackr/security/advisories/new). This is the preferred method because it:
+
+* Keeps the report confidential until a fix is available.
+* Allows collaborative triage between reporter and maintainer.
+* Generates a CVE identifier when appropriate.
+* Does not require PGP keys or special tooling.
+
+### Alternative: Email
+
+If you are unable to use GitHub Security Advisories, email **willvelida [at] hotmail [dot] co [dot] uk** with the subject line `[SECURITY] Biotrackr — <brief description>`.
+
+Include as much of the following as possible:
+
+* Description of the vulnerability
+* Steps to reproduce or proof of concept
+* Affected component(s) and version(s)
+* Potential impact assessment
+* Any suggested remediation
+
+## Response Timeline
+
+| Action | Timeframe |
+|--------|-----------|
+| Acknowledgment of report | Within 72 hours |
+| Initial assessment and triage | Within 7 days |
+| Status update to reporter | At least every 14 days |
+| Fix development and testing | Best effort, varies by severity |
+| Coordinated disclosure | 90 days from report, negotiable |
+
+For critical vulnerabilities affecting deployed services, the maintainer will prioritize an expedited fix.
+
+## What Constitutes a Security Issue
+
+The following are considered security issues and should be reported privately:
+
+* **Data exposure:** Unauthorized access to personal health data (activity, sleep, food, vitals, weight)
+* **Authentication/authorization bypass:** Circumventing Azure API Management JWT validation, managed identity controls, or subscription key requirements
+* **Secrets exposure:** Leakage of API keys, Azure Key Vault secrets, managed identity credentials, or connection strings
+* **Injection attacks:** SQL injection, NoSQL injection (Cosmos DB), prompt injection against AI components, or command injection
+* **AI/Agent security:** Exploitation of AI agent components including prompt injection, tool misuse, agent goal hijacking, or unauthorized code execution (see OWASP Agentic Security ASI01-ASI10)
+* **MCP Server exploitation:** Unauthorized tool invocation, rate limit bypass, or data exfiltration through MCP tools
+* **Supply chain attacks:** Compromised dependencies, container image tampering, or CI/CD pipeline manipulation
+* **Infrastructure misconfiguration:** Azure resource misconfigurations that could lead to unauthorized access
+
+## Out of Scope
+
+The following are NOT security vulnerabilities and should be reported as regular GitHub issues:
+
+* Denial of service against your own local development environment
+* Social engineering attacks against contributors
+* Issues in third-party dependencies with existing CVEs (use Dependabot alerts instead)
+* Feature requests for additional security controls
+* Questions about the security architecture (open a Discussion instead)
+* Requests for AI Bill of Materials (AI-BOM) data (use the `ai-bom-request` issue label)
+* Vulnerabilities in services Biotrackr integrates with (Fitbit API, Withings API, Anthropic API) — report those to the respective vendors
+
+## AI-Specific Security Concerns
+
+Biotrackr includes AI components powered by Claude (Anthropic) via the Microsoft Agent Framework. The project implements OWASP Agentic Security controls (ASI01-ASI10). AI-specific security concerns include:
+
+* **Prompt injection** (ASI01): Attempts to manipulate the AI agent's behavior through crafted inputs
+* **Tool misuse** (ASI02): Exploitation of MCP tools beyond intended functionality
+* **Identity abuse** (ASI03): Compromise of agent identity tokens used for inter-service authentication
+* **Context poisoning** (ASI06): Manipulation of conversation history or cached data to influence AI behavior
+* **Unauthorized code execution** (ASI05): Bypassing code validation gates in the Reporting API
+
+For transparency about AI components used in this project, see [AI-TRANSPARENCY.md](AI-TRANSPARENCY.md).
+
+## Disclosure Policy
+
+* The maintainer follows coordinated disclosure with a default 90-day timeline.
+* Security fixes are released as soon as practical after a fix is developed and tested.
+* Security advisories are published via GitHub Security Advisories after fixes are deployed.
+* Credit is given to reporters in the advisory unless anonymity is requested.
+
+## Security Controls
+
+This project implements the following security measures:
+
+* **Azure API Management** with JWT validation on all external endpoints
+* **Azure Key Vault** for secrets and system prompt storage
+* **User-assigned managed identity** for Azure service access (no stored credentials)
+* **Dependabot** for automated dependency updates
+* **CodeQL** scanning for static analysis
+* **Trivy** container vulnerability scanning in CI/CD
+* **Dockle** container best-practice linting
+* **SBOM generation** (CycloneDX) for all container images
+* **OWASP Agentic Security** controls (ASI01-ASI10) for AI components


### PR DESCRIPTION
## Summary

PR 1 of 7 for the AI-BOM implementation. Creates public transparency and security documents at the repo root, updates cross-references in existing documentation.

## Changes

### Added
- **SECURITY.md** — Security vulnerability reporting policy with GitHub Private Security Advisory as primary channel, AI-specific security concerns (OWASP ASI01-ASI10), 72-hour acknowledgment / 90-day disclosure timeline
- **AI-TRANSPARENCY.md** — Public AI transparency statement with 14 sections: system overview, AI models, frameworks, data categories, safety approach, human oversight, ethical considerations, health disclaimer, data privacy, known limitations, AI dependencies, licensing, contact, technical documentation
- GitHub labels `responsible-ai` and `ai-bom-request`

### Modified
- **README.md** — Added AI Transparency and Security section with links
- **AGENTS.md** — Added AI-TRANSPARENCY.md and SECURITY.md references in Security Overview
- **.github/copilot-instructions.md** — Added cross-references for new documents

## Security Verification

Zero Tier 3 confidential details in any public document (validated via pattern scan for rate limits, blocklist patterns, model version IDs, auth flow details, API endpoints).

Anthropic API data usage terms verified: Section B of Commercial Terms confirms *Anthropic may not train models on Customer Content from Services*.

## Related
- Tracking: `.copilot-tracking/plans/2026-04-16/ai-bom-implementation-plan.instructions.md`
- Research: `.copilot-tracking/research/2026-04-16/ai-bom-implementation-research.md`