### PR TITLE
feat(chat-api): adopt AI-BOM workflow template

### DIFF
--- a/.github/sbom/ai-bom-overlay.cdx.json
+++ b/.github/sbom/ai-bom-overlay.cdx.json
@@ -88,8 +88,14 @@
             "Over-eagerness behavior observed in alignment evaluations — model may take creative actions not explicitly requested. Mitigated via system prompt constraints."
           ],
           "ethicalConsiderations": [
-            "Processes personal health data (PHI) including activity, sleep, nutrition, and weight records. Prompt injection mitigations (ASI01) and tool policy limits are in place.",
-            "Deployed under Anthropic's ASL-3 Standard with enhanced security and deployment safeguards."
+            {
+              "name": "Personal health data processing",
+              "mitigationStrategy": "Processes PHI including activity, sleep, nutrition, and weight records. Prompt injection mitigations (ASI01) and tool policy limits are in place."
+            },
+            {
+              "name": "AI safety classification",
+              "mitigationStrategy": "Deployed under Anthropic's ASL-3 Standard with enhanced security and deployment safeguards."
+            }
           ],
           "users": [
             "Biotrackr users querying personal health data via conversational AI interface. Not intended for clinical diagnosis or medical advice."
@@ -157,8 +163,14 @@
             "Knowledge cutoff: May 2025 (reliable), August 2025 (training data)."
           ],
           "ethicalConsiderations": [
-            "Processes personal health data (PHI) for report generation. Reports undergo independent reviewer agent validation (ASI09). Code validation gate prevents dangerous pattern execution (ASI05).",
-            "Deployed under Anthropic's ASL-3 Standard."
+            {
+              "name": "Personal health data processing",
+              "mitigationStrategy": "Processes PHI for report generation. Reports undergo independent reviewer agent validation (ASI09). Code validation gate prevents dangerous pattern execution (ASI05)."
+            },
+            {
+              "name": "AI safety classification",
+              "mitigationStrategy": "Deployed under Anthropic's ASL-3 Standard."
+            }
           ]
         }
       },

--- a/.github/sbom/ai-bom-overlay.cdx.json
+++ b/.github/sbom/ai-bom-overlay.cdx.json
@@ -83,16 +83,16 @@
         },
         "considerations": {
           "technicalLimitations": [
-            { "description": "1M token context window. 64k max output tokens (300k on Batch API). API rate limits apply. Provider-managed versioning — model behavior may change without notice." },
-            { "description": "Knowledge cutoff: May 2025 (reliable), January 2026 (training data). Information after these dates may be absent or inaccurate." },
-            { "description": "Over-eagerness behavior observed in alignment evaluations — model may take creative actions not explicitly requested. Mitigated via system prompt constraints." }
+            "1M token context window. 64k max output tokens (300k on Batch API). API rate limits apply. Provider-managed versioning — model behavior may change without notice.",
+            "Knowledge cutoff: May 2025 (reliable), January 2026 (training data). Information after these dates may be absent or inaccurate.",
+            "Over-eagerness behavior observed in alignment evaluations — model may take creative actions not explicitly requested. Mitigated via system prompt constraints."
           ],
           "ethicalConsiderations": [
-            { "description": "Processes personal health data (PHI) including activity, sleep, nutrition, and weight records. Prompt injection mitigations (ASI01) and tool policy limits are in place." },
-            { "description": "Deployed under Anthropic's ASL-3 Standard with enhanced security and deployment safeguards." }
+            "Processes personal health data (PHI) including activity, sleep, nutrition, and weight records. Prompt injection mitigations (ASI01) and tool policy limits are in place.",
+            "Deployed under Anthropic's ASL-3 Standard with enhanced security and deployment safeguards."
           ],
           "users": [
-            { "description": "Biotrackr users querying personal health data via conversational AI interface. Not intended for clinical diagnosis or medical advice." }
+            "Biotrackr users querying personal health data via conversational AI interface. Not intended for clinical diagnosis or medical advice."
           ]
         }
       },
@@ -153,12 +153,12 @@
         },
         "considerations": {
           "technicalLimitations": [
-            { "description": "1M token context window. 128k max output tokens. API rate limits apply. Provider-managed versioning." },
-            { "description": "Knowledge cutoff: May 2025 (reliable), August 2025 (training data)." }
+            "1M token context window. 128k max output tokens. API rate limits apply. Provider-managed versioning.",
+            "Knowledge cutoff: May 2025 (reliable), August 2025 (training data)."
           ],
           "ethicalConsiderations": [
-            { "description": "Processes personal health data (PHI) for report generation. Reports undergo independent reviewer agent validation (ASI09). Code validation gate prevents dangerous pattern execution (ASI05)." },
-            { "description": "Deployed under Anthropic's ASL-3 Standard." }
+            "Processes personal health data (PHI) for report generation. Reports undergo independent reviewer agent validation (ASI09). Code validation gate prevents dangerous pattern execution (ASI05).",
+            "Deployed under Anthropic's ASL-3 Standard."
           ]
         }
       },

--- a/.github/workflows/deploy-chat-api.yml
+++ b/.github/workflows/deploy-chat-api.yml
@@ -55,7 +55,7 @@ jobs:
     build-container-image-dev:
           name: Build and Push Container Image
           needs: [run-unit-tests, run-contract-tests]
-          uses: willvelida/biotrackr/.github/workflows/template-ai-bom-push-image.yml@main
+          uses: willvelida/biotrackr/.github/workflows/template-ai-bom-push-image.yml@feat/chat-api-ai-bom
           with:
             working-directory: ./src/Biotrackr.Chat.Api
             app-name: biotrackr-chat-api

--- a/.github/workflows/deploy-chat-api.yml
+++ b/.github/workflows/deploy-chat-api.yml
@@ -8,12 +8,14 @@ on:
             - 'infra/apps/chat-api/**'
             - 'src/Biotrackr.Chat.Api/**'
             - '!src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.Evaluation.Tests/**'
+            - '.github/workflows/deploy-chat-api.yml'
 
 permissions:
     contents: write
     id-token: write
     pull-requests: write
     checks: write
+    attestations: write
 
 env:
   DOTNET_VERSION: 10.0.x
@@ -53,7 +55,7 @@ jobs:
     build-container-image-dev:
           name: Build and Push Container Image
           needs: [run-unit-tests, run-contract-tests]
-          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
+          uses: willvelida/biotrackr/.github/workflows/template-ai-bom-push-image.yml@main
           with:
             working-directory: ./src/Biotrackr.Chat.Api
             app-name: biotrackr-chat-api

--- a/.github/workflows/template-ai-bom-push-image.yml
+++ b/.github/workflows/template-ai-bom-push-image.yml
@@ -85,7 +85,11 @@ jobs:
 
         - name: Install CycloneDX CLI
           run: |
-            curl -sSLo cyclonedx-cli https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.30.0/cyclonedx-linux-x64
+            cyclonedxCliUrl="https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.30.0/cyclonedx-linux-x64"
+            cyclonedxCliSha256="f89876326620f5fc78a9b27cc1af57d6ed13d019aab87490e1246a44a910babb"
+
+            curl -fsSLo cyclonedx-cli "$cyclonedxCliUrl"
+            echo "${cyclonedxCliSha256}  cyclonedx-cli" | sha256sum -c -
             chmod +x cyclonedx-cli
             sudo mv cyclonedx-cli /usr/local/bin/cyclonedx
 

--- a/.github/workflows/template-ai-bom-push-image.yml
+++ b/.github/workflows/template-ai-bom-push-image.yml
@@ -85,7 +85,7 @@ jobs:
 
         - name: Install CycloneDX CLI
           run: |
-            curl -sSLo cyclonedx-cli https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.27.1/cyclonedx-linux-x64
+            curl -sSLo cyclonedx-cli https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.30.0/cyclonedx-linux-x64
             chmod +x cyclonedx-cli
             sudo mv cyclonedx-cli /usr/local/bin/cyclonedx
 

--- a/.github/workflows/template-ai-bom-push-image.yml
+++ b/.github/workflows/template-ai-bom-push-image.yml
@@ -84,7 +84,10 @@ jobs:
           continue-on-error: true
 
         - name: Install CycloneDX CLI
-          run: dotnet tool install --global CycloneDX.Cli --version 3.1.0
+          run: |
+            curl -sSLo cyclonedx-cli https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.27.1/cyclonedx-linux-x64
+            chmod +x cyclonedx-cli
+            sudo mv cyclonedx-cli /usr/local/bin/cyclonedx
 
         - name: Merge SBOM with AI-BOM overlay
           if: hashFiles(format('{0}/sbom.cdx.json', github.workspace)) != ''


### PR DESCRIPTION
## Summary

PR 3 of 7 for the AI-BOM implementation. Switches Chat.Api deploy workflow to the new AI-BOM reusable template. Also includes fixes to the template and overlay discovered during pipeline testing.

## Changes

### Modified
- **`.github/workflows/deploy-chat-api.yml`**
  - `uses:` changed from `template-acr-push-image.yml` to `template-ai-bom-push-image.yml`
  - Added `attestations: write` permission
  - Added self-referencing path trigger for workflow changes
- **`.github/workflows/template-ai-bom-push-image.yml`** (fixes from pipeline testing)
  - Replaced broken `dotnet tool install` with direct binary download from GitHub Releases
  - Upgraded CycloneDX CLI from v0.27.1 to v0.30.0 (full CycloneDX v1.6 support)
  - Added `curl -f` flag and SHA256 checksum verification for supply chain integrity
- **`.github/sbom/ai-bom-overlay.cdx.json`** (fixes from pipeline testing)
  - Fixed `ethicalConsiderations` format to use `name`/`mitigationStrategy` objects (CycloneDX CLI v0.30.0 schema)
  - Kept `technicalLimitations` and `users` as plain string arrays

### Pipeline Verification
- Full pipeline passed: build → SBOM → merge → upload → attest → deploy → E2E tests
- Merged SBOM verified: 198 components (193 Trivy + 5 AI overlay), 3 services, 199 dependencies
- AI model components present: Claude Sonnet 4.6, Claude Opus 4.6
- Services present: Anthropic Messages API, Copilot SDK Sidecar, MCP Server

### Note
Template ref currently points to `@feat/chat-api-ai-bom` for testing. Will be reverted to `@main` after merge since the template fixes land with this PR.

## Depends On
- PR #282 (merged) — initial AI-BOM overlay + template