### PR TITLE
feat(reporting-api): adopt AI-BOM template and add sidecar SBOM

### DIFF
--- a/.github/workflows/deploy-reporting-api.yml
+++ b/.github/workflows/deploy-reporting-api.yml
@@ -7,12 +7,14 @@ on:
         paths:
             - 'infra/apps/reporting-api/**'
             - 'src/Biotrackr.Reporting.Api/**'
+            - '.github/workflows/deploy-reporting-api.yml'
 
 permissions:
     contents: write
     id-token: write
     pull-requests: write
     checks: write
+    attestations: write
 
 env:
   DOTNET_VERSION: 10.0.x
@@ -52,7 +54,7 @@ jobs:
     build-container-image-dev:
           name: Build and Push Container Image
           needs: [run-unit-tests, run-contract-tests]
-          uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
+          uses: willvelida/biotrackr/.github/workflows/template-ai-bom-push-image.yml@main
           with:
             working-directory: ./src/Biotrackr.Reporting.Api
             app-name: biotrackr-reporting-api
@@ -111,6 +113,22 @@ jobs:
             - name: Push Docker image
               run: |
                 docker push ${{ steps.acr.outputs.loginServer }}/biotrackr-copilot-python:${{ github.sha }}
+
+            - name: Generate Sidecar SBOM
+              uses: aquasecurity/trivy-action@0.35.0
+              with:
+                image-ref: ${{ steps.acr.outputs.loginServer }}/biotrackr-copilot-python:${{ github.sha }}
+                format: 'cyclonedx'
+                output: 'sidecar-sbom.cdx.json'
+              continue-on-error: true
+
+            - name: Upload Sidecar SBOM as artifact
+              if: always()
+              uses: actions/upload-artifact@v7
+              with:
+                name: sbom-biotrackr-copilot-python
+                path: sidecar-sbom.cdx.json
+                retention-days: 90
 
     retrieve-container-image-dev:
         name: Retrieve Container Image


### PR DESCRIPTION
## Summary

PR 5 of 7 for the AI-BOM implementation. Switches Reporting.Api deploy workflow to the AI-BOM template and adds CycloneDX SBOM generation for the Python Copilot sidecar image.

## Changes

### Modified
- **`.github/workflows/deploy-reporting-api.yml`**
  - Main container image: `uses:` changed from `template-acr-push-image.yml` to `template-ai-bom-push-image.yml`
  - Added `attestations: write` permission
  - Added self-referencing path trigger
  - Sidecar job: Added CycloneDX SBOM generation (`aquasecurity/trivy-action` with `cyclonedx` format) after sidecar image push
  - Sidecar job: Added SBOM artifact upload (`sbom-biotrackr-copilot-python`, 90-day retention)

### Why Reporting.Api?
Reporting.Api is an AI service — it uses Claude Opus via the Copilot SDK sidecar for health report generation. The main container gets the AI-BOM overlay (Claude model cards, service definitions). The sidecar gets its own SBOM capturing Python dependencies (pandas, matplotlib, seaborn, reportlab, numpy).

### Two SBOMs produced
| Image | SBOM | Contents |
|---|---|---|
| `biotrackr-reporting-api` | `sbom-biotrackr-reporting-api` | .NET deps + AI overlay (merged) + attestation |
| `biotrackr-copilot-python` | `sbom-biotrackr-copilot-python` | Python deps (pandas, matplotlib, etc.) |

## Depends On
- PR #284 (merged) — MCP Server AI-BOM + ListToolsFilter