### PR TITLE
feat(reporting-svc): adopt AI-BOM workflow template

### DIFF
--- a/.github/workflows/deploy-reporting-service-monthly.yml
+++ b/.github/workflows/deploy-reporting-service-monthly.yml
@@ -7,12 +7,14 @@ on:
         paths:
             - 'infra/apps/reporting-service-monthly/**'
             - 'src/Biotrackr.Reporting.Svc/**'
+            - '.github/workflows/deploy-reporting-service-monthly.yml'
 
 permissions:
     contents: read
     id-token: write
     pull-requests: write
     checks: write  # Required for dorny/test-reporter@v2
+    attestations: write
 
 env:
   DOTNET_VERSION: 10.0.x
@@ -68,7 +70,7 @@ jobs:
     build-container-image-dev:
         name: Build and Push Container Image
         needs: [run-unit-tests, run-contract-tests, run-e2e-tests]
-        uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
+        uses: willvelida/biotrackr/.github/workflows/template-ai-bom-push-image.yml@main
         with:
           working-directory: ./src/Biotrackr.Reporting.Svc
           app-name: biotrackr-reporting-svc

--- a/.github/workflows/deploy-reporting-service-weekly.yml
+++ b/.github/workflows/deploy-reporting-service-weekly.yml
@@ -7,12 +7,14 @@ on:
         paths:
             - 'infra/apps/reporting-service-weekly/**'
             - 'src/Biotrackr.Reporting.Svc/**'
+            - '.github/workflows/deploy-reporting-service-weekly.yml'
 
 permissions:
     contents: read
     id-token: write
     pull-requests: write
     checks: write  # Required for dorny/test-reporter@v2
+    attestations: write
 
 env:
   DOTNET_VERSION: 10.0.x
@@ -68,7 +70,7 @@ jobs:
     build-container-image-dev:
         name: Build and Push Container Image
         needs: [run-unit-tests, run-contract-tests, run-e2e-tests]
-        uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
+        uses: willvelida/biotrackr/.github/workflows/template-ai-bom-push-image.yml@main
         with:
           working-directory: ./src/Biotrackr.Reporting.Svc
           app-name: biotrackr-reporting-svc

--- a/.github/workflows/deploy-reporting-service-yearly.yml
+++ b/.github/workflows/deploy-reporting-service-yearly.yml
@@ -7,12 +7,14 @@ on:
         paths:
             - 'infra/apps/reporting-service-yearly/**'
             - 'src/Biotrackr.Reporting.Svc/**'
+            - '.github/workflows/deploy-reporting-service-yearly.yml'
 
 permissions:
     contents: read
     id-token: write
     pull-requests: write
     checks: write  # Required for dorny/test-reporter@v2
+    attestations: write
 
 env:
   DOTNET_VERSION: 10.0.x
@@ -68,7 +70,7 @@ jobs:
     build-container-image-dev:
         name: Build and Push Container Image
         needs: [run-unit-tests, run-contract-tests, run-e2e-tests]
-        uses: willvelida/biotrackr/.github/workflows/template-acr-push-image.yml@main
+        uses: willvelida/biotrackr/.github/workflows/template-ai-bom-push-image.yml@main
         with:
           working-directory: ./src/Biotrackr.Reporting.Svc
           app-name: biotrackr-reporting-svc


### PR DESCRIPTION
## Summary

PR 6 of 7 for the AI-BOM implementation. Switches all 3 Reporting.Svc deploy workflow variants to the AI-BOM template.

## Changes

### Modified
- **`.github/workflows/deploy-reporting-service-monthly.yml`** — switched to `template-ai-bom-push-image.yml`, added `attestations: write`, added self-trigger path
- **`.github/workflows/deploy-reporting-service-weekly.yml`** — same changes
- **`.github/workflows/deploy-reporting-service-yearly.yml`** — same changes

### Why Reporting.Svc?
Reporting.Svc is an AI service — it connects to the MCP Server as a client to fetch health data and calls Reporting.Api to generate AI-powered reports. The AI-BOM template enriches its SBOM with AI overlay metadata (Claude model cards, MCP tool inventory, service definitions).

### Not Modified
- All 11 non-AI service workflows unchanged
- Existing `template-acr-push-image.yml` unchanged

## Depends On
- PR #285 (merged) — Reporting.Api AI-BOM + sidecar SBOM