### PR TITLE
core(github): add CODEOWNERS for security-sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default owner for everything
+* @willvelida
+
+# Security-sensitive paths require explicit review
+scripts/ @willvelida
+infra/ @willvelida
+.github/workflows/ @willvelida


### PR DESCRIPTION
## Summary

Adds a `CODEOWNERS` file to declare ownership of security-sensitive paths. This is part of the broader CodeQL expansion and GitHub Actions security hardening effort.

## Changes

- **`.github/CODEOWNERS`** (new) — Declares `@willvelida` as default owner for all paths, with explicit entries for:
  - `scripts/` — Key Vault secrets, Entra ID identity, RBAC scripts
  - `infra/` — Bicep infrastructure definitions
  - `.github/workflows/` — CI/CD pipeline configurations

## Context

Research identified that no CODEOWNERS file existed in the repository. For an open-source project with security-sensitive infrastructure scripts and CI/CD workflows, explicit code ownership ensures PR file changes show ownership clearly in the GitHub UI.

## Follow-up

After this PR merges, the "protect-main" ruleset (id: 9460275) should be enabled via:
```bash
gh api --method PUT /repos/willvelida/biotrackr/rulesets/9460275 -f enforcement=active
```
Or via GitHub UI: Settings > Rules > protect-main > Change "Disabled" to "Active".

This was deliberately sequenced so the ruleset doesn't block the first PR in this series.

## Related

- Part of: CodeQL Expansion & GitHub Actions Security Hardening (PR 1 of 7)
- Research: `.copilot-tracking/research/2026-04-16/codeql-workflow-security-research.md`
- Plan: `.copilot-tracking/plans/2026-04-17/codeql-workflow-security-plan.instructions.md`