### PR TITLE
core(codeql): expand to actions language and upgrade C# config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ permissions:
     security-events: write
 
 jobs:
-    analyze:
+    analyze-csharp:
         name: Analyze C#
         runs-on: ubuntu-latest
 
@@ -25,7 +25,7 @@ jobs:
               uses: actions/checkout@v5
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                 dotnet-version: 10.0.x
 
@@ -33,6 +33,12 @@ jobs:
               uses: github/codeql-action/init@v4
               with:
                 languages: csharp
+                queries: security-extended
+                dependency-caching: true
+                config: |
+                    threat-models: local
+                    paths:
+                        - src
 
             - name: Autobuild
               uses: github/codeql-action/autobuild@v4
@@ -41,3 +47,22 @@ jobs:
               uses: github/codeql-action/analyze@v4
               with:
                 category: "/language:csharp"
+
+    analyze-actions:
+        name: Analyze GitHub Actions
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v5
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v4
+              with:
+                languages: actions
+                queries: security-extended
+
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v4
+              with:
+                category: "/language:actions"


### PR DESCRIPTION
## Summary

Expands CodeQL analysis from 1 language (C# with default config) to 2 languages (C# enhanced + GitHub Actions), and upgrades the C# scanning configuration.

## Changes

### C# Scanning Upgrades (`analyze-csharp` job)
- **`queries: security-extended`** — adds ~10 security queries over `default` suite: IDOR (CWE-639), thread-safety (CWE-362), missing access control (CWE-285), insecure SQL (CWE-327)
- **`threat-models: local`** — extends taint tracking to local data sources (Cosmos DB queries, Key Vault reads, environment variables, App Configuration)
- **`dependency-caching: true`** — caches NuGet packages across runs for faster builds
- **`paths: [src]`** — scopes analysis to source code directory
- **`setup-dotnet@v5`** — fixes version inconsistency (was `@v4`, all other workflows use `@v5`)

### GitHub Actions Scanning (`analyze-actions` job — NEW)
- Adds a parallel job scanning all 35 workflow YAML files
- Uses `security-extended` suite to include `unpinned-tag` detection (moved from default to extended in v0.5.0)
- No build step needed — purely static YAML analysis
- Covers 13+ security queries: expression injection (CWE-094), untrusted checkout (CWE-829), missing permissions (CWE-275), known vulnerable actions (CWE-1395), artifact poisoning, SSRF (CWE-349)

### Expected New Alerts
- `unpinned-tag` alerts for actions using tag-based pinning (will be addressed in PR 7: SHA pinning)
- Potential `missing-permissions` on template workflows
- Potential `code-injection` for deprecated `::set-output` pattern (will be fixed in PR 3: workflow hardening)

## Related

- Part of: CodeQL Expansion & GitHub Actions Security Hardening (PR 2 of 7)
- Research: `.copilot-tracking/research/2026-04-16/codeql-workflow-security-research.md`