### PR TITLE
core(workflows): harden security across CI/CD templates

### DIFF
--- a/.github/workflows/build-copilot-python-image.yml
+++ b/.github/workflows/build-copilot-python-image.yml
@@ -4,7 +4,7 @@ on:
     workflow_dispatch:
 
 permissions:
-    contents: write
+    contents: read
     id-token: write
     pull-requests: write
     checks: write

--- a/.github/workflows/deploy-chat-api.yml
+++ b/.github/workflows/deploy-chat-api.yml
@@ -11,7 +11,7 @@ on:
             - '.github/workflows/deploy-chat-api.yml'
 
 permissions:
-    contents: write
+    contents: read
     id-token: write
     pull-requests: write
     checks: write

--- a/.github/workflows/deploy-reporting-api.yml
+++ b/.github/workflows/deploy-reporting-api.yml
@@ -10,7 +10,7 @@ on:
             - '.github/workflows/deploy-reporting-api.yml'
 
 permissions:
-    contents: write
+    contents: read
     id-token: write
     pull-requests: write
     checks: write

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -54,19 +54,19 @@ jobs:
                 echo "Installing containerapp extension"
                 az extension add -n containerapp --yes
                 apiURL=$(az containerapp revision list -g ${{ secrets.resource-group-name }} -n ${{ inputs.api-name }} --query 'reverse(sort_by([].{Revision:name,Replicas:properties.replicas,Active:properties.active,Created:properties.createdTime,FQDN:properties.fqdn}[?Active!=`false`], &Created))| [0].FQDN' -o tsv)
-                echo "::set-output name=apiURL::$apiURL"
+                echo "apiURL=$apiURL" >> "$GITHUB_OUTPUT"
 
             - name: Get Cosmos DB endpoint
               id: getcosmosendpoint
               run: |
                 cosmosurl=$(az cosmosdb list --resource-group ${{ secrets.resource-group-name }} --query "[0].documentEndpoint" --output tsv)
-                echo "::Set-output name=cosmosurl::$cosmosurl"
+                echo "cosmosurl=$cosmosurl" >> "$GITHUB_OUTPUT"
 
             - name: Get App Config endpoint
               id: getappconfigendpoint
               run: |
                 appconfigurl=$(az appconfig list --resource-group ${{ secrets.resource-group-name }} --query "[0].endpoint" --output tsv)
-                echo "::set-output name=appconfigurl::$appconfigurl"
+                echo "appconfigurl=$appconfigurl" >> "$GITHUB_OUTPUT"
             
             - name: Setup .NET ${{ inputs.dotnet-version }}
               uses: actions/setup-dotnet@v5

--- a/.github/workflows/template-bicep-deploy.yml
+++ b/.github/workflows/template-bicep-deploy.yml
@@ -63,27 +63,35 @@ jobs:
         - name: Prepare Parameters
           id: prepare-params
           shell: bash
+          env:
+            INPUT_PARAMS: ${{ inputs.parameters }}
+            INJECT_TENANT_ID: ${{ inputs.inject-tenant-id }}
+            TENANT_ID: ${{ secrets.tenant-id }}
+            INJECT_EASY_AUTH: ${{ inputs.inject-easy-auth-config }}
+            EASY_AUTH_CLIENT_ID: ${{ secrets.easy-auth-client-id }}
+            INJECT_ALERT_EMAIL: ${{ inputs.inject-alert-email }}
+            ALERT_EMAIL_ADDRESS: ${{ secrets.alert-email-address }}
           run: |
-            PARAMS='${{ inputs.parameters }}'
+            PARAMS="$INPUT_PARAMS"
 
             if [ -z "$PARAMS" ]; then
               PARAMS='{}'
             fi
 
-            if [ "${{ inputs.inject-tenant-id }}" = "true" ]; then
-              PARAMS=$(echo "$PARAMS" | jq -c --arg tenantId "${{ secrets.tenant-id }}" '. + {"tenantId": $tenantId}')
+            if [ "$INJECT_TENANT_ID" = "true" ]; then
+              PARAMS=$(echo "$PARAMS" | jq -c --arg tenantId "$TENANT_ID" '. + {"tenantId": $tenantId}')
             fi
 
-            if [ "${{ inputs.inject-easy-auth-config }}" = "true" ]; then
-              PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthTenantId "${{ secrets.tenant-id }}" '. + {"easyAuthTenantId": $easyAuthTenantId}')
+            if [ "$INJECT_EASY_AUTH" = "true" ]; then
+              PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthTenantId "$TENANT_ID" '. + {"easyAuthTenantId": $easyAuthTenantId}')
 
-              if [ -n "${{ secrets.easy-auth-client-id }}" ]; then
-                PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthClientId "${{ secrets.easy-auth-client-id }}" '. + {"easyAuthClientId": $easyAuthClientId}')
+              if [ -n "$EASY_AUTH_CLIENT_ID" ]; then
+                PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthClientId "$EASY_AUTH_CLIENT_ID" '. + {"easyAuthClientId": $easyAuthClientId}')
               fi
             fi
 
-            if [ "${{ inputs.inject-alert-email }}" = "true" ]; then
-              PARAMS=$(echo "$PARAMS" | jq -c --arg alertEmailAddress "${{ secrets.alert-email-address }}" '. + {"alertEmailAddress": $alertEmailAddress}')
+            if [ "$INJECT_ALERT_EMAIL" = "true" ]; then
+              PARAMS=$(echo "$PARAMS" | jq -c --arg alertEmailAddress "$ALERT_EMAIL_ADDRESS" '. + {"alertEmailAddress": $alertEmailAddress}')
             fi
 
             echo "params=$PARAMS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/template-bicep-validate.yml
+++ b/.github/workflows/template-bicep-validate.yml
@@ -59,22 +59,28 @@ jobs:
             - name: Prepare Parameters
               id: prepare-params
               shell: bash
+              env:
+                INPUT_PARAMS: ${{ inputs.parameters }}
+                INJECT_TENANT_ID: ${{ inputs.inject-tenant-id }}
+                TENANT_ID: ${{ secrets.tenant-id }}
+                INJECT_EASY_AUTH: ${{ inputs.inject-easy-auth-config }}
+                EASY_AUTH_CLIENT_ID: ${{ secrets.easy-auth-client-id }}
               run: |
-                PARAMS='${{ inputs.parameters }}'
+                PARAMS="$INPUT_PARAMS"
 
                 if [ -z "$PARAMS" ]; then
                   PARAMS='{}'
                 fi
 
-                if [ "${{ inputs.inject-tenant-id }}" = "true" ]; then
-                  PARAMS=$(echo "$PARAMS" | jq -c --arg tenantId "${{ secrets.tenant-id }}" '. + {"tenantId": $tenantId}')
+                if [ "$INJECT_TENANT_ID" = "true" ]; then
+                  PARAMS=$(echo "$PARAMS" | jq -c --arg tenantId "$TENANT_ID" '. + {"tenantId": $tenantId}')
                 fi
 
-                if [ "${{ inputs.inject-easy-auth-config }}" = "true" ]; then
-                  PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthTenantId "${{ secrets.tenant-id }}" '. + {"easyAuthTenantId": $easyAuthTenantId}')
+                if [ "$INJECT_EASY_AUTH" = "true" ]; then
+                  PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthTenantId "$TENANT_ID" '. + {"easyAuthTenantId": $easyAuthTenantId}')
 
-                  if [ -n "${{ secrets.easy-auth-client-id }}" ]; then
-                    PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthClientId "${{ secrets.easy-auth-client-id }}" '. + {"easyAuthClientId": $easyAuthClientId}')
+                  if [ -n "$EASY_AUTH_CLIENT_ID" ]; then
+                    PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthClientId "$EASY_AUTH_CLIENT_ID" '. + {"easyAuthClientId": $easyAuthClientId}')
                   fi
                 fi
 

--- a/.github/workflows/template-bicep-validate.yml
+++ b/.github/workflows/template-bicep-validate.yml
@@ -65,6 +65,8 @@ jobs:
                 TENANT_ID: ${{ secrets.tenant-id }}
                 INJECT_EASY_AUTH: ${{ inputs.inject-easy-auth-config }}
                 EASY_AUTH_CLIENT_ID: ${{ secrets.easy-auth-client-id }}
+                INJECT_ALERT_EMAIL: ${{ inputs.inject-alert-email }}
+                ALERT_EMAIL_ADDRESS: ${{ secrets.alert-email-address }}
               run: |
                 PARAMS="$INPUT_PARAMS"
 
@@ -84,8 +86,8 @@ jobs:
                   fi
                 fi
 
-                if [ "${{ inputs.inject-alert-email }}" = "true" ]; then
-                  PARAMS=$(echo "$PARAMS" | jq -c --arg alertEmailAddress "${{ secrets.alert-email-address }}" '. + {"alertEmailAddress": $alertEmailAddress}')
+                if [ "$INJECT_ALERT_EMAIL" = "true" ]; then
+                  PARAMS=$(echo "$PARAMS" | jq -c --arg alertEmailAddress "$ALERT_EMAIL_ADDRESS" '. + {"alertEmailAddress": $alertEmailAddress}')
                 fi
 
                 echo "params=$PARAMS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/template-bicep-whatif.yml
+++ b/.github/workflows/template-bicep-whatif.yml
@@ -59,27 +59,35 @@ jobs:
         - name: Prepare Parameters
           id: prepare-params
           shell: bash
+          env:
+            INPUT_PARAMS: ${{ inputs.parameters }}
+            INJECT_TENANT_ID: ${{ inputs.inject-tenant-id }}
+            TENANT_ID: ${{ secrets.tenant-id }}
+            INJECT_EASY_AUTH: ${{ inputs.inject-easy-auth-config }}
+            EASY_AUTH_CLIENT_ID: ${{ secrets.easy-auth-client-id }}
+            INJECT_ALERT_EMAIL: ${{ inputs.inject-alert-email }}
+            ALERT_EMAIL_ADDRESS: ${{ secrets.alert-email-address }}
           run: |
-            PARAMS='${{ inputs.parameters }}'
+            PARAMS="$INPUT_PARAMS"
 
             if [ -z "$PARAMS" ]; then
               PARAMS='{}'
             fi
 
-            if [ "${{ inputs.inject-tenant-id }}" = "true" ]; then
-              PARAMS=$(echo "$PARAMS" | jq -c --arg tenantId "${{ secrets.tenant-id }}" '. + {"tenantId": $tenantId}')
+            if [ "$INJECT_TENANT_ID" = "true" ]; then
+              PARAMS=$(echo "$PARAMS" | jq -c --arg tenantId "$TENANT_ID" '. + {"tenantId": $tenantId}')
             fi
 
-            if [ "${{ inputs.inject-easy-auth-config }}" = "true" ]; then
-              PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthTenantId "${{ secrets.tenant-id }}" '. + {"easyAuthTenantId": $easyAuthTenantId}')
+            if [ "$INJECT_EASY_AUTH" = "true" ]; then
+              PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthTenantId "$TENANT_ID" '. + {"easyAuthTenantId": $easyAuthTenantId}')
 
-              if [ -n "${{ secrets.easy-auth-client-id }}" ]; then
-                PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthClientId "${{ secrets.easy-auth-client-id }}" '. + {"easyAuthClientId": $easyAuthClientId}')
+              if [ -n "$EASY_AUTH_CLIENT_ID" ]; then
+                PARAMS=$(echo "$PARAMS" | jq -c --arg easyAuthClientId "$EASY_AUTH_CLIENT_ID" '. + {"easyAuthClientId": $easyAuthClientId}')
               fi
             fi
 
-            if [ "${{ inputs.inject-alert-email }}" = "true" ]; then
-              PARAMS=$(echo "$PARAMS" | jq -c --arg alertEmailAddress "${{ secrets.alert-email-address }}" '. + {"alertEmailAddress": $alertEmailAddress}')
+            if [ "$INJECT_ALERT_EMAIL" = "true" ]; then
+              PARAMS=$(echo "$PARAMS" | jq -c --arg alertEmailAddress "$ALERT_EMAIL_ADDRESS" '. + {"alertEmailAddress": $alertEmailAddress}')
             fi
 
             echo "params=$PARAMS" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Hardens 7 GitHub Actions workflow files against OWASP CI/CD Top 10 findings identified during the security audit.

## Changes

### Fix deprecated `::set-output` commands (CICD-07)
- **`template-aca-api-integration-tests.yml`** — Replace 3 deprecated `::set-output` / `::Set-output` commands with modern `$GITHUB_OUTPUT` syntax (lines 57, 63, 69)
- The deprecated command is vulnerable to log injection attacks and has been removed in newer GitHub Actions runners

### Scope `contents: write` to `contents: read` (CICD-05)
- **`deploy-chat-api.yml`** — `contents: write` → `contents: read` (workflow-level)
- **`deploy-reporting-api.yml`** — `contents: write` → `contents: read` (workflow-level)
- **`build-copilot-python-image.yml`** — `contents: write` → `contents: read` (workflow-level)
- The `template-ai-bom-push-image.yml` reusable workflow already sets its own job-level `contents: read` + `attestations: write`, so callers don't need `contents: write`

### Mitigate `inputs.parameters` shell injection (CICD-04)
- **`template-bicep-deploy.yml`** — Move all `${{ inputs.* }}` and `${{ secrets.* }}` from `run:` blocks to `env:` block
- **`template-bicep-validate.yml`** — Same pattern
- **`template-bicep-whatif.yml`** — Same pattern
- Prevents potential shell injection if parameter values contain metacharacters. While inputs come from trusted `workflow_call` callers, using `env:` is defense-in-depth best practice.

## OWASP CI/CD Findings Addressed

| Finding | Severity | OWASP | Fix |
|---------|----------|-------|-----|
| Deprecated `::set-output` | HIGH | CICD-07 | `$GITHUB_OUTPUT` syntax |
| `contents: write` at workflow level | MEDIUM | CICD-05 | Scoped to `contents: read` |
| Direct `${{ }}` in `run:` blocks | MEDIUM | CICD-04 | `env:` block indirection |

## Related

- Part of: CodeQL Expansion & GitHub Actions Security Hardening (PR 3 of 7)
- Research: `.copilot-tracking/research/2026-04-16/codeql-workflow-security-research.md`
- zizmor findings addressed: `insecure-commands` (3), `excessive-permissions` (partial), `template-injection` (partial)