### PR TITLE
core(workflows): SHA-pin all GitHub Actions across 37 workflows

### DIFF
--- a/.github/workflows/ai-bom-safety-check.yml
+++ b/.github/workflows/ai-bom-safety-check.yml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Run AI-BOM safety check
               shell: pwsh

--- a/.github/workflows/build-copilot-python-image.yml
+++ b/.github/workflows/build-copilot-python-image.yml
@@ -23,17 +23,17 @@ jobs:
           working-directory: ${{ env.WORKING_DIRECTORY }}
       steps:
         - name: Checkout code
-          uses: actions/checkout@v5
+          uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}
             subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v4
+          uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
         - name: Get ACR name
           id: getacrname
@@ -58,7 +58,7 @@ jobs:
             docker build -f Dockerfile.sidecar -t ${{ steps.getacrserver.outputs.loginServer }}/${{ env.APP_NAME }}:${{ github.sha }} .
 
         - name: Run Trivy vulnerability scanner
-          uses: aquasecurity/trivy-action@0.35.0
+          uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
           with:
             image-ref: ${{ steps.getacrserver.outputs.loginServer }}/${{ env.APP_NAME }}:${{ github.sha }}
             format: 'table'

--- a/.github/workflows/checkov-bicep.yml
+++ b/.github/workflows/checkov-bicep.yml
@@ -22,10 +22,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Run Checkov
-              uses: bridgecrewio/checkov-action@v12
+              uses: bridgecrewio/checkov-action@de2bfaecd21d58ef232e0d2a3391c33c32c460d7 # v12
               with:
                 directory: infra/modules/
                 framework: bicep
@@ -34,7 +34,7 @@ jobs:
                 soft_fail: true
 
             - name: Upload SARIF
-              uses: github/codeql-action/upload-sarif@v4
+              uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
               if: success() || failure()
               with:
                 sarif_file: results.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,15 +22,15 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
               with:
                 dotnet-version: 10.0.x
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v4
+              uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
               with:
                 languages: csharp
                 queries: security-extended
@@ -41,10 +41,10 @@ jobs:
                         - src
 
             - name: Autobuild
-              uses: github/codeql-action/autobuild@v4
+              uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v4
+              uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
               with:
                 category: "/language:csharp"
 
@@ -54,15 +54,15 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v4
+              uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
               with:
                 languages: actions
                 queries: security-extended
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v4
+              uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
               with:
                 category: "/language:actions"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,12 +12,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
               with:
                 persist-credentials: false
 
             - name: Dependency Review
-              uses: actions/dependency-review-action@v4
+              uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
               with:
                 fail-on-severity: moderate
                 comment-summary-in-pr: on-failure

--- a/.github/workflows/deploy-activity-api.yml
+++ b/.github/workflows/deploy-activity-api.yml
@@ -70,7 +70,7 @@ jobs:
           loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
         steps:
           - name: Azure login
-            uses: azure/login@v2
+            uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
             with:
               client-id: ${{ secrets.AZURE_CLIENT_ID }}
               tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-activity-service.yml
+++ b/.github/workflows/deploy-activity-service.yml
@@ -12,7 +12,7 @@ permissions:
     contents: read
     id-token: write
     pull-requests: write
-    checks: write  # Required for dorny/test-reporter@v2
+    checks: write  # Required for dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
 
 env:
   DOTNET_VERSION: 10.0.x
@@ -86,7 +86,7 @@ jobs:
         loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
       steps:
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-auth-fitbit-service.yml
+++ b/.github/workflows/deploy-auth-fitbit-service.yml
@@ -57,10 +57,10 @@ jobs:
           working-directory: ./src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.IntegrationTests
       steps:
         - name: Checkout Repository code
-          uses: actions/checkout@v5
+          uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
         - name: Setup .NET ${{ needs.env-setup.outputs.dotnet-version }}
-          uses: actions/setup-dotnet@v5
+          uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
         
@@ -80,7 +80,7 @@ jobs:
               --results-directory ./TestResults
 
         - name: Publish Test Results
-          uses: dorny/test-reporter@v2
+          uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
           if: always()
           with:
             name: E2E Test Results (Auth Fitbit)
@@ -109,7 +109,7 @@ jobs:
         loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
       steps:
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-auth-withings-service.yml
+++ b/.github/workflows/deploy-auth-withings-service.yml
@@ -57,10 +57,10 @@ jobs:
           working-directory: ./src/Biotrackr.Auth.Svc/Biotrackr.Auth.Svc.IntegrationTests
       steps:
         - name: Checkout Repository code
-          uses: actions/checkout@v5
+          uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
         - name: Setup .NET ${{ needs.env-setup.outputs.dotnet-version }}
-          uses: actions/setup-dotnet@v5
+          uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
           with:
             dotnet-version: ${{ needs.env-setup.outputs.dotnet-version }}
         
@@ -80,7 +80,7 @@ jobs:
               --results-directory ./TestResults
 
         - name: Publish Test Results
-          uses: dorny/test-reporter@v2
+          uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
           if: always()
           with:
             name: E2E Test Results (Auth Withings)
@@ -109,7 +109,7 @@ jobs:
         loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
       steps:
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-chat-api.yml
+++ b/.github/workflows/deploy-chat-api.yml
@@ -73,7 +73,7 @@ jobs:
           loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
         steps:
           - name: Azure login
-            uses: azure/login@v2
+            uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
             with:
               client-id: ${{ secrets.AZURE_CLIENT_ID }}
               tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-food-api.yml
+++ b/.github/workflows/deploy-food-api.yml
@@ -70,7 +70,7 @@ jobs:
           loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
         steps:
           - name: Azure login
-            uses: azure/login@v2
+            uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
             with:
               client-id: ${{ secrets.AZURE_CLIENT_ID }}
               tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-food-service.yml
+++ b/.github/workflows/deploy-food-service.yml
@@ -12,7 +12,7 @@ permissions:
     contents: read
     id-token: write
     pull-requests: write
-    checks: write  # Required for dorny/test-reporter@v2
+    checks: write  # Required for dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
 
 env:
   DOTNET_VERSION: 10.0.x
@@ -86,7 +86,7 @@ jobs:
         loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
       steps:
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-mcp-server.yml
+++ b/.github/workflows/deploy-mcp-server.yml
@@ -71,7 +71,7 @@ jobs:
           loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
         steps:
           - name: Azure login
-            uses: azure/login@v2
+            uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
             with:
               client-id: ${{ secrets.AZURE_CLIENT_ID }}
               tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-reporting-api.yml
+++ b/.github/workflows/deploy-reporting-api.yml
@@ -73,17 +73,17 @@ jobs:
               working-directory: ./src/Biotrackr.Reporting.Api
           steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Azure login
-              uses: azure/login@v2
+              uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
               with:
                 client-id: ${{ secrets.AZURE_CLIENT_ID }}
                 tenant-id: ${{ secrets.AZURE_TENANT_ID }}
                 subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4
+              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
             - name: Get ACR details
               id: acr
@@ -101,7 +101,7 @@ jobs:
                 docker build -f Dockerfile.sidecar -t ${{ steps.acr.outputs.loginServer }}/biotrackr-copilot-python:${{ github.sha }} .
 
             - name: Run Trivy vulnerability scanner
-              uses: aquasecurity/trivy-action@0.35.0
+              uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
               with:
                 image-ref: ${{ steps.acr.outputs.loginServer }}/biotrackr-copilot-python:${{ github.sha }}
                 format: 'table'
@@ -115,7 +115,7 @@ jobs:
                 docker push ${{ steps.acr.outputs.loginServer }}/biotrackr-copilot-python:${{ github.sha }}
 
             - name: Generate Sidecar SBOM
-              uses: aquasecurity/trivy-action@0.35.0
+              uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
               with:
                 image-ref: ${{ steps.acr.outputs.loginServer }}/biotrackr-copilot-python:${{ github.sha }}
                 format: 'cyclonedx'
@@ -124,7 +124,7 @@ jobs:
 
             - name: Upload Sidecar SBOM as artifact
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                 name: sbom-biotrackr-copilot-python
                 path: sidecar-sbom.cdx.json
@@ -138,7 +138,7 @@ jobs:
           loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
         steps:
           - name: Azure login
-            uses: azure/login@v2
+            uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
             with:
               client-id: ${{ secrets.AZURE_CLIENT_ID }}
               tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-reporting-service-monthly.yml
+++ b/.github/workflows/deploy-reporting-service-monthly.yml
@@ -13,7 +13,7 @@ permissions:
     contents: read
     id-token: write
     pull-requests: write
-    checks: write  # Required for dorny/test-reporter@v2
+    checks: write  # Required for dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
     attestations: write
 
 env:
@@ -88,7 +88,7 @@ jobs:
         loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
       steps:
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-reporting-service-weekly.yml
+++ b/.github/workflows/deploy-reporting-service-weekly.yml
@@ -13,7 +13,7 @@ permissions:
     contents: read
     id-token: write
     pull-requests: write
-    checks: write  # Required for dorny/test-reporter@v2
+    checks: write  # Required for dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
     attestations: write
 
 env:
@@ -88,7 +88,7 @@ jobs:
         loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
       steps:
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-reporting-service-yearly.yml
+++ b/.github/workflows/deploy-reporting-service-yearly.yml
@@ -13,7 +13,7 @@ permissions:
     contents: read
     id-token: write
     pull-requests: write
-    checks: write  # Required for dorny/test-reporter@v2
+    checks: write  # Required for dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
     attestations: write
 
 env:
@@ -88,7 +88,7 @@ jobs:
         loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
       steps:
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-sleep-api.yml
+++ b/.github/workflows/deploy-sleep-api.yml
@@ -86,7 +86,7 @@ jobs:
           loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
         steps:
           - name: Azure login
-            uses: azure/login@v2
+            uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
             with:
               client-id: ${{ secrets.AZURE_CLIENT_ID }}
               tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-sleep-service.yml
+++ b/.github/workflows/deploy-sleep-service.yml
@@ -13,7 +13,7 @@ permissions:
     contents: read
     id-token: write
     pull-requests: write
-    checks: write  # Required for dorny/test-reporter@v2
+    checks: write  # Required for dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
 
 env:
   DOTNET_VERSION: 10.0.x
@@ -82,7 +82,7 @@ jobs:
         loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
       steps:
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -60,7 +60,7 @@ jobs:
       loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
     steps:
       - name: Azure login
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-vitals-api.yml
+++ b/.github/workflows/deploy-vitals-api.yml
@@ -70,7 +70,7 @@ jobs:
           loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
         steps:
           - name: Azure login
-            uses: azure/login@v2
+            uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
             with:
               client-id: ${{ secrets.AZURE_CLIENT_ID }}
               tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-vitals-service.yml
+++ b/.github/workflows/deploy-vitals-service.yml
@@ -82,7 +82,7 @@ jobs:
         loginServer: ${{ steps.get-acr-server.outputs.loginServer }}
       steps:
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -23,10 +23,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
               with:
                   dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -41,15 +41,15 @@ jobs:
         environment: dev
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
               with:
                   dotnet-version: ${{ env.DOTNET_VERSION }}
 
             - name: Azure Login
-              uses: azure/login@v2
+              uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -64,7 +64,7 @@ jobs:
 
             - name: Upload Results
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: evaluation-results
                   path: ./src/Biotrackr.Chat.Api/Biotrackr.Chat.Api.Evaluation.Tests/TestResults/

--- a/.github/workflows/psrule-bicep.yml
+++ b/.github/workflows/psrule-bicep.yml
@@ -24,10 +24,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Analyze Bicep files
-              uses: microsoft/ps-rule@v2.9.0
+              uses: microsoft/ps-rule@46451b8f5258c41beb5ae69ed7190ccbba84112c # v2.9.0
               continue-on-error: true
               with:
                 modules: 'PSRule.Rules.Azure'
@@ -35,7 +35,7 @@ jobs:
                 outputPath: results.sarif
 
             - name: Upload SARIF
-              uses: github/codeql-action/upload-sarif@v4
+              uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
               if: success() || failure()
               with:
                 sarif_file: results.sarif

--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -25,7 +25,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
               with:
                 persist-credentials: false
 

--- a/.github/workflows/task-purge-old-images.yml
+++ b/.github/workflows/task-purge-old-images.yml
@@ -16,7 +16,7 @@ jobs:
 
         steps:
             - name: Azure login
-              uses: azure/login@v2
+              uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
               with:
                 client-id: ${{ secrets.AZURE_CLIENT_ID }}
                 tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/template-aca-api-integration-tests.yml
+++ b/.github/workflows/template-aca-api-integration-tests.yml
@@ -39,9 +39,9 @@ jobs:
 
         steps:
             - name: Checkout Repository code
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-            - uses: azure/login@v2
+            - uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
               name: Login to Azure
               with:
                 client-id: ${{ secrets.client-id }}
@@ -69,7 +69,7 @@ jobs:
                 echo "appconfigurl=$appconfigurl" >> "$GITHUB_OUTPUT"
             
             - name: Setup .NET ${{ inputs.dotnet-version }}
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
               with:
                 dotnet-version: ${{ inputs.dotnet-version }}
             

--- a/.github/workflows/template-acr-push-image.yml
+++ b/.github/workflows/template-acr-push-image.yml
@@ -35,17 +35,17 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
       steps:
         - name: Checkout code
-          uses: actions/checkout@v5
+          uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
   
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.client-id }}
             tenant-id: ${{ secrets.tenant-id }}
             subscription-id: ${{ secrets.subscription-id }}
   
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v4
+          uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
   
         - name: Get ACR name
           id: getacrname
@@ -67,7 +67,7 @@ jobs:
             docker build -f ${{ inputs.dockerfile }} -t ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}:${{ github.sha }} .
 
         - name: Generate SBOM
-          uses: aquasecurity/trivy-action@0.35.0
+          uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
           with:
             image-ref: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}:${{ github.sha }}
             format: 'cyclonedx'
@@ -76,14 +76,14 @@ jobs:
 
         - name: Upload SBOM as artifact
           if: always()
-          uses: actions/upload-artifact@v7
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
           with:
             name: sbom-${{ inputs.app-name }}
             path: sbom.cdx.json
             retention-days: 90
 
         - name: Submit SBOM to GitHub Dependency Graph
-          uses: anchore/sbom-action@v0
+          uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
           with:
             image: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}:${{ github.sha }}
             dependency-snapshot: true
@@ -91,12 +91,12 @@ jobs:
           continue-on-error: true
 
         - name: Run Dockle
-          uses: erzz/dockle-action@v1
+          uses: erzz/dockle-action@e8a7c41f36f1236ca3282b298d425ffbfdb2e922 # v1
           with:
             image: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}:${{ github.sha }}
 
         - name: Run Trivy vulnerability scanner
-          uses: aquasecurity/trivy-action@0.35.0
+          uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
           with:
             image-ref: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}:${{ github.sha }}
             format: 'table'

--- a/.github/workflows/template-ai-bom-push-image.yml
+++ b/.github/workflows/template-ai-bom-push-image.yml
@@ -39,17 +39,17 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
       steps:
         - name: Checkout code
-          uses: actions/checkout@v5
+          uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           with:
             client-id: ${{ secrets.client-id }}
             tenant-id: ${{ secrets.tenant-id }}
             subscription-id: ${{ secrets.subscription-id }}
 
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v4
+          uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
         - name: Get ACR name
           id: getacrname
@@ -68,7 +68,7 @@ jobs:
 
         - name: Build and push Docker image
           id: build-push
-          uses: docker/build-push-action@v6
+          uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
           with:
             context: ${{ inputs.working-directory }}
             file: ${{ inputs.working-directory }}/${{ inputs.dockerfile }}
@@ -76,7 +76,7 @@ jobs:
             tags: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}:${{ github.sha }}
 
         - name: Generate SBOM
-          uses: aquasecurity/trivy-action@0.35.0
+          uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
           with:
             image-ref: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}@${{ steps.build-push.outputs.digest }}
             format: 'cyclonedx'
@@ -106,14 +106,14 @@ jobs:
 
         - name: Upload SBOM as artifact
           if: always()
-          uses: actions/upload-artifact@v7
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
           with:
             name: sbom-${{ inputs.app-name }}
             path: ${{ github.workspace }}/sbom.cdx.json
             retention-days: 90
 
         - name: Submit SBOM to GitHub Dependency Graph
-          uses: anchore/sbom-action@v0
+          uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
           with:
             image: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}@${{ steps.build-push.outputs.digest }}
             dependency-snapshot: true
@@ -121,12 +121,12 @@ jobs:
           continue-on-error: true
 
         - name: Run Dockle
-          uses: erzz/dockle-action@v1
+          uses: erzz/dockle-action@e8a7c41f36f1236ca3282b298d425ffbfdb2e922 # v1
           with:
             image: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}:${{ github.sha }}
 
         - name: Run Trivy vulnerability scanner
-          uses: aquasecurity/trivy-action@0.35.0
+          uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
           with:
             image-ref: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}@${{ steps.build-push.outputs.digest }}
             format: 'table'
@@ -136,7 +136,7 @@ jobs:
             severity: 'CRITICAL,HIGH'
 
         - name: Attest build provenance
-          uses: actions/attest@v4
+          uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
           with:
             subject-name: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}
             subject-digest: ${{ steps.build-push.outputs.digest }}
@@ -144,7 +144,7 @@ jobs:
 
         - name: Attest SBOM
           if: hashFiles(format('{0}/sbom.cdx.json', github.workspace)) != ''
-          uses: actions/attest@v4
+          uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
           with:
             subject-name: ${{ steps.getacrserver.outputs.loginServer }}/${{ inputs.app-name }}
             subject-digest: ${{ steps.build-push.outputs.digest }}

--- a/.github/workflows/template-bicep-deploy.yml
+++ b/.github/workflows/template-bicep-deploy.yml
@@ -50,10 +50,10 @@ jobs:
         runs-on: ubuntu-latest
         environment: ${{ inputs.environment }}
         steps:
-        - uses: actions/checkout@v5
+        - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
           name: Checkout Repository Code
 
-        - uses: azure/login@v2
+        - uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           name: Login to Azure
           with:
             client-id: ${{ secrets.client-id }}
@@ -96,7 +96,7 @@ jobs:
 
             echo "params=$PARAMS" >> "$GITHUB_OUTPUT"
 
-        - uses: azure/bicep-deploy@v2
+        - uses: azure/bicep-deploy@66910e9c5c7733c33a1cd605030d02234b3bc4ed # v2
           name: Deploy Bicep Template
           with:
             type: deployment

--- a/.github/workflows/template-bicep-linter.yml
+++ b/.github/workflows/template-bicep-linter.yml
@@ -12,7 +12,7 @@ jobs:
         name: Lint Bicep Template
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
               name: Checkout Repository Code
 
             - name: Run Bicep Linter

--- a/.github/workflows/template-bicep-validate.yml
+++ b/.github/workflows/template-bicep-validate.yml
@@ -46,10 +46,10 @@ jobs:
         name: Validate Bicep Template
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
               name: Checkout Repository Code
 
-            - uses: azure/login@v2
+            - uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
               name: Login to Azure
               with:
                 client-id: ${{ secrets.client-id }}
@@ -92,7 +92,7 @@ jobs:
 
                 echo "params=$PARAMS" >> "$GITHUB_OUTPUT"
 
-            - uses: azure/bicep-deploy@v2
+            - uses: azure/bicep-deploy@66910e9c5c7733c33a1cd605030d02234b3bc4ed # v2
               name: Run preflight validation
               with:
                 type: deployment

--- a/.github/workflows/template-bicep-whatif.yml
+++ b/.github/workflows/template-bicep-whatif.yml
@@ -46,10 +46,10 @@ jobs:
         name: Preview Bicep Template Deployment
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v5
+        - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
           name: Checkout Repository Code
 
-        - uses: azure/login@v2
+        - uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
           name: Login to Azure
           with:
             client-id: ${{ secrets.client-id }}
@@ -92,7 +92,7 @@ jobs:
 
             echo "params=$PARAMS" >> "$GITHUB_OUTPUT"
 
-        - uses: azure/bicep-deploy@v2
+        - uses: azure/bicep-deploy@66910e9c5c7733c33a1cd605030d02234b3bc4ed # v2
           name: Perform What-If
           with:
             type: deployment

--- a/.github/workflows/template-dotnet-run-contract-tests.yml
+++ b/.github/workflows/template-dotnet-run-contract-tests.yml
@@ -26,10 +26,10 @@ jobs:
                 working-directory: ${{ inputs.working-directory }}
         steps:
             - name: Checkout Repository code
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Setup .NET ${{ inputs.dotnet-version }}
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
               with:
                 dotnet-version: ${{ inputs.dotnet-version }}
             
@@ -49,7 +49,7 @@ jobs:
                   --results-directory ./TestResults
 
             - name: Upload Test Results
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               if: always()
               with:
                 name: contract-test-results-${{ github.run_number }}
@@ -57,7 +57,7 @@ jobs:
                 retention-days: 30
 
             - name: Publish Test Results
-              uses: dorny/test-reporter@v2
+              uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
               if: always()
               with:
                 name: Contract Test Results

--- a/.github/workflows/template-dotnet-run-e2e-tests.yml
+++ b/.github/workflows/template-dotnet-run-e2e-tests.yml
@@ -53,10 +53,10 @@ jobs:
 
         steps:
             - name: Checkout Repository code
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Setup .NET ${{ inputs.dotnet-version }}
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
               with:
                 dotnet-version: ${{ inputs.dotnet-version }}
 
@@ -102,7 +102,7 @@ jobs:
                 tenantid: ${{ secrets.tenant-id }}
 
             - name: Upload Test Results
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               if: always()
               with:
                 name: e2e-test-results-${{ github.run_number }}
@@ -110,7 +110,7 @@ jobs:
                 retention-days: 30
 
             - name: Publish Test Results
-              uses: dorny/test-reporter@v2
+              uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
               if: always()
               with:
                 name: E2E Test Results

--- a/.github/workflows/template-dotnet-run-unit-tests.yml
+++ b/.github/workflows/template-dotnet-run-unit-tests.yml
@@ -36,10 +36,10 @@ jobs:
                 working-directory: ${{ inputs.working-directory }}
         steps:
             - name: Checkout Repository code
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Setup .NET ${{ inputs.dotnet-version }}
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
               with:
                 dotnet-version: ${{ inputs.dotnet-version }}
             
@@ -69,7 +69,7 @@ jobs:
                     "-filefilters:-*.g.cs"
 
             - name: Upload Coverage Report
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               if: always()
               with:
                 name: coverage-report-${{ github.run_number }}
@@ -77,7 +77,7 @@ jobs:
                 retention-days: 30
 
             - name: Code Coverage Summary
-              uses: irongut/CodeCoverageSummary@v1.3.0
+              uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
               with:
                   filename: ${{ inputs.working-directory }}/CoverageReport/Cobertura.xml
                   badge: true
@@ -90,7 +90,7 @@ jobs:
                   thresholds: '${{ inputs.coverage-threshold }} 80'
 
             - name: Add Coverage PR Comment
-              uses: marocchino/sticky-pull-request-comment@v3
+              uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
               if: github.event_name == 'pull_request'
               with:
                 recreate: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,10 +20,10 @@ jobs:
             actions: read
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
               with:
                 persist-credentials: false
 
             - name: Run zizmor
-              uses: zizmorcore/zizmor-action@v0.5.3
+              uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
               continue-on-error: true


### PR DESCRIPTION
## Summary

SHA-pins all 21 external GitHub Actions to full 40-character commit SHAs across all 37 workflow files. This is the final PR in the CodeQL Expansion & GitHub Actions Security Hardening series.

## Changes

**37 files modified, 111 lines changed** — every external `uses:` reference now includes a commit SHA with a version comment.

### Actions Pinned (21 unique, by risk tier)

#### Community / Third-Party (highest risk)
| Action | Tag | SHA |
|--------|-----|-----|
| `irongut/CodeCoverageSummary` | v1.3.0 | `51cc3a75...` |
| `marocchino/sticky-pull-request-comment` | v3 | `d4d6b093...` |
| `dorny/test-reporter` | v2 | `df624742...` |
| `erzz/dockle-action` | v1 | `e8a7c41f...` |

#### Verified Vendors
| Action | Tag | SHA |
|--------|-----|-----|
| `aquasecurity/trivy-action` | 0.35.0 | `57a97c7e...` |
| `anchore/sbom-action` | v0 | `e22c3899...` |
| `docker/setup-buildx-action` | v4 | `4d04d5d9...` |
| `docker/build-push-action` | v6 | `10e90e36...` |
| `bridgecrewio/checkov-action` | v12 | `de2bfaec...` |
| `microsoft/ps-rule` | v2.9.0 | `46451b8f...` |
| `zizmorcore/zizmor-action` | v0.5.3 | `b1d7e1fb...` |

#### GitHub / Microsoft Official
| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v5 | `93cb6efe...` |
| `actions/setup-dotnet` | v5 | `c2fa09f4...` |
| `actions/upload-artifact` | v7 | `043fb46d...` |
| `actions/attest` | v4 | `59d89421...` |
| `actions/dependency-review-action` | v4 | `2031cfc0...` |
| `azure/login` | v2 | `a457da9e...` |
| `azure/bicep-deploy` | v2 | `66910e9c...` |
| `github/codeql-action/*` | v4 | `95e58e9a...` |

## OWASP CI/CD Findings Addressed

- **CICD-03: Dependency Chain Abuse** — Eliminated tag-based pinning vulnerability across all workflows
- **CICD-08: Ungoverned 3rd Party Services** — All 11 third-party actions now SHA-pinned

## Dependabot Compatibility

The existing `dependabot.yml` with `package-ecosystem: "github-actions"` will auto-detect SHA-pinned actions and open PRs to update them when new versions are released. The `# v5` tag comments help Dependabot identify the current version.

## Related

- Part of: CodeQL Expansion & GitHub Actions Security Hardening (PR 7 of 7 — **FINAL**)
- Resolves all `unpinned-uses` findings from zizmor (221 findings) and CodeQL `actions` scanning