### PR TITLE
feat(reporting-api): add PUT review endpoint and wire ReportStatus.Reviewed

### DIFF
--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Contract/AuthorizationPolicyShould.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Contract/AuthorizationPolicyShould.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Net.Http.Json;
+using Biotrackr.Reporting.Api.Endpoints;
 using Biotrackr.Reporting.Api.IntegrationTests.Fixtures;
 using FluentAssertions;
 
@@ -106,6 +108,32 @@ public class AuthorizationPolicyShould
 
         // Act
         var response = await client.GetAsync("/api/reports");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task SubmitReview_ShouldRequireAuthorization()
+    {
+        // Arrange
+        await using var factory = new AuthorizationTestWebApplicationFactory
+        {
+            ChatApiAgentIdentityId = "chat-api-identity",
+            ReportingSvcAgentIdentityId = "reporting-svc-identity"
+        };
+        var client = factory.CreateClient();
+        ConfigurableAuthHandler.AzpClaimValue = string.Empty;
+
+        var request = new SubmitReviewRequest
+        {
+            Approved = true,
+            Concerns = [],
+            ValidatedSummary = "Summary"
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync("/api/reports/test-job/review", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Contract/SubmitReviewTests.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Contract/SubmitReviewTests.cs
@@ -59,7 +59,7 @@ public class SubmitReviewTests : IClassFixture<ReportingApiWebApplicationFactory
 
         _factory.MockBlobStorageService
             .Setup(s => s.UpdateReviewResultAsync(jobId, It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<string>()))
-            .ThrowsAsync(new InvalidOperationException($"Job {jobId} not found"));
+            .ThrowsAsync(new KeyNotFoundException($"Job {jobId} not found"));
 
         // Act
         var response = await _client.PutAsJsonAsync($"/api/reports/{jobId}/review", request);

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Contract/SubmitReviewTests.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.IntegrationTests/Contract/SubmitReviewTests.cs
@@ -1,0 +1,161 @@
+using System.Net;
+using System.Net.Http.Json;
+using Biotrackr.Reporting.Api.Endpoints;
+using Biotrackr.Reporting.Api.IntegrationTests.Fixtures;
+using FluentAssertions;
+using Moq;
+
+namespace Biotrackr.Reporting.Api.IntegrationTests.Contract;
+
+/// <summary>
+/// Contract tests for PUT /api/reports/{jobId}/review endpoint.
+/// Verifies routing, error handling, authentication, and service integration.
+/// </summary>
+public class SubmitReviewTests : IClassFixture<ReportingApiWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly ReportingApiWebApplicationFactory _factory;
+
+    public SubmitReviewTests(ReportingApiWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task SubmitReview_ShouldReturnNoContent_WhenJobIsGenerated()
+    {
+        // Arrange
+        var jobId = "contract-test-job-1";
+        var request = new SubmitReviewRequest
+        {
+            Approved = true,
+            Concerns = ["minor note about step count"],
+            ValidatedSummary = "Weekly summary is accurate"
+        };
+
+        _factory.MockBlobStorageService
+            .Setup(s => s.UpdateReviewResultAsync(jobId, request.Approved, request.Concerns, request.ValidatedSummary))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var response = await _client.PutAsJsonAsync($"/api/reports/{jobId}/review", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task SubmitReview_ShouldReturnNotFound_WhenJobDoesNotExist()
+    {
+        // Arrange
+        var jobId = "nonexistent-job";
+        var request = new SubmitReviewRequest
+        {
+            Approved = true,
+            Concerns = [],
+            ValidatedSummary = "Summary"
+        };
+
+        _factory.MockBlobStorageService
+            .Setup(s => s.UpdateReviewResultAsync(jobId, It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<string>()))
+            .ThrowsAsync(new InvalidOperationException($"Job {jobId} not found"));
+
+        // Act
+        var response = await _client.PutAsJsonAsync($"/api/reports/{jobId}/review", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task SubmitReview_ShouldReturnConflict_WhenJobIsGenerating()
+    {
+        // Arrange
+        var jobId = "generating-job";
+        var request = new SubmitReviewRequest
+        {
+            Approved = true,
+            Concerns = [],
+            ValidatedSummary = "Summary"
+        };
+
+        _factory.MockBlobStorageService
+            .Setup(s => s.UpdateReviewResultAsync(jobId, It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<string>()))
+            .ThrowsAsync(new InvalidOperationException($"Job {jobId} is not in generated status (current: generating)"));
+
+        // Act
+        var response = await _client.PutAsJsonAsync($"/api/reports/{jobId}/review", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("not in generated status");
+    }
+
+    [Fact]
+    public async Task SubmitReview_ShouldReturnConflict_WhenJobIsFailed()
+    {
+        // Arrange
+        var jobId = "failed-job";
+        var request = new SubmitReviewRequest
+        {
+            Approved = false,
+            Concerns = ["job failed"],
+            ValidatedSummary = "N/A"
+        };
+
+        _factory.MockBlobStorageService
+            .Setup(s => s.UpdateReviewResultAsync(jobId, It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<string>()))
+            .ThrowsAsync(new InvalidOperationException($"Job {jobId} is not in generated status (current: failed)"));
+
+        // Act
+        var response = await _client.PutAsJsonAsync($"/api/reports/{jobId}/review", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task SubmitReview_ShouldReturnConflict_WhenJobIsAlreadyReviewed()
+    {
+        // Arrange
+        var jobId = "reviewed-job";
+        var request = new SubmitReviewRequest
+        {
+            Approved = true,
+            Concerns = [],
+            ValidatedSummary = "Already reviewed"
+        };
+
+        _factory.MockBlobStorageService
+            .Setup(s => s.UpdateReviewResultAsync(jobId, It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<string>()))
+            .ThrowsAsync(new InvalidOperationException($"Job {jobId} is not in generated status (current: reviewed)"));
+
+        // Act
+        var response = await _client.PutAsJsonAsync($"/api/reports/{jobId}/review", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task SubmitReview_ShouldHandleWhitespaceJobId()
+    {
+        // Arrange — whitespace jobId may be caught by routing or handler
+        var request = new SubmitReviewRequest
+        {
+            Approved = true,
+            Concerns = [],
+            ValidatedSummary = "Summary"
+        };
+
+        // Act
+        var response = await _client.PutAsJsonAsync("/api/reports/%20/review", request);
+
+        // Assert — expect 400 from handler's whitespace check
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.UnitTests/Endpoints/ReviewEndpointsShould.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.UnitTests/Endpoints/ReviewEndpointsShould.cs
@@ -59,7 +59,7 @@ public class ReviewEndpointsShould
 
         _blobStorageServiceMock
             .Setup(s => s.UpdateReviewResultAsync(jobId, It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<string>()))
-            .ThrowsAsync(new InvalidOperationException($"Job {jobId} not found"));
+            .ThrowsAsync(new KeyNotFoundException($"Job {jobId} not found"));
 
         // Act
         var result = await ReviewEndpoints.HandleSubmitReview(

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.UnitTests/Endpoints/ReviewEndpointsShould.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.UnitTests/Endpoints/ReviewEndpointsShould.cs
@@ -1,0 +1,120 @@
+using Biotrackr.Reporting.Api.Endpoints;
+using Biotrackr.Reporting.Api.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Biotrackr.Reporting.Api.UnitTests.Endpoints;
+
+public class ReviewEndpointsShould
+{
+    private readonly Mock<IBlobStorageService> _blobStorageServiceMock;
+    private readonly Mock<ILogger<Program>> _loggerMock;
+
+    public ReviewEndpointsShould()
+    {
+        _blobStorageServiceMock = new Mock<IBlobStorageService>();
+        _loggerMock = new Mock<ILogger<Program>>();
+    }
+
+    [Fact]
+    public async Task HandleSubmitReview_ShouldReturnNoContent_WhenReviewIsSuccessful()
+    {
+        // Arrange
+        var jobId = "test-job-123";
+        var request = new SubmitReviewRequest
+        {
+            Approved = true,
+            Concerns = ["minor note"],
+            ValidatedSummary = "All checks passed"
+        };
+
+        _blobStorageServiceMock
+            .Setup(s => s.UpdateReviewResultAsync(jobId, request.Approved, request.Concerns, request.ValidatedSummary))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await ReviewEndpoints.HandleSubmitReview(
+            jobId, request, _blobStorageServiceMock.Object, _loggerMock.Object);
+
+        // Assert
+        result.Should().BeOfType<NoContent>();
+        _blobStorageServiceMock.Verify(
+            s => s.UpdateReviewResultAsync(jobId, true, request.Concerns, request.ValidatedSummary), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleSubmitReview_ShouldReturnNotFound_WhenJobDoesNotExist()
+    {
+        // Arrange
+        var jobId = "nonexistent-job";
+        var request = new SubmitReviewRequest
+        {
+            Approved = true,
+            Concerns = [],
+            ValidatedSummary = "Summary"
+        };
+
+        _blobStorageServiceMock
+            .Setup(s => s.UpdateReviewResultAsync(jobId, It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<string>()))
+            .ThrowsAsync(new InvalidOperationException($"Job {jobId} not found"));
+
+        // Act
+        var result = await ReviewEndpoints.HandleSubmitReview(
+            jobId, request, _blobStorageServiceMock.Object, _loggerMock.Object);
+
+        // Assert
+        var statusCodeResult = result as IStatusCodeHttpResult;
+        statusCodeResult.Should().NotBeNull();
+        statusCodeResult!.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleSubmitReview_ShouldReturnConflict_WhenJobIsNotGenerated()
+    {
+        // Arrange
+        var jobId = "test-job-456";
+        var request = new SubmitReviewRequest
+        {
+            Approved = false,
+            Concerns = ["data mismatch"],
+            ValidatedSummary = "Failed validation"
+        };
+
+        _blobStorageServiceMock
+            .Setup(s => s.UpdateReviewResultAsync(jobId, It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<string>()))
+            .ThrowsAsync(new InvalidOperationException($"Job {jobId} is not in generated status (current: generating)"));
+
+        // Act
+        var result = await ReviewEndpoints.HandleSubmitReview(
+            jobId, request, _blobStorageServiceMock.Object, _loggerMock.Object);
+
+        // Assert
+        var statusCodeResult = result as IStatusCodeHttpResult;
+        statusCodeResult.Should().NotBeNull();
+        statusCodeResult!.StatusCode.Should().Be(409);
+    }
+
+    [Fact]
+    public async Task HandleSubmitReview_ShouldReturnBadRequest_WhenJobIdIsEmpty()
+    {
+        // Arrange
+        var request = new SubmitReviewRequest
+        {
+            Approved = true,
+            Concerns = [],
+            ValidatedSummary = "Summary"
+        };
+
+        // Act
+        var result = await ReviewEndpoints.HandleSubmitReview(
+            " ", request, _blobStorageServiceMock.Object, _loggerMock.Object);
+
+        // Assert
+        var statusCodeResult = result as IStatusCodeHttpResult;
+        statusCodeResult.Should().NotBeNull();
+        statusCodeResult!.StatusCode.Should().Be(400);
+    }
+}

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.UnitTests/Models/ReportMetadataShould.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.UnitTests/Models/ReportMetadataShould.cs
@@ -61,5 +61,45 @@ namespace Biotrackr.Reporting.Api.UnitTests.Models
             range.Start.Should().BeEmpty();
             range.End.Should().BeEmpty();
         }
+
+        [Fact]
+        public void HaveNullReviewedAtByDefault()
+        {
+            // Arrange & Act
+            var metadata = new ReportMetadata();
+
+            // Assert
+            metadata.ReviewedAt.Should().BeNull();
+        }
+
+        [Fact]
+        public void HaveNullReviewApprovedByDefault()
+        {
+            // Arrange & Act
+            var metadata = new ReportMetadata();
+
+            // Assert
+            metadata.ReviewApproved.Should().BeNull();
+        }
+
+        [Fact]
+        public void HaveNullReviewConcernsByDefault()
+        {
+            // Arrange & Act
+            var metadata = new ReportMetadata();
+
+            // Assert
+            metadata.ReviewConcerns.Should().BeNull();
+        }
+
+        [Fact]
+        public void HaveNullReviewValidatedSummaryByDefault()
+        {
+            // Arrange & Act
+            var metadata = new ReportMetadata();
+
+            // Assert
+            metadata.ReviewValidatedSummary.Should().BeNull();
+        }
     }
 }

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.UnitTests/Services/ReportGenerationServiceShould.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.UnitTests/Services/ReportGenerationServiceShould.cs
@@ -74,6 +74,14 @@ namespace Biotrackr.Reporting.Api.UnitTests.Services
             _blobStorageService.Setup(b => b.CreateJobAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync("job-id");
 
+            // Keep the background task alive by blocking UpdateJobStatusAsync
+            // (called from Task.Run's catch when GenerateReportAsync throws).
+            // Without this, the background task completes instantly and releases
+            // the semaphore before the second call executes — causing a flaky test.
+            var backgroundGate = new TaskCompletionSource();
+            _blobStorageService.Setup(b => b.UpdateJobStatusAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(backgroundGate.Task);
+
             var sut = CreateService(maxConcurrentJobs: 1);
 
             // First call should succeed (takes the semaphore slot)
@@ -81,16 +89,15 @@ namespace Biotrackr.Reporting.Api.UnitTests.Services
                 "weekly_summary", "2026-03-01", "2026-03-07", "Generate report 1", new object());
             result1.Status.Should().Be(ReportStatus.Generating);
 
-            // Reset the health check for second call
-            _copilotService.Setup(c => c.IsHealthyAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true);
-
             // Second call should fail due to concurrency limit
             var result2 = await sut.StartReportGenerationAsync(
                 "weekly_summary", "2026-03-08", "2026-03-14", "Generate report 2", new object());
 
             result2.Status.Should().Be(ReportStatus.Failed);
             result2.Message.Should().Contain("concurrent");
+
+            // Release the background task so it can reach finally block and clean up
+            backgroundGate.SetResult();
         }
 
         [Fact]

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Endpoints/ReviewEndpoints.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Endpoints/ReviewEndpoints.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics.CodeAnalysis;
+using Biotrackr.Reporting.Api.Services;
+using Biotrackr.Reporting.Api.Telemetry;
+
+namespace Biotrackr.Reporting.Api.Endpoints;
+
+[ExcludeFromCodeCoverage]
+public static class ReviewEndpoints
+{
+    public static void MapReviewEndpoints(this WebApplication app)
+    {
+        app.MapPut("/api/reports/{jobId}/review", HandleSubmitReview)
+            .RequireAuthorization("ChatApiAgent");
+    }
+
+    internal static async Task<IResult> HandleSubmitReview(
+        string jobId,
+        SubmitReviewRequest request,
+        IBlobStorageService blobStorageService,
+        ILogger<Program> logger)
+    {
+        if (string.IsNullOrWhiteSpace(jobId))
+        {
+            return Results.BadRequest(new { error = "jobId is required" });
+        }
+
+        try
+        {
+            await blobStorageService.UpdateReviewResultAsync(
+                jobId,
+                request.Approved,
+                request.Concerns,
+                request.ValidatedSummary);
+
+            ReportingTelemetry.ReportsReviewed.Add(1);
+            logger.LogInformation("Report {JobId} reviewed: Approved={Approved}, Concerns={ConcernCount}",
+                jobId, request.Approved, request.Concerns.Count);
+
+            return Results.NoContent();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+        {
+            return Results.NotFound(new { error = ex.Message });
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("not in generated status"))
+        {
+            return Results.Conflict(new { error = ex.Message });
+        }
+    }
+}
+
+public class SubmitReviewRequest
+{
+    public bool Approved { get; set; }
+    public List<string> Concerns { get; set; } = [];
+    public string ValidatedSummary { get; set; } = string.Empty;
+}

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Endpoints/ReviewEndpoints.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Endpoints/ReviewEndpoints.cs
@@ -24,25 +24,28 @@ public static class ReviewEndpoints
             return Results.BadRequest(new { error = "jobId is required" });
         }
 
+        var concerns = request.Concerns ?? [];
+        var validatedSummary = request.ValidatedSummary ?? string.Empty;
+
         try
         {
             await blobStorageService.UpdateReviewResultAsync(
                 jobId,
                 request.Approved,
-                request.Concerns,
-                request.ValidatedSummary);
+                concerns,
+                validatedSummary);
 
             ReportingTelemetry.ReportsReviewed.Add(1);
             logger.LogInformation("Report {JobId} reviewed: Approved={Approved}, Concerns={ConcernCount}",
-                jobId, request.Approved, request.Concerns.Count);
+                jobId, request.Approved, concerns.Count);
 
             return Results.NoContent();
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
+        catch (KeyNotFoundException ex)
         {
             return Results.NotFound(new { error = ex.Message });
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("not in generated status"))
+        catch (InvalidOperationException ex)
         {
             return Results.Conflict(new { error = ex.Message });
         }

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Models/ReportMetadata.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Models/ReportMetadata.cs
@@ -33,6 +33,18 @@ namespace Biotrackr.Reporting.Api.Models
 
         [JsonPropertyName("blobPath")]
         public string? BlobPath { get; set; }
+
+        [JsonPropertyName("reviewedAt")]
+        public DateTimeOffset? ReviewedAt { get; set; }
+
+        [JsonPropertyName("reviewApproved")]
+        public bool? ReviewApproved { get; set; }
+
+        [JsonPropertyName("reviewConcerns")]
+        public List<string>? ReviewConcerns { get; set; }
+
+        [JsonPropertyName("reviewValidatedSummary")]
+        public string? ReviewValidatedSummary { get; set; }
     }
 
     public class ReportDateRange

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Program.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Program.cs
@@ -152,6 +152,9 @@ app.MapGenerateEndpoints();
 // Report retrieval endpoints
 app.MapReportEndpoints();
 
+// Review submission endpoint
+app.MapReviewEndpoints();
+
 // A2A endpoint (alongside existing HTTP endpoints for backward compatibility)
 app.MapA2AEndpoints(reportAgent);
 

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Services/BlobStorageService.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Services/BlobStorageService.cs
@@ -135,6 +135,34 @@ namespace Biotrackr.Reporting.Api.Services
             logger.LogInformation("Updated job {JobId} status to {Status}", jobId, status);
         }
 
+        public async Task UpdateReviewResultAsync(string jobId, bool approved, List<string> concerns, string validatedSummary)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
+
+            var metadata = await GetMetadataAsync(jobId);
+            if (metadata is null)
+            {
+                throw new InvalidOperationException($"Job {jobId} not found");
+            }
+
+            if (metadata.Status != ReportStatus.Generated)
+            {
+                throw new InvalidOperationException($"Job {jobId} is not in generated status (current: {metadata.Status})");
+            }
+
+            metadata.Status = ReportStatus.Reviewed;
+            metadata.ReviewedAt = DateTimeOffset.UtcNow;
+            metadata.ReviewApproved = approved;
+            metadata.ReviewConcerns = concerns;
+            metadata.ReviewValidatedSummary = validatedSummary;
+
+            var blobPath = metadata.BlobPath
+                ?? BuildBlobPath(metadata.DateRange.Start, metadata.DateRange.End, metadata.ReportType);
+            await UploadMetadataAsync(blobPath, metadata);
+            await UploadJobIndexAsync(jobId, metadata);
+            logger.LogInformation("Updated job {JobId} with review result: Approved={Approved}", jobId, approved);
+        }
+
         public async Task<ReportMetadata?> GetMetadataAsync(string jobId)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(jobId);

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Services/BlobStorageService.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Services/BlobStorageService.cs
@@ -138,11 +138,13 @@ namespace Biotrackr.Reporting.Api.Services
         public async Task UpdateReviewResultAsync(string jobId, bool approved, List<string> concerns, string validatedSummary)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
+            ArgumentNullException.ThrowIfNull(concerns);
+            ArgumentNullException.ThrowIfNull(validatedSummary);
 
             var metadata = await GetMetadataAsync(jobId);
             if (metadata is null)
             {
-                throw new InvalidOperationException($"Job {jobId} not found");
+                throw new KeyNotFoundException($"Job {jobId} not found");
             }
 
             if (metadata.Status != ReportStatus.Generated)

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Services/IBlobStorageService.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Services/IBlobStorageService.cs
@@ -7,6 +7,7 @@ namespace Biotrackr.Reporting.Api.Services
         Task<string> CreateJobAsync(string reportType, string startDate, string endDate);
         Task UploadReportAsync(string jobId, byte[] pdfBytes, Dictionary<string, byte[]> charts, string summary, object sourceDataSnapshot);
         Task UpdateJobStatusAsync(string jobId, string status, string? error = null);
+        Task UpdateReviewResultAsync(string jobId, bool approved, List<string> concerns, string validatedSummary);
         Task<ReportMetadata?> GetMetadataAsync(string jobId);
         Task<string> GetReportSasUrlAsync(string blobPath);
         Task<List<ReportMetadata>> ListReportsAsync(string? reportType = null, string? startDate = null, string? endDate = null);

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Telemetry/ReportingTelemetry.cs
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Telemetry/ReportingTelemetry.cs
@@ -17,6 +17,9 @@ internal static class ReportingTelemetry
     public static readonly Counter<long> ReportsFailed = Meter.CreateCounter<long>(
         "reporting.reports.failed", description: "Total reports failed");
 
+    public static readonly Counter<long> ReportsReviewed = Meter.CreateCounter<long>(
+        "reporting.reports.reviewed", description: "Total reports reviewed");
+
     public static readonly Histogram<double> ReportDuration = Meter.CreateHistogram<double>(
         "reporting.reports.duration_ms", "ms", "Report generation duration");
 


### PR DESCRIPTION
## Summary

Adds durable persistence for report review results in Reporting.Api (Phase 2 of the ReportReviewerService fail-closed fix, Issue #269). After this change, the `PUT /api/reports/{jobId}/review` endpoint transitions reports from `Generated` → `Reviewed` status with review metadata persisted to blob storage.

## Changes

### Model
- Added 4 nullable review fields to `ReportMetadata`: `ReviewedAt`, `ReviewApproved`, `ReviewConcerns`, `ReviewValidatedSummary`
- All fields use `[JsonPropertyName]` with camelCase convention, nullable for backward compatibility

### Service Layer
- Added `UpdateReviewResultAsync` to `IBlobStorageService` interface
- Implemented in `BlobStorageService` following the existing `UpdateJobStatusAsync` pattern (get → guard status → mutate → dual-write)
- Status guard rejects non-`"generated"` reports with `InvalidOperationException`

### Endpoint
- Created `PUT /api/reports/{jobId}/review` in `ReviewEndpoints.cs`
- Returns 204 No Content on success, 404 Not Found, 409 Conflict, 400 Bad Request
- Uses `ChatApiAgent` authorization policy (same as all other endpoints)
- `SubmitReviewRequest` POCO defined in same file (matches `GenerateReportRequest` pattern)

### Telemetry
- Added `ReportsReviewed` counter to `ReportingTelemetry` (auto-exported to Application Insights via existing OpenTelemetry pipeline)

### Tests
- 4 unit tests in `ReviewEndpointsShould.cs` (handler logic in isolation)
- 4 default-value tests in `ReportMetadataShould.cs` for new fields
- 6 contract tests in `SubmitReviewTests.cs` (HTTP pipeline via WebApplicationFactory)
- 1 authorization test added to `AuthorizationPolicyShould.cs`

## Validation

- **209 tests pass** (0 failures)
- **70.2% line coverage** (threshold: 60%)
- All new code paths covered: `SubmitReviewRequest` 100%, `ReportMetadata` 100%, `ReportingTelemetry` 100%

## Context

- **Issue:** #269
- **Phase 1** (fail-closed + IMemoryCache) is already merged
- **Phase 2 PR 2** (Chat.Api consumer changes) will follow in a separate PR after this merges
- **No APIM changes** — Chat.Api calls Reporting.Api directly via agent identity JWT, bypassing APIM