### PR TITLE
fix(workflows): add .NET 10.0 runtime and optimize autoloop evaluation

### DIFF
--- a/.autoloop/programs/test_coverage/program.md
+++ b/.autoloop/programs/test_coverage/program.md
@@ -17,6 +17,25 @@ Focus on:
 
 The metric is `coverage_percent`. **Higher is better.**
 
+### Baseline Caching
+
+After each evaluation, update the `## 📦 Coverage Baselines` section in your state file with per-service coverage data from the evaluation output. For each service with `"source": "tested"` in the `per_service` JSON:
+- Update the `Covered`, `Coverable`, and `Pct` columns with the fresh values
+- Set `Commit` to the `commit` value from the JSON (short SHA)
+- Set `Updated` to today's date (YYYY-MM-DD format)
+
+Do NOT update baselines for services with `"source": "cached"` — their values are already correct.
+
+If the `## 📦 Coverage Baselines` section does not exist in your state file, create it with a markdown table containing all 14 services from the evaluation output.
+
+The baseline table format:
+
+| Service | Covered | Coverable | Pct | Commit | Updated |
+|---------|---------|-----------|-----|--------|---------|
+| Activity.Api | 1234 | 1500 | 82.27 | a1b2c3d | 2026-05-07 |
+
+Update baselines on both accepted AND rejected iterations — the per-service data reflects the pre-change state and is valid regardless of whether the aggregate metric improved.
+
 The repository is a .NET 10 microservices platform with 14 services. Each service has its own solution file under `src/Biotrackr.{Domain}.{Type}/`. Unit tests use xUnit, FluentAssertions, Moq, and AutoFixture. Follow the existing test naming convention: class `{ClassUnderTest}Should`, method `{Method}_Should{Behavior}_When{Condition}`. Use strict Arrange/Act/Assert with comments.
 
 ## Target
@@ -36,37 +55,110 @@ Do NOT modify:
 #!/bin/bash
 set -e
 
-# Find all solution files and run unit tests with coverage collection
+STATE_FILE="/tmp/gh-aw/repo-memory/autoloop/test_coverage.md"
 TOTAL_COVERED=0
 TOTAL_COVERABLE=0
 FAILED_SERVICES=0
+TESTED_SERVICES=0
+CACHED_SERVICES=0
+PER_SERVICE=""
 
-for sln in src/Biotrackr.*/Biotrackr.*.sln src/Biotrackr.*/Biotrackr.*.slnx; do
-  [ -f "$sln" ] || continue
-  SVC_DIR=$(dirname "$sln")
-  
-  # Restore and run unit tests with coverage
-  dotnet restore "$sln" -v:q 2>/dev/null
-  if ! dotnet test "$sln" --no-restore \
-    --collect:"XPlat Code Coverage" \
-    --settings "$SVC_DIR/coverage.runsettings" \
-    --results-directory "$SVC_DIR/TestResults" \
-    --filter "FullyQualifiedName!~Contract&FullyQualifiedName!~E2E" \
-    -v:q 2>/dev/null; then
-    FAILED_SERVICES=$((FAILED_SERVICES + 1))
+# Parse a single service's baseline from the state file
+# Returns: covered|coverable|commit (pipe-delimited)
+parse_baseline() {
+  local svc="$1"
+  if [ -f "$STATE_FILE" ]; then
+    # Match the service name in the baselines table
+    local row
+    row=$(grep "| ${svc} " "$STATE_FILE" 2>/dev/null | head -1)
+    if [ -n "$row" ]; then
+      local covered coverable commit
+      covered=$(echo "$row" | awk -F'|' '{print $3}' | tr -d ' ')
+      coverable=$(echo "$row" | awk -F'|' '{print $4}' | tr -d ' ')
+      commit=$(echo "$row" | awk -F'|' '{print $6}' | tr -d ' ')
+      echo "${covered}|${coverable}|${commit}"
+      return
+    fi
+  fi
+  echo ""
+}
+
+for svc_dir in src/Biotrackr.*/; do
+  [ -d "$svc_dir" ] || continue
+  SVC_NAME=$(basename "$svc_dir" | sed 's/Biotrackr\.//')
+
+  # Find solution file (.sln or .slnx)
+  sln=""
+  for f in "$svc_dir"/*.sln "$svc_dir"/*.slnx; do
+    [ -f "$f" ] && sln="$f" && break
+  done
+  [ -n "$sln" ] || continue
+
+  # Check for cached baseline
+  BASELINE=$(parse_baseline "$SVC_NAME")
+  NEED_TEST=true
+
+  if [ -n "$BASELINE" ]; then
+    BASELINE_COMMIT=$(echo "$BASELINE" | cut -d'|' -f3)
+    if [ -n "$BASELINE_COMMIT" ] && git diff --quiet "$BASELINE_COMMIT" HEAD -- "$svc_dir" 2>/dev/null; then
+      # Unchanged since baseline — use cached values
+      CACHED_COVERED=$(echo "$BASELINE" | cut -d'|' -f1)
+      CACHED_COVERABLE=$(echo "$BASELINE" | cut -d'|' -f2)
+      if [ -n "$CACHED_COVERED" ] && [ -n "$CACHED_COVERABLE" ] && \
+         [ "$CACHED_COVERED" -ge 0 ] 2>/dev/null && [ "$CACHED_COVERABLE" -gt 0 ] 2>/dev/null; then
+        TOTAL_COVERED=$((TOTAL_COVERED + CACHED_COVERED))
+        TOTAL_COVERABLE=$((TOTAL_COVERABLE + CACHED_COVERABLE))
+        CACHED_SERVICES=$((CACHED_SERVICES + 1))
+        CACHED_PCT=$(python3 -c "print(round($CACHED_COVERED * 100 / $CACHED_COVERABLE, 2))")
+        PER_SERVICE="${PER_SERVICE}\"${SVC_NAME}\": {\"covered\": ${CACHED_COVERED}, \"coverable\": ${CACHED_COVERABLE}, \"pct\": ${CACHED_PCT}, \"source\": \"cached\"}, "
+        NEED_TEST=false
+      fi
+    fi
   fi
 
-  # Parse coverage XML
-  for cov in "$SVC_DIR"/TestResults/*/coverage.cobertura.xml; do
-    [ -f "$cov" ] || continue
-    COVERED=$(grep -oP 'lines-covered="\K[0-9]+' "$cov" | head -1)
-    COVERABLE=$(grep -oP 'lines-valid="\K[0-9]+' "$cov" | head -1)
-    TOTAL_COVERED=$((TOTAL_COVERED + COVERED))
-    TOTAL_COVERABLE=$((TOTAL_COVERABLE + COVERABLE))
-  done
+  if [ "$NEED_TEST" = true ]; then
+    # Determine coverage settings path
+    SETTINGS_FLAG=""
+    if [ -f "$svc_dir/coverage.runsettings" ]; then
+      SETTINGS_FLAG="--settings $svc_dir/coverage.runsettings"
+    fi
 
-  # Clean up results
-  rm -rf "$SVC_DIR/TestResults"
+    # Restore and run unit tests with coverage
+    dotnet restore "$sln" -v:q 2>/dev/null
+    if ! dotnet test "$sln" --no-restore \
+      --collect:"XPlat Code Coverage" \
+      $SETTINGS_FLAG \
+      --results-directory "$svc_dir/TestResults" \
+      --filter "FullyQualifiedName!~Contract&FullyQualifiedName!~E2E" \
+      -v:q 2>/dev/null; then
+      FAILED_SERVICES=$((FAILED_SERVICES + 1))
+    fi
+
+    # Parse coverage XML
+    SVC_COVERED=0
+    SVC_COVERABLE=0
+    for cov in "$svc_dir"/TestResults/*/coverage.cobertura.xml; do
+      [ -f "$cov" ] || continue
+      COVERED=$(grep -oP 'lines-covered="\K[0-9]+' "$cov" | head -1)
+      COVERABLE=$(grep -oP 'lines-valid="\K[0-9]+' "$cov" | head -1)
+      SVC_COVERED=$((SVC_COVERED + ${COVERED:-0}))
+      SVC_COVERABLE=$((SVC_COVERABLE + ${COVERABLE:-0}))
+    done
+
+    TOTAL_COVERED=$((TOTAL_COVERED + SVC_COVERED))
+    TOTAL_COVERABLE=$((TOTAL_COVERABLE + SVC_COVERABLE))
+    TESTED_SERVICES=$((TESTED_SERVICES + 1))
+
+    SVC_PCT=0
+    if [ "$SVC_COVERABLE" -gt 0 ]; then
+      SVC_PCT=$(python3 -c "print(round($SVC_COVERED * 100 / $SVC_COVERABLE, 2))")
+    fi
+    SVC_COMMIT=$(git rev-parse --short HEAD)
+    PER_SERVICE="${PER_SERVICE}\"${SVC_NAME}\": {\"covered\": ${SVC_COVERED}, \"coverable\": ${SVC_COVERABLE}, \"pct\": ${SVC_PCT}, \"commit\": \"${SVC_COMMIT}\", \"source\": \"tested\"}, "
+
+    # Clean up results
+    rm -rf "$svc_dir/TestResults"
+  fi
 done
 
 # Calculate overall percentage
@@ -76,7 +168,10 @@ else
   PERCENT=0
 fi
 
-echo "{\"coverage_percent\": $PERCENT, \"covered_lines\": $TOTAL_COVERED, \"coverable_lines\": $TOTAL_COVERABLE, \"failed_services\": $FAILED_SERVICES}"
+# Remove trailing comma+space from per-service JSON
+PER_SERVICE=$(echo "$PER_SERVICE" | sed 's/, $//')
+
+echo "{\"coverage_percent\": $PERCENT, \"covered_lines\": $TOTAL_COVERED, \"coverable_lines\": $TOTAL_COVERABLE, \"failed_services\": $FAILED_SERVICES, \"tested_services\": $TESTED_SERVICES, \"cached_services\": $CACHED_SERVICES, \"per_service\": {${PER_SERVICE}}}"
 
 # Fail evaluation if any service had test failures
 if [ "$FAILED_SERVICES" -gt 0 ]; then

--- a/.github/workflows/autoloop.lock.yml
+++ b/.github/workflows/autoloop.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3a6cf59bd705cac7d84420b31f9429cdd7462fef26110a0c5b8792c038ec9599","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f6dea90c2ac3b14c959ff127d83562249257c0832ff08a140212e6b35074ad48","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-dotnet","sha":"c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7","version":"v5.2.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -50,6 +50,7 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+#   - actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -279,25 +280,25 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_19336c640ccd2cd8_EOF'
+          cat << 'GH_AW_PROMPT_04db49da39dec6c7_EOF'
           <system>
-          GH_AW_PROMPT_19336c640ccd2cd8_EOF
+          GH_AW_PROMPT_04db49da39dec6c7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_19336c640ccd2cd8_EOF'
+          cat << 'GH_AW_PROMPT_04db49da39dec6c7_EOF'
           <safe-output-tools>
           Tools: add_comment(max:7), create_issue, update_issue(max:3), create_pull_request, add_labels(max:2), remove_labels(max:2), push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_19336c640ccd2cd8_EOF
+          GH_AW_PROMPT_04db49da39dec6c7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_19336c640ccd2cd8_EOF'
+          cat << 'GH_AW_PROMPT_04db49da39dec6c7_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_19336c640ccd2cd8_EOF
+          GH_AW_PROMPT_04db49da39dec6c7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_19336c640ccd2cd8_EOF'
+          cat << 'GH_AW_PROMPT_04db49da39dec6c7_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -329,7 +330,7 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_19336c640ccd2cd8_EOF
+          GH_AW_PROMPT_04db49da39dec6c7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
@@ -337,11 +338,11 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_push_to_pr_branch_guidance.md"
           fi
-          cat << 'GH_AW_PROMPT_19336c640ccd2cd8_EOF'
+          cat << 'GH_AW_PROMPT_04db49da39dec6c7_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/autoloop.md}}
-          GH_AW_PROMPT_19336c640ccd2cd8_EOF
+          GH_AW_PROMPT_04db49da39dec6c7_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -493,6 +494,10 @@ jobs:
         run: |
           header=$(printf "x-access-token:%s" "${GH_AW_FETCH_TOKEN}" | base64 -w 0)
           git -c "http.extraheader=Authorization: Basic ${header}" fetch origin '+refs/heads/*:refs/remotes/origin/*'
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: '10.0'
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -587,9 +592,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_69b7cf6ba2e42dba_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_02228f648a077b64_EOF'
           {"add_comment":{"hide_older_comments":false,"max":7,"target":"*"},"add_labels":{"max":2,"target":"*"},"create_issue":{"labels":["automation","autoloop"],"max":1},"create_pull_request":{"draft":true,"labels":["automation","autoloop"],"max":1,"max_patch_files":100,"max_patch_size":10240,"preserve_branch_name":true,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":30720,"max_patch_size":10240}]},"push_to_pull_request_branch":{"if_no_changes":"warn","max":1,"max_patch_size":10240,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"target":"*","title_prefix":"[Autoloop"},"remove_labels":{"max":2,"target":"*"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":3,"target":"*","title_prefix":"[Autoloop"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_69b7cf6ba2e42dba_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_02228f648a077b64_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -970,7 +975,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_fad3877f54b3311c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_16866c7ee1fd46f1_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -1011,7 +1016,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_fad3877f54b3311c_EOF
+          GH_AW_MCP_CONFIG_16866c7ee1fd46f1_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1036,7 +1041,7 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 45
+        timeout-minutes: 75
         run: |
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
@@ -1056,6 +1061,7 @@ jobs:
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
+          GH_AW_TOOL_TIMEOUT: 600
           GH_AW_VERSION: v0.71.5
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_AW: true
@@ -1393,7 +1399,7 @@ jobs:
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
-          GH_AW_TIMEOUT_MINUTES: "45"
+          GH_AW_TIMEOUT_MINUTES: "75"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/autoloop.md
+++ b/.github/workflows/autoloop.md
@@ -23,7 +23,7 @@ on:
 
 permissions: read-all
 
-timeout-minutes: 45
+timeout-minutes: 75
 
 network:
   allowed:
@@ -33,6 +33,10 @@ network:
   - rust
   - java
   - dotnet
+
+runtimes:
+  dotnet:
+    version: "10.0"
 
 safe-outputs:
   max-patch-size: 10240
@@ -69,6 +73,7 @@ checkout:
   fetch-depth: 0
 
 tools:
+  timeout: 600
   web-fetch:
   github:
     toolsets: [all]

--- a/src/Biotrackr.Mcp.Server/coverage.runsettings
+++ b/src/Biotrackr.Mcp.Server/coverage.runsettings
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Coverage exclusion settings for .NET 10 projects.
+  
+  The Microsoft.AspNetCore.OpenApi source generator (used by AddOpenApi()) emits classes
+  under the Microsoft.AspNetCore.OpenApi.Generated namespace that coverlet instruments
+  but no unit tests exercise, dragging coverage down significantly.
+  
+  Place this file at the solution root and pass it via:
+    dotnet test - -settings coverage.runsettings
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+          <Exclude>
+            [*]Microsoft.AspNetCore.OpenApi.Generated.*,
+            [*]System.Runtime.CompilerServices.*OpenApiXmlCommentSupport_generated*
+          </Exclude>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/Biotrackr.UI/coverage.runsettings
+++ b/src/Biotrackr.UI/coverage.runsettings
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Coverage exclusion settings for .NET 10 projects.
+  
+  The Microsoft.AspNetCore.OpenApi source generator (used by AddOpenApi()) emits classes
+  under the Microsoft.AspNetCore.OpenApi.Generated namespace that coverlet instruments
+  but no unit tests exercise, dragging coverage down significantly.
+  
+  Place this file at the solution root and pass it via:
+    dotnet test - -settings coverage.runsettings
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+          <Exclude>
+            [*]Microsoft.AspNetCore.OpenApi.Generated.*,
+            [*]System.Runtime.CompilerServices.*OpenApiXmlCommentSupport_generated*
+          </Exclude>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
# 📝 Description

Fix the autoloop.lock.yml workflow timeout (run #25470357137) by adding .NET 10.0 runtime support, rewriting the evaluation script for targeted per-service testing with baseline caching, adding missing coverage.runsettings files, and increasing the timeout budget.

## 🔗 Related Issues

Autoloop pipeline failure — run #25470357137 timed out at 45 minutes during evaluation phase.

## 🚀 Changes

**🐛 fix(Add .NET 10.0 runtime to autoloop workflow)**
What: Added `runtimes: dotnet: version: \"10.0\"` to autoloop.md frontmatter so GH-AW installs the correct SDK before agent execution.
Why: GH-AW defaults to .NET 8.0 but Biotrackr requires 10.0 per global.json, causing SDK mismatch.
📁 Files: `.github/workflows/autoloop.md` (runtimes block), `.github/workflows/autoloop.lock.yml` (setup-dotnet step)

**🐛 fix(Rewrite evaluation script for targeted testing)**
What: Replaced all-services evaluation with git-diff-based targeted testing and baseline caching via repo-memory state file.
Why: Previous script tested all 14 services (~34 min) when only 1 changed, consuming 74%% of the timeout budget.
📁 Files: `.autoloop/programs/test_coverage/program.md` (evaluation script + baseline caching instructions)

**🔧 config(Increase timeout and add tool timeout)**
What: Increased `timeout-minutes` from 45 to 75 and added `tools.timeout: 600`.
Why: Provides headroom for agent work + evaluation + CI wait + fix loop cycle.
📁 Files: `.github/workflows/autoloop.md` (timeout-minutes, tools.timeout)

**🔧 config(Add missing coverage.runsettings)**
What: Created coverage.runsettings for Mcp.Server and UI services matching the existing template.
Why: These 2 services lacked the file, causing unfiltered coverage data in evaluations.
📁 Files: `src/Biotrackr.Mcp.Server/coverage.runsettings`, `src/Biotrackr.UI/coverage.runsettings`

## 🙏 Additional Context

- Evaluation time for single-service changes drops from ~30 min to ~3-5 min
- First run with no baselines still does full evaluation; baselines accumulate over iterations
- Review log: `.copilot-tracking/reviews/2026-05-07/autoloop-pipeline-fix-plan-review.md`