### PR TITLE
core(autoloop): add explicit test conventions to program.md

### DIFF
--- a/.autoloop/programs/test_coverage/program.md
+++ b/.autoloop/programs/test_coverage/program.md
@@ -36,7 +36,29 @@ The baseline table format:
 
 Update baselines on both accepted AND rejected iterations — the per-service data reflects the pre-change state and is valid regardless of whether the aggregate metric improved.
 
-The repository is a .NET 10 microservices platform with 14 services. Each service has its own solution file under `src/Biotrackr.{Domain}.{Type}/`. Unit tests use xUnit, FluentAssertions, Moq, and AutoFixture. Follow the existing test naming convention: class `{ClassUnderTest}Should`, method `{Method}_Should{Behavior}_When{Condition}`. Use strict Arrange/Act/Assert with comments.
+The repository is a .NET 10 microservices platform with 14 services. Each service has its own solution file under `src/Biotrackr.{Domain}.{Type}/`. Unit tests use xUnit, FluentAssertions, Moq, and AutoFixture. Follow these conventions strictly:
+
+### Test Naming
+
+- **Class:** `{ClassUnderTest}Should` (e.g., `ActivityHandlersShould`)
+- **Method:** `{Method}_Should{Behavior}_When{Condition}` (e.g., `GetActivityByDate_ShouldReturnOk_WhenActivityIsFound`)
+- Never use short names like `ShouldSerializeAndDeserialize()` — always include the subject and condition.
+
+### Using Directive Ordering
+
+- `System.*` namespaces must come first, followed by third-party libraries (e.g., `AutoFixture`, `FluentAssertions`, `Moq`), then project namespaces.
+- Example:
+  ```csharp
+  using System.Text.Json;
+  using AutoFixture;
+  using FluentAssertions;
+  using Biotrackr.Mcp.Server.Models.Activity;
+  ```
+
+### Code Style
+
+- Use strict Arrange/Act/Assert with `// Arrange`, `// Act`, `// Assert` comments.
+- Use file-scoped namespaces (e.g., `namespace Biotrackr.Mcp.Server.UnitTests.Models;`).
 
 ## Target
 


### PR DESCRIPTION
## Summary

Adds explicit test naming, using directive ordering, and code style conventions to the autoloop `test_coverage` program definition. This prevents the autoloop agent from generating tests that violate repository conventions (as seen in PR #350's Copilot code review comments).

## Changes

- **Test naming**: Reinforced `{Method}_Should{Behavior}_When{Condition}` convention with examples and explicit "never use short names" guidance
- **Using directive ordering**: Added rule that `System.*` namespaces must come first, with a concrete example
- **Code style**: Added file-scoped namespace and AAA comment requirements

## Context

PR #350 (autoloop's first successful test coverage iteration) received multiple Copilot code review comments about:
- Using directives out of order (`FluentAssertions` before `System.*`)
- Test method names not following `{Method}_Should{Behavior}_When{Condition}` convention

These were fixed directly on PR #350 in commit `41a6c30`. This PR updates the program definition so future autoloop iterations follow conventions from the start.