### PR TITLE
docs: add missing Reporting Svc and communication/ rows

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -155,6 +155,7 @@ dotnet build --no-restore --no-dependencies -v:q
 | Food Svc | `src/Biotrackr.Food.Svc` | `.sln` | Yes | Yes (E2E + Contract) |
 | MCP Server | `src/Biotrackr.Mcp.Server` | `.slnx` | Yes | Yes (E2E + Contract) |
 | Reporting API | `src/Biotrackr.Reporting.Api` | `.slnx` | Yes | Yes (E2E + Contract) |
+| Reporting Svc | `src/Biotrackr.Reporting.Svc` | `.slnx` | Yes | Yes (Contract) |
 | Sleep API | `src/Biotrackr.Sleep.Api` | `.sln` | Yes | Yes (E2E + Contract) |
 | Sleep Svc | `src/Biotrackr.Sleep.Svc` | `.sln` | Yes | Yes (E2E + Contract) |
 | UI | `src/Biotrackr.UI` | `.slnx` | Yes | No |
@@ -407,6 +408,7 @@ infra/
 |------------------|--------------------------------------------------------------------------|
 | `ai/`            | Foundry                                                                  |
 | `apim/`          | API Management (consumption, named values, products)                     |
+| `communication/` | Communication Services (ACS email, Azure-managed domain)                 |
 | `configuration/` | App Configuration                                                        |
 | `database/`      | Cosmos DB (serverless)                                                   |
 | `host/`          | Container Apps (HTTP, sidecar, jobs), Container Registry                 |


### PR DESCRIPTION
Fixes documentation drift in `.github/copilot-instructions.md` detected by the Documentation Drift Detection workflow.

## Changes

- Inserted **Reporting Svc** row into the *Service Reference* table (between Reporting API and Sleep API), bringing the table to 14 rows matching all services in `src/` and aligning with `AGENTS.md`
- Inserted **`communication/`** row into the *Module Domains* table (between `apim/` and `configuration/`), bringing the table to 10 rows matching all directories in `infra/modules/`

## Related Issues

Closes #364