### PR TITLE
fix(agentic-workflows): add workflow, section, and Bicep count checks to doc-drift-detection

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ Each service has its own solution file (`.sln` or `.slnx`), Dockerfile, test pro
 ├── AGENTS.md                          # Standalone agent guide (cross-tool)
 ├── CLAUDE.md                          # @AGENTS.md import for Claude Code
 ├── .github/
-│   ├── copilot-instructions.md        # Comprehensive Copilot guide (14 sections)
+│   ├── copilot-instructions.md        # Comprehensive Copilot guide (15 sections)
 │   ├── instructions/                  # Path-scoped .instructions.md files
 │   ├── agents/                        # 9 custom agent definitions
 │   ├── aw/                            # Agentic workflow runtime artifacts
@@ -616,7 +616,7 @@ Do not modify decision records — they are append-only historical documents.
 
 ## Cross-References
 
-* `AGENTS.md` — Standalone agent guide (9 sections, cross-tool compatible)
+* `AGENTS.md` — Standalone agent guide (10 sections, cross-tool compatible)
 * `CLAUDE.md` — Claude Code import file (`@AGENTS.md`)
 * `AI-TRANSPARENCY.md` — Public AI transparency statement (models, data categories, safety approach, ethical considerations)
 * `SECURITY.md` — Security vulnerability reporting policy (GitHub Private Advisory, AI-specific concerns)

--- a/.github/workflows/doc-drift-detection.md
+++ b/.github/workflows/doc-drift-detection.md
@@ -31,6 +31,12 @@ Analyze the Biotrackr repository for documentation that has drifted from the act
 
 5. **Architecture overview**: Check that the service count (currently "14 independently-deployable services") in AGENTS.md and copilot-instructions.md matches the actual `src/Biotrackr.*` directory count.
 
+6. **Workflow category counts**: Verify the workflow counts in the repository structure tree ("N workflows + N reusable templates + N agentic workflows") in both `AGENTS.md` and `.github/copilot-instructions.md` match actual files in `.github/workflows/`: regular `.yml` files (excluding `*.lock.yml` and `template-*.yml`), `template-*.yml` templates, and `*.lock.yml` agentic workflow locks paired with `.md` prompt bodies.
+
+7. **Section heading counts**: Verify the documented section counts for `copilot-instructions.md` ("N sections") and `AGENTS.md` ("N sections") in the repository structure tree and cross-references of both files match the actual count of `##` headings in each file.
+
+8. **Bicep module count**: Verify the "N reusable Bicep modules" count in the repository structure tree of both `AGENTS.md` and `.github/copilot-instructions.md` matches the actual number of `.bicep` files across `infra/modules/` subdirectories, and the Module Domains table row count in `.github/copilot-instructions.md` matches the number of `infra/modules/` subdirectories.
+
 ## Output
 
 If drift is found, create an issue listing each discrepancy with:

--- a/.github/workflows/doc-drift-detection.md
+++ b/.github/workflows/doc-drift-detection.md
@@ -29,11 +29,11 @@ Analyze the Biotrackr repository for documentation that has drifted from the act
 
 4. **Agent/Skill/Prompt inventory**: Verify the counts in documentation match actual files in `.github/agents/`, `.github/skills/`, `.github/instructions/`, and `.github/prompts/`.
 
-5. **Architecture overview**: Check that the service count (currently "14 independently-deployable services") in AGENTS.md and copilot-instructions.md matches the actual `src/Biotrackr.*` directory count.
+5. **Architecture overview**: Check that the service count (currently "14 independently-deployable services") in `AGENTS.md` and `.github/copilot-instructions.md` matches the actual `src/Biotrackr.*` directory count.
 
 6. **Workflow category counts**: Verify the workflow counts in the repository structure tree ("N workflows + N reusable templates + N agentic workflows") in both `AGENTS.md` and `.github/copilot-instructions.md` match actual files in `.github/workflows/`: regular `.yml` files (excluding `*.lock.yml` and `template-*.yml`), `template-*.yml` templates, and `*.lock.yml` agentic workflow locks paired with `.md` prompt bodies.
 
-7. **Section heading counts**: Verify the documented section counts for `copilot-instructions.md` ("N sections") and `AGENTS.md` ("N sections") in the repository structure tree and cross-references of both files match the actual count of `##` headings in each file.
+7. **Section heading counts**: Verify the documented section counts for `.github/copilot-instructions.md` ("N sections") and `AGENTS.md` ("N sections") in the repository structure tree of both files, and the `AGENTS.md` section count in the Cross-References section of `.github/copilot-instructions.md`, match the actual count of `##` headings in each file.
 
 8. **Bicep module count**: Verify the "N reusable Bicep modules" count in the repository structure tree of both `AGENTS.md` and `.github/copilot-instructions.md` matches the actual number of `.bicep` files across `infra/modules/` subdirectories, and the Module Domains table row count in `.github/copilot-instructions.md` matches the number of `infra/modules/` subdirectories.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Each service has its own solution file (`.sln` or `.slnx`), Dockerfile, test pro
 ├── AGENTS.md                          # This file
 ├── CLAUDE.md                          # @AGENTS.md import for Claude Code
 ├── .github/
-│   ├── copilot-instructions.md        # Comprehensive Copilot guide (14 sections)
+│   ├── copilot-instructions.md        # Comprehensive Copilot guide (15 sections)
 │   ├── instructions/                  # Path-scoped .instructions.md files
 │   ├── agents/                        # 9 custom agent definitions
 │   ├── aw/                            # Agentic workflow runtime artifacts


### PR DESCRIPTION
## Summary

Add 3 new detection checks to the `doc-drift-detection` agentic workflow prompt and correct 2 active documentation drift instances, addressing the root cause reported in #360.

## Problem

The `doc-drift-detection` workflow could not detect agentic workflow count drift because its 5 existing checks did not cover workflow category counts, section heading counts, or Bicep module counts. During investigation, 2 active drift instances were also discovered:

- `copilot-instructions.md` and `AGENTS.md` both stated "14 sections" when the actual count was 15
- `copilot-instructions.md` cross-reference stated "9 sections" for AGENTS.md when the actual count was 10

## Changes

### New detection checks in `doc-drift-detection.md`

- **Check #6 — Workflow category counts**: Verifies the "N workflows + N reusable templates + N agentic workflows" annotation in both `AGENTS.md` and `copilot-instructions.md` against actual files (regular `.yml`, `template-*.yml`, `*.lock.yml` paired with `.md`)
- **Check #7 — Section heading counts**: Verifies documented section counts match the actual `##` heading count in each file
- **Check #8 — Bicep module count**: Verifies the Bicep modules count and Module Domains table row count against `infra/modules/` subdirectories

### Documentation drift fixes

- `copilot-instructions.md` L49: "14 sections" → "15 sections"
- `AGENTS.md` L49: "14 sections" → "15 sections"
- `copilot-instructions.md` L619: "9 sections" → "10 sections"

## Validation

- `##` heading counts verified: 15 in `copilot-instructions.md`, 10 in `AGENTS.md`
- 8 numbered checks confirmed in `doc-drift-detection.md`
- No stale "14 sections" or "9 sections" references remain
- YAML frontmatter and `## Output` section unchanged
- Git diff: 3 files, 9 insertions, 3 deletions

## References

- Research: `.copilot-tracking/research/2026-05-10/issue-360-resolution-status-research.md`
- Plan: `.copilot-tracking/plans/2026-05-10/issue-360-doc-drift-detection-fix-plan.instructions.md`
- Review: `.copilot-tracking/reviews/2026-05-10/issue-360-doc-drift-detection-fix-plan-review.md`

Closes #360