### PR TITLE
core(infra): switch container apps to single revision mode

### DIFF
--- a/infra/apps/activity-api/main.bicep
+++ b/infra/apps/activity-api/main.bicep
@@ -1,3 +1,4 @@
+// Shared module update: container-app-http revision mode changed to Single
 @description('The name of the Activity Api application')
 param name string
 

--- a/infra/apps/chat-api/main.bicep
+++ b/infra/apps/chat-api/main.bicep
@@ -1,4 +1,5 @@
 // Chat API infrastructure — AzureAd:ClientId is owned by this template
+// Shared module update: container-app-http revision mode changed to Single
 @description('The name of the Chat Api application')
 param name string
 

--- a/infra/apps/food-api/main.bicep
+++ b/infra/apps/food-api/main.bicep
@@ -1,3 +1,4 @@
+// Shared module update: container-app-http revision mode changed to Single
 @description('The name of the Food Api application')
 param name string
 

--- a/infra/apps/mcp-server/main.bicep
+++ b/infra/apps/mcp-server/main.bicep
@@ -1,3 +1,4 @@
+// Shared module update: container-app-http revision mode changed to Single
 @description('The name of the MCP Server application')
 param name string
 

--- a/infra/apps/reporting-api/main.bicep
+++ b/infra/apps/reporting-api/main.bicep
@@ -1,3 +1,4 @@
+// Shared module update: container-app-http-sidecar revision mode changed to Single
 @description('The name of the Reporting Api application')
 param name string
 

--- a/infra/apps/sleep-api/main.bicep
+++ b/infra/apps/sleep-api/main.bicep
@@ -1,3 +1,4 @@
+// Shared module update: container-app-http revision mode changed to Single
 @description('The name of the Sleep Api application')
 param name string
 

--- a/infra/apps/ui/main.bicep
+++ b/infra/apps/ui/main.bicep
@@ -1,3 +1,4 @@
+// Shared module update: container-app-http revision mode changed to Single
 @description('The name of the UI application')
 param name string
 

--- a/infra/apps/vitals-api/main.bicep
+++ b/infra/apps/vitals-api/main.bicep
@@ -1,3 +1,4 @@
+// Shared module update: container-app-http revision mode changed to Single
 @description('The name of the Vitals Api application')
 param name string
 

--- a/infra/modules/host/container-app-http-sidecar.bicep
+++ b/infra/modules/host/container-app-http-sidecar.bicep
@@ -97,18 +97,12 @@ resource httpContainerApp 'Microsoft.App/containerApps@2024-03-01' = {
   properties: {
     environmentId: containerAppEnv.id
     configuration: {
-      activeRevisionsMode: 'Multiple'
+      activeRevisionsMode: 'Single'
       ingress: {
         external: externalIngress
         transport: 'http'
         targetPort: targetPort
         allowInsecure: false
-        traffic: [
-          {
-            latestRevision: true
-            weight: 100
-          }
-        ]
       }
       registries: [
         {

--- a/infra/modules/host/container-app-http.bicep
+++ b/infra/modules/host/container-app-http.bicep
@@ -56,19 +56,13 @@ resource httpContainerApp 'Microsoft.App/containerApps@2024-03-01' = {
   properties: {
     environmentId: containerAppEnv.id
     configuration: {
-      activeRevisionsMode: 'Multiple'
+      activeRevisionsMode: 'Single'
       ingress: {
         external: true
         transport: 'http'
         targetPort: targetPort
         allowInsecure: false
         customDomains: empty(customDomains) ? null : customDomains
-        traffic: [
-          {
-            latestRevision: true
-            weight: 100
-          }
-        ]
       }
       registries: [
         {


### PR DESCRIPTION
## Summary

Switch all Container Apps from multiple revision mode to single revision mode. Remove unused traffic weight-splitting blocks. All services scale to zero when idle except the MCP Server (minReplicas: 1).

## Changes

### Module changes (functional)
- **\infra/modules/host/container-app-http.bicep\** — \ctiveRevisionsMode: 'Multiple'\ → \'Single'\, removed \	raffic\ block
- **\infra/modules/host/container-app-http-sidecar.bicep\** — \ctiveRevisionsMode: 'Multiple'\ → \'Single'\, removed \	raffic\ block

### Per-service trigger comments (CI/CD)
Added trigger comment to 8 \infra/apps/{service}/main.bicep\ files so per-service deploy workflows fire (shared module changes under \infra/modules/\ do not trigger per-service pipelines).

## Acceptance Criteria
- [x] Both modules set \ctiveRevisionsMode: 'Single'\
- [x] No \	raffic\ block in either module
- [x] MCP Server retains \minReplicas: 1\
- [x] All other services inherit \minReplicas: 0\ (scale to zero)
- [x] Both modules pass \z bicep build\ linting
- [x] Per-service deploy workflows will trigger on PR merge

## Testing
Bicep lint validation only (\z bicep build\ exit code 0 for both modules). No application code changes.