### PR TITLE
fix(reporting-api): pin Nerdbank.MessagePack to resolve CVE-2026-44375

### DIFF
--- a/.github/instructions/csharp-conventions.instructions.md
+++ b/.github/instructions/csharp-conventions.instructions.md
@@ -1,6 +1,6 @@
 ---
-description: "C# coding conventions for Biotrackr .NET services. Use when: writing or editing C# source files, service implementations, API handlers, or data models."
-applyTo: "**/*.cs"
+description: "C# coding conventions for Biotrackr .NET services. Use when: writing or editing C# source files, service implementations, API handlers, data models, or project files."
+applyTo: "**/*.cs,**/*.csproj"
 ---
 
 # C# Conventions
@@ -51,3 +51,9 @@ applyTo: "**/*.cs"
 - One class per file (exceptions: small nested types, records)
 - File-scoped namespaces (`namespace Biotrackr.Activity.Api.Models;`)
 - Group `using` directives: System first, then Microsoft, then third-party, then project
+
+## Security Dependency Pins
+
+- When pinning a transitive NuGet dependency to fix a CVE, add an XML comment above the `PackageReference` with the CVE ID and removal condition
+- Example: `<!-- CVE-2026-44375: pin until Microsoft.Agents.AI.* updates to >= 1.1.62 -->`
+- After pinning, verify no new HIGH/CRITICAL audit warnings (NU1902/NU1903) were introduced by the updated package's own transitives

--- a/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.csproj
+++ b/src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
+    <!-- CVE-2026-44375: pin until Microsoft.Agents.AI.* updates to >= 1.1.62 -->
+    <PackageReference Include="Nerdbank.MessagePack" Version="1.1.62" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />


### PR DESCRIPTION
﻿## Summary

Pin Nerdbank.MessagePack to v1.1.62 to resolve CVE-2026-44375 (HIGH severity) and unblock the Reporting.Api deployment pipeline.

## Changes

### Code fix
- **src/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api/Biotrackr.Reporting.Api.csproj** - Added direct PackageReference for Nerdbank.MessagePack v1.1.62 with XML comment documenting the CVE and removal condition. This overrides the vulnerable v1.0.2 transitive dependency from Microsoft.Agents.AI.Hosting.A2A.AspNetCore.

### Harness evolution
- **.github/instructions/csharp-conventions.instructions.md** - Added Security Dependency Pins section documenting the pattern for future transitive CVE pins.

## Root Cause

Trivy detected [CVE-2026-44375](https://github.com/advisories/GHSA-2cwq-pwfr-wcw3) (HIGH) in Nerdbank.MessagePack v1.0.2. An attacker-controlled stackalloc in DateTime decoding causes a process-terminating StackOverflowException. The package is a transitive dependency of Microsoft.Agents.AI.Hosting.A2A.AspNetCore (v1.0.0-preview.260311.1).

## Verification

- dotnet restore: No Nerdbank.MessagePack audit warnings
- dotnet list package --include-transitive: Nerdbank.MessagePack resolved at 1.1.62
- dotnet build: 0 errors
- Unit tests: 180 passed, 0 failed
- Contract tests: 29 passed, 0 failed

Closes #379
